### PR TITLE
Rename get_pr_commits to get_all_pr_commits in abstract.py

### DIFF
--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -577,7 +577,7 @@ class GitProject:
         """
         raise NotImplementedError()
 
-    def get_pr_commits(self, pr_id: int) -> List[str]:
+    def get_all_pr_commits(self, pr_id: int) -> List[str]:
         """
         Return list of pull-request commits (sha).
 


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

By PR #144 we add a bug. In `github.py` is mentioned https://github.com/packit-service/ogr/blob/master/ogr/services/github.py#L398 `get_all_pr_commits`.

Suddenly it was not caught by PR review.