### PR TITLE
pagure: use web url in issue

### DIFF
--- a/ogr/services/pagure.py
+++ b/ogr/services/pagure.py
@@ -658,7 +658,9 @@ class PagureProject(BaseGitProject):
             title=issue_dict["title"],
             id=issue_dict["id"],
             status=IssueStatus[issue_dict["status"].lower()],
-            url=self._get_project_url("issue", str(issue_dict["id"])),
+            url=self._get_project_url(
+                "issue", str(issue_dict["id"]), add_api_endpoint_part=False
+            ),
             description=issue_dict["content"],
             author=issue_dict["user"]["name"],
             created=datetime.datetime.fromtimestamp(int(issue_dict["date_created"])),


### PR DESCRIPTION
Don't use the api url when populating the data for an issue. Use
the web url so that it can be used in a web browser.

Fixes #146