### PR TITLE
pagure/get_urls: fill in {username}

### DIFF
--- a/ogr/services/our_pagure.py
+++ b/ogr/services/our_pagure.py
@@ -279,7 +279,14 @@ class OurPagure(libpagure.Pagure):
         request_url = self.get_api_url(self.repo, "git", "urls")
 
         return_value = self._call_api(url=request_url, method="GET", data={})
-        return return_value["urls"]
+        urls = return_value["urls"]
+        rendered_urls = {}
+        for k, v in urls.items():
+            # https://pagure.io/pagure/issue/4427
+            if "{username}" in v:
+                v = v.format(username=self.whoami())
+            rendered_urls[k] = v
+        return rendered_urls
 
     def get_branches(self):
         request_url = self.get_api_url(self.repo, "git", "branches")

--- a/tests/integration/test_pagure.py
+++ b/tests/integration/test_pagure.py
@@ -148,13 +148,12 @@ def test_fork(abiword_project_fork):
     a = abiword_project_fork.parent
     assert a
     is_forked = a.is_forked()
-    assert isinstance(is_forked, bool)
-    # `is True` is here on purpose: we want to be sure that .is_forked() returns True object
-    # because Tomas had his crazy ideas and wanted to return GitProject directly, stop that madman
-    assert is_forked is True
+    assert is_forked and isinstance(is_forked, bool)
     fork = a.get_fork(create=False)
     assert fork
     assert fork.is_fork
+    urls = fork.get_git_urls()
+    assert "{username}" not in urls["ssh"]
 
 
 def test_nonexisting_fork(abiword_project_non_existing_fork):


### PR DESCRIPTION
https://pagure.io/pagure/issue/4427

```
$ pytest-3 -k test_fork
=== test session starts ===
platform linux -- Python 3.7.3, pytest-3.6.4, py-1.5.4, pluggy-0.6.0
rootdir: /home/tt/g/user-cont/ogr, inifile:
plugins: cov-2.5.1
collected 76 items / 72 deselected

tests/integration/test_github.py s             [ 25%]
tests/integration/test_pagure.py ..            [ 75%]
tests/unit/test_pagure.py .                    [100%]

==== 3 passed, 1 skipped, 72 deselected in 8.83 seconds ===
```