### PR TITLE
add get_release/get_releases into abstract.py

### DIFF
--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -237,6 +237,17 @@ class Release:
         file.write(data)
         file.close()
 
+    def __str__(self) -> str:
+        return (
+            f"Release("
+            f"title='{self.title}', "
+            f"body='{self.body}', "
+            f"tag_name='{self.tag_name}', "
+            f"url='{self.url}',"
+            f"created_at='{self.created_at}',"
+            f"tarball_url='{self.tarball_url}')"
+        )
+
 
 class GitService:
     instance_url: Optional[str] = None

--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -519,6 +519,23 @@ class GitProject:
         """
         raise NotImplementedError()
 
+    def get_release(self, identifier: int) -> Release:
+        """
+        Get a single release
+
+        :param identifier:
+        :return: Release
+        """
+        raise NotImplementedError()
+
+    def get_releases(self) -> List[Release]:
+        """
+        Return list of releases
+
+        :return: [Release]
+        """
+        raise NotImplementedError()
+
     def _get_all_pr_comments(self, pr_id: int) -> List["PRComment"]:
         """
         Get list of pull-request comments.

--- a/ogr/services/github.py
+++ b/ogr/services/github.py
@@ -268,9 +268,8 @@ class GithubProject(BaseGitProject):
     def can_close_issue(self, username: str, issue: Issue) -> bool:
         allowed_users = self.who_can_close_issue()
 
-        for allowed_user in allowed_users:
-            if username == allowed_user:
-                return True
+        if username in allowed_users:
+            return True
         if username == issue.author:
             return True
 
@@ -279,9 +278,8 @@ class GithubProject(BaseGitProject):
     def can_merge_pr(self, username) -> bool:
         allowed_users = self.who_can_merge_pr()
 
-        for allowed_user in allowed_users:
-            if username == allowed_user:
-                return True
+        if username in allowed_users:
+            return True
 
         return False
 

--- a/ogr/services/pagure.py
+++ b/ogr/services/pagure.py
@@ -27,7 +27,14 @@ from typing import List, Optional, Dict, Any, Set
 import requests
 
 from ogr.abstract import PRStatus, GitTag, CommitStatus, CommitComment
-from ogr.abstract import PullRequest, PRComment, Issue, IssueStatus, IssueComment
+from ogr.abstract import (
+    PullRequest,
+    PRComment,
+    Issue,
+    IssueStatus,
+    IssueComment,
+    Release,
+)
 from ogr.exceptions import (
     OurPagureRawRequest,
     PagureAPIException,
@@ -767,6 +774,23 @@ class PagureProject(BaseGitProject):
             n: GitTag(name=n, commit_sha=c) for n, c in response["tags"].items()
         }
         return tags_dict
+
+    def get_releases(self) -> List[Release]:
+        # git tag for Pagure is shown as Release in Pagure UI
+        git_tags = self.get_tags()
+        return [self._release_from_git_tag(git_tag) for git_tag in git_tags]
+
+    @staticmethod
+    def _release_from_git_tag(git_tag: GitTag) -> Release:
+        return Release(
+            title=git_tag.name,
+            body="",
+            tag_name=git_tag.name,
+            url="",
+            created_at="",
+            tarball_url="",
+            git_tag=git_tag,
+        )
 
     def get_forks(self) -> List["PagureProject"]:
         """

--- a/tests/integration/test_data/test_pagure_data_tests.integration.test_pagure.GenericCommands.test_get_releases.yaml
+++ b/tests/integration/test_data/test_pagure_data_tests.integration.test_pagure.GenericCommands.test_get_releases.yaml
@@ -1,0 +1,20 @@
+GET:
+  https://pagure.io/api/0/ogr-test/git/tags:
+    '{''with_commits'': True}':
+      empty:
+      - content: !!binary |
+          ewogICJ0YWdzIjogewogICAgIjAuMC4xIjogImY2N2Q1Y2I2NTU1YWVmYzk1YWRjZjIyYmQ0OTdh
+          NjViMGZmZGIwYjIiLAogICAgInYwLjAuMiI6ICJmNjdkNWNiNjU1NWFlZmM5NWFkY2YyMmJkNDk3
+          YTY1YjBmZmRiMGIyIiwKICAgICJ2MC4wLjMiOiAiZjY3ZDVjYjY1NTVhZWZjOTVhZGNmMjJiZDQ5
+          N2E2NWIwZmZkYjBiMiIsCiAgICAidjAuMC40IjogIjdkOTVmMGMyMWQyMDkyM2FmNzQ4NGI5OWJk
+          ZDU4NjA0ZWE3MmMxMDgiCiAgfSwKICAidG90YWxfdGFncyI6IDQKfQ==
+        json:
+          tags:
+            0.0.1: f67d5cb6555aefc95adcf22bd497a65b0ffdb0b2
+            v0.0.2: f67d5cb6555aefc95adcf22bd497a65b0ffdb0b2
+            v0.0.3: f67d5cb6555aefc95adcf22bd497a65b0ffdb0b2
+            v0.0.4: 7d95f0c21d20923af7484b99bdd58604ea72c108
+          total_tags: 4
+        ok: true
+        reason: OK
+        status_code: 200

--- a/tests/integration/test_pagure.py
+++ b/tests/integration/test_pagure.py
@@ -110,6 +110,12 @@ class GenericCommands(PagureTests):
         assert branches
         assert set(branches) == {"f26", "f27", "f28", "f29", "f30", "master"}
 
+    def test_get_releases(self):
+        releases = self.ogr_test_project.get_releases()
+        assert releases
+
+        assert len(releases) >= 2
+
     def test_git_urls(self):
         urls = self.docker_py_project.get_git_urls()
         assert urls


### PR DESCRIPTION
Functions `get_release` and `get_releases` implemented in services/github.py were missing in the abstract.py. I also fixed notes from PR #101 which was added after PR was merged. 

**Edit:** I also added functionality `get_releases` for Pagure in the second commit.