### PR TITLE
Forcewrite mode from file existance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,15 @@ make prepare-check && make check
 
 As a CI we use [CentOS CI](https://ci.centos.org/job/ogr-pr/) with a configuration in [Jenkinsfile](Jenkinsfile).
 
+
+When running the tests we are using the pregenerated responses that are saved in the ./tests/integration/test_data.
+If you need to generate a new file, just run the tests and provide environment variables for the service.
+The missing file will be automatically generated from the real response. Do not forget to commit the file as well.
+
+If you need to regenerate a response file, just remove it and rerun the tests.
+(There are Makefile targets for removing the response files: `remove-response-files`, `remove-response-files-github`, `remove-response-files-gitlab`, `remove-response-files-pagure`.)
+
+
 ### Makefile
 
 #### Requirements

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,14 @@ check-pypi-packaging:
 		&& python3 -c "import ogr; assert ogr.__version__" \
 		&& pip3 show -f $(PY_PACKAGE) | ( grep test && exit 1 || :) \
 		'
+
+remove-response-files-github:
+	rm -rf ./tests/integration/test_data/test_github*
+
+remove-response-files-pagure:
+	rm -rf ./tests/integration/test_data/test_pagure*
+
+remove-response-files-gitlab:
+	rm -rf ./tests/integration/test_data/test_gitlab*
+
+remove-response-files: remove-response-files-github remove-response-files-pagure remove-response-files-gitlab

--- a/ogr/mock_core.py
+++ b/ogr/mock_core.py
@@ -160,12 +160,7 @@ class PersistentObjectStorage:
     is_write_mode: bool = False
     is_flushed = True
 
-    def __init__(
-        self,
-        storage_file: str,
-        is_write_mode: Optional[bool] = None,
-        dump_after_store: bool = False,
-    ) -> None:
+    def __init__(self, storage_file: str, dump_after_store: bool = False) -> None:
         """
         :param storage_file: file name location where to write/read object data
         :param is_write_mode: force read/write mode, if not set (None) it tries to guess if
@@ -177,22 +172,13 @@ class PersistentObjectStorage:
         # call dump() after store() is called
         self.dump_after_store = dump_after_store
         self.storage_file = storage_file
-        if is_write_mode is not None:
-            self.is_write_mode = is_write_mode
-        else:
-            self.is_write_mode = not os.path.exists(self.storage_file)
+
+        self.is_write_mode = not os.path.exists(self.storage_file)
+
         if self.is_write_mode:
             self.is_flushed = False
-            # load existing file if exist or use empty dir for write mode
-            if os.path.exists(self.storage_file):
-                self.storage_object = self.load()
-            else:
-                self.storage_object = {}
+            self.storage_object = {}
         else:
-            if not os.path.exists(self.storage_file):
-                raise PersistenStorageException(
-                    f"file does not exists: {self.storage_file}"
-                )
             self.storage_object = self.load()
 
     @staticmethod

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -17,17 +17,19 @@ class GithubTests(unittest.TestCase):
         self.token = os.environ.get("GITHUB_TOKEN")
         self.user = os.environ.get("GITHUB_USER")
         test_name = self.id() or "all"
-        self.is_write_mode = bool(os.environ.get("FORCE_WRITE"))
-        if self.is_write_mode and (not self.user or not self.token):
-            raise EnvironmentError("please set GITHUB_TOKEN GITHUB_USER env variables")
+
         persistent_data_file = os.path.join(
             PERSISTENT_DATA_PREFIX, f"test_github_data_{test_name}.yaml"
         )
+        persistant_object_storage = PersistentObjectStorage(persistent_data_file)
+
+        if persistant_object_storage.is_write_mode and (
+            not self.user or not self.token
+        ):
+            raise EnvironmentError("please set GITHUB_TOKEN GITHUB_USER env variables")
+
         self.service = GithubService(
-            token=self.token,
-            persistent_storage=PersistentObjectStorage(
-                persistent_data_file, self.is_write_mode
-            ),
+            token=self.token, persistent_storage=persistant_object_storage
         )
         self.colin_project = self.service.get_project(
             namespace="user-cont", repo="colin"

--- a/tests/integration/test_pagure.py
+++ b/tests/integration/test_pagure.py
@@ -17,17 +17,20 @@ class PagureTests(unittest.TestCase):
         self.token = os.environ.get("PAGURE_TOKEN")
         self.user = os.environ.get("PAGURE_USER")
         test_name = self.id() or "all"
-        self.is_write_mode = bool(os.environ.get("FORCE_WRITE"))
-        if self.is_write_mode and (not self.user or not self.token):
-            raise EnvironmentError("please set PAGURE_TOKEN PAGURE_USER env variables")
+
         persistent_data_file = os.path.join(
             PERSISTENT_DATA_PREFIX, f"test_pagure_data_{test_name}.yaml"
         )
+
+        persistant_object_storage = PersistentObjectStorage(persistent_data_file)
+
+        if persistant_object_storage.is_write_mode and (
+            not self.user or not self.token
+        ):
+            raise EnvironmentError("please set PAGURE_TOKEN PAGURE_USER env variables")
+
         self.service = PagureMockAPI(
-            token=self.token,
-            persistent_storage=PersistentObjectStorage(
-                persistent_data_file, self.is_write_mode
-            ),
+            token=self.token, persistent_storage=persistant_object_storage
         )
         self.docker_py_project = self.service.get_project(
             namespace="rpms", repo="python-docker", username="lachmanfrantisek"


### PR DESCRIPTION
- Add Makefile targets for removing response files.
- Determine forcewrite mode from file existance.


Why?
- less magic
- easier for newcomers:
    - When adding a new test, you need to rerun the tests to generate the response files.
    - To update a response file, you need to remove the file and rerun the tests.


TODO:

- [x] describe the testing in the contribution guide