### PR TITLE
0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 0.1.0
+
+### New Features
+
+* Ogr now has an API for Github releases.
+
+## Minor
+
+* We have started using black, flake8 and mypy to improve the code quality.
+
+* We are running upstream CI in CentosCI.
+
+* Ogr is using packit to bring upstream releases to Fedora.
+
+
 # 0.0.3
 
 ## Fixes


### PR DESCRIPTION
Hi,
 you have requested a release PR from me. Here it is!
This is the changelog I created:
### Changes

### Other

* Utilize gitchangelog feature of r-bot. [Tomas Tomecek]

* Merge pull request #35 from TomasTomecek/update-packit-yaml. [Tomas Tomecek]

  update packit.yaml to reflect packit==0.2.0

* Update packit.yaml to reflect packit==0.2.0. [Tomas Tomecek]

* Merge pull request #34 from jpopelka/no-dimensions. [Jiri Popelka]

  pre-commit config & black/Flake8/mypy fixes

* Black & Flake8 & mypy fixes. [Jiri Popelka]

* .pre-commit-config.yaml. [Jiri Popelka]

* Merge pull request #32 from packit-service/releases. [Jiri Popelka]

  Releases

* Add test and docs for GitHub releases. [Radoslav Pitonak]

* Add releases for github. [Frantisek Lachman]

* Merge pull request #27 from jpopelka/ci. [Jiri Popelka]

  Tox & Jenkinsfile

* Jenkinsfile. [Jiri Popelka]

* Tox. [Jiri Popelka]

* [Makefile] no sudo. [Jiri Popelka]

* Enum -> IntEnum. [Jiri Popelka]

* Merge pull request #30 from jscotka/test_integration_skip. [Jiri Popelka]

  [integration tests] skip whole module if not all env. variables set

* Move skip_tests() to conftest.py. [Jiri Popelka]

* Create better function to skip tests. [Jan Scotka]

* Add skip decorators to skip whole module in case of integration tests in case env vars are not typed. [Jan Scotka]

* Merge pull request #28 from TomasTomecek/add-packit. [Tomas Tomecek]

  add packit config

* Add packit config. [Tomas Tomecek]




You can change it by editing `CHANGELOG.md` in the root of this repository and pushing to `0.1.0-release` branch before merging this PR.
I didn't find any files where  `__version__` is set.