### PR TITLE
add RPM spec file

### DIFF
--- a/python-ogr.spec
+++ b/python-ogr.spec
@@ -1,0 +1,55 @@
+# created by pyp2rpm-3.3.2
+%global pypi_name ogr
+
+%{?python_enable_dependency_generator}
+
+Name:           python-%{pypi_name}
+Version:        0.0.2
+Release:        1%{?dist}
+Summary:        One API for multiple git forges
+
+License:        MIT
+URL:            https://github.com/packit-service/ogr
+Source0:        https://files.pythonhosted.org/packages/source/o/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm)
+BuildRequires:  python3dist(setuptools-scm-git-archive)
+
+%description
+One Git library to Rule!
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+One Git library to Rule!
+
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+
+
+%build
+%py3_build
+
+
+%install
+%py3_install
+
+
+%files -n python3-%{pypi_name}
+%license LICENSE
+%doc README.md
+%{python3_sitelib}/%{pypi_name}
+%{python3_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+
+
+%changelog
+* Tue Feb 26 2019 Tomas Tomecek <ttomecek@redhat.com> - 0.0.2-1
+- Initial package.


### PR DESCRIPTION
# how to test
```
git checkout 0.0.2
python3 ./setup.py sdist
mv ./dist/ogr-0.0.2.tar.gz .
rpmbuild ./*.spec --define "_sourcedir ${PWD}" --define "_specdir ${PWD}" --define "_builddir ${PWD}" --define "_srcrpmdir ${PWD}" --define "_rpmdir ${PWD}" -bs
fedora-review -n python-ogr -m fedora-29-x86_64
```

Once merged, I'll open a Fedora review for ogr. Franta could do it so he can get the pkgr perms.