### PR TITLE
collections.Hashable -> collections.abc.Hashable

### DIFF
--- a/ogr/mock_core.py
+++ b/ogr/mock_core.py
@@ -232,7 +232,7 @@ class PersistentObjectStorage:
         for item in keys:
             if not item:
                 output.append("empty")
-            elif not isinstance(item, collections.Hashable):
+            elif not isinstance(item, collections.abc.Hashable):
                 output.append(str(item))
             else:
                 output.append(item)


### PR DESCRIPTION
Fixes
_DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working_