### PR TITLE
Add gitlab to service mapping

### DIFF
--- a/ogr/services/base.py
+++ b/ogr/services/base.py
@@ -23,8 +23,8 @@
 from typing import List, Optional, Match, Any
 
 from ogr.abstract import GitService, GitProject, PRComment, GitUser
-from ogr.utils import search_in_comments, filter_comments
 from ogr.parsing import parse_git_repo
+from ogr.utils import search_in_comments, filter_comments
 
 
 class BaseGitService(GitService):

--- a/ogr/services/gitlab.py
+++ b/ogr/services/gitlab.py
@@ -21,10 +21,9 @@
 # SOFTWARE.
 
 import logging
+from typing import List, Optional
 
 import gitlab
-
-from typing import List, Optional
 
 from ogr.abstract import (
     GitService,
@@ -37,14 +36,14 @@ from ogr.abstract import (
     GitTag,
     IssueStatus,
 )
+from ogr.factory import use_for_service
+from ogr.services.base import BaseGitProject, BaseGitUser
 from ogr.utils import (
     clone_repo_and_cd_inside,
     set_upstream_remote,
     set_origin_remote,
     fetch_all,
 )
-
-from ogr.services.base import BaseGitProject, BaseGitUser
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +73,7 @@ class GitlabRelease(Release):
         return self.raw_release.description
 
 
+@use_for_service("gitlab")
 class GitlabService(GitService):
     name = "gitlab"
 

--- a/ogr/services/gitlab.py
+++ b/ogr/services/gitlab.py
@@ -184,35 +184,6 @@ class GitlabService(GitService):
 
         return fork
 
-    def update_labels(self, labels):
-        """
-        Update the labels of the repository. (No deletion, only add not existing ones.)
-
-        :param labels: [str]
-        :return: int - number of added labels
-        """
-        current_label_names = [l.name for l in list(self.repo.labels.list())]
-        changes = 0
-        for label in labels:
-            if label.name not in current_label_names:
-                color = self._normalize_label_color(color=label.color)
-                self.repo.labels.create(
-                    {
-                        "name": label.name,
-                        "color": color,
-                        "description": label.description or "",
-                    }
-                )
-
-                changes += 1
-        return changes
-
-    @staticmethod
-    def _normalize_label_color(color):
-        if not color.startswith("#"):
-            return "#{}".format(color)
-        return color
-
 
 class GitlabProject(BaseGitProject):
     service: GitlabService
@@ -461,6 +432,36 @@ class GitlabProject(BaseGitProject):
             for fork in self.gitlab_repo.forks.list()
         ]
         return fork_objects
+
+    def update_labels(self, labels):
+        """
+        TODO: Not in API yet.
+        Update the labels of the repository. (No deletion, only add not existing ones.)
+
+        :param labels: [str]
+        :return: int - number of added labels
+        """
+        current_label_names = [l.name for l in list(self.gitlab_repo.labels.list())]
+        changes = 0
+        for label in labels:
+            if label.name not in current_label_names:
+                color = self._normalize_label_color(color=label.color)
+                self.gitlab_repo.labels.create(
+                    {
+                        "name": label.name,
+                        "color": color,
+                        "description": label.description or "",
+                    }
+                )
+
+                changes += 1
+        return changes
+
+    @staticmethod
+    def _normalize_label_color(color):
+        if not color.startswith("#"):
+            return "#{}".format(color)
+        return color
 
 
 class GitlabUser(BaseGitUser):

--- a/ogr/services/pagure.py
+++ b/ogr/services/pagure.py
@@ -42,8 +42,8 @@ from ogr.exceptions import (
     OperationNotSupported,
 )
 from ogr.factory import use_for_service
-from ogr.read_only import if_readonly, GitProjectReadOnly
 from ogr.parsing import parse_git_repo
+from ogr.read_only import if_readonly, GitProjectReadOnly
 from ogr.services.base import BaseGitService, BaseGitProject, BaseGitUser
 from ogr.utils import RequestResponse
 
@@ -73,7 +73,7 @@ class PagureRelease(Release):
         return ""
 
 
-@use_for_service("pagure.io")
+@use_for_service("pagure")
 @use_for_service("src.fedoraproject.org")
 class PagureService(BaseGitService):
     def __init__(

--- a/tests/integration/test_data/test_factory_data_tests.integration.test_factory.FactoryTests.test_get_project_gitlab.yaml
+++ b/tests/integration/test_data/test_factory_data_tests.integration.test_factory.FactoryTests.test_get_project_gitlab.yaml
@@ -1,0 +1,221 @@
+get:
+  /projects/lbarcziova%2Ftesting-ogr-repo:
+    OrderedDict([('query_data', {}), ('streamed', False)]):
+    - content: !!binary |
+        eyJpZCI6ODQyMCwiZGVzY3JpcHRpb24iOiIiLCJuYW1lIjoidGVzdGluZyBvZ3IgcmVwbyIsIm5h
+        bWVfd2l0aF9uYW1lc3BhY2UiOiJsYmFyY3ppb3ZhIC8gdGVzdGluZyBvZ3IgcmVwbyIsInBhdGgi
+        OiJ0ZXN0aW5nLW9nci1yZXBvIiwicGF0aF93aXRoX25hbWVzcGFjZSI6ImxiYXJjemlvdmEvdGVz
+        dGluZy1vZ3ItcmVwbyIsImNyZWF0ZWRfYXQiOiIyMDE5LTA4LTE0VDEwOjAwOjEwLjE1MloiLCJk
+        ZWZhdWx0X2JyYW5jaCI6Im1hc3RlciIsInRhZ19saXN0IjpbXSwic3NoX3VybF90b19yZXBvIjoi
+        Z2l0QGdpdGxhYi5nbm9tZS5vcmc6bGJhcmN6aW92YS90ZXN0aW5nLW9nci1yZXBvLmdpdCIsImh0
+        dHBfdXJsX3RvX3JlcG8iOiJodHRwczovL2dpdGxhYi5nbm9tZS5vcmcvbGJhcmN6aW92YS90ZXN0
+        aW5nLW9nci1yZXBvLmdpdCIsIndlYl91cmwiOiJodHRwczovL2dpdGxhYi5nbm9tZS5vcmcvbGJh
+        cmN6aW92YS90ZXN0aW5nLW9nci1yZXBvIiwicmVhZG1lX3VybCI6Imh0dHBzOi8vZ2l0bGFiLmdu
+        b21lLm9yZy9sYmFyY3ppb3ZhL3Rlc3Rpbmctb2dyLXJlcG8vYmxvYi9tYXN0ZXIvUkVBRE1FLm1k
+        IiwiYXZhdGFyX3VybCI6bnVsbCwic3Rhcl9jb3VudCI6MCwiZm9ya3NfY291bnQiOjAsImxhc3Rf
+        YWN0aXZpdHlfYXQiOiIyMDE5LTA4LTE0VDEzOjU2OjAwLjUzN1oiLCJuYW1lc3BhY2UiOnsiaWQi
+        OjIzNDAzLCJuYW1lIjoibGJhcmN6aW92YSIsInBhdGgiOiJsYmFyY3ppb3ZhIiwia2luZCI6InVz
+        ZXIiLCJmdWxsX3BhdGgiOiJsYmFyY3ppb3ZhIiwicGFyZW50X2lkIjpudWxsLCJhdmF0YXJfdXJs
+        IjoiaHR0cHM6Ly9zZWN1cmUuZ3JhdmF0YXIuY29tL2F2YXRhci85YzhkOWEyODgxNTFhOGU1NjM1
+        NDdlMDgyYzU5MWYyYT9zPTgwXHUwMDI2ZD1pZGVudGljb24iLCJ3ZWJfdXJsIjoiaHR0cHM6Ly9n
+        aXRsYWIuZ25vbWUub3JnL2xiYXJjemlvdmEifSwiX2xpbmtzIjp7InNlbGYiOiJodHRwczovL2dp
+        dGxhYi5nbm9tZS5vcmcvYXBpL3Y0L3Byb2plY3RzLzg0MjAiLCJpc3N1ZXMiOiJodHRwczovL2dp
+        dGxhYi5nbm9tZS5vcmcvYXBpL3Y0L3Byb2plY3RzLzg0MjAvaXNzdWVzIiwibWVyZ2VfcmVxdWVz
+        dHMiOiJodHRwczovL2dpdGxhYi5nbm9tZS5vcmcvYXBpL3Y0L3Byb2plY3RzLzg0MjAvbWVyZ2Vf
+        cmVxdWVzdHMiLCJyZXBvX2JyYW5jaGVzIjoiaHR0cHM6Ly9naXRsYWIuZ25vbWUub3JnL2FwaS92
+        NC9wcm9qZWN0cy84NDIwL3JlcG9zaXRvcnkvYnJhbmNoZXMiLCJsYWJlbHMiOiJodHRwczovL2dp
+        dGxhYi5nbm9tZS5vcmcvYXBpL3Y0L3Byb2plY3RzLzg0MjAvbGFiZWxzIiwiZXZlbnRzIjoiaHR0
+        cHM6Ly9naXRsYWIuZ25vbWUub3JnL2FwaS92NC9wcm9qZWN0cy84NDIwL2V2ZW50cyIsIm1lbWJl
+        cnMiOiJodHRwczovL2dpdGxhYi5nbm9tZS5vcmcvYXBpL3Y0L3Byb2plY3RzLzg0MjAvbWVtYmVy
+        cyJ9LCJlbXB0eV9yZXBvIjpmYWxzZSwiYXJjaGl2ZWQiOmZhbHNlLCJ2aXNpYmlsaXR5IjoicHVi
+        bGljIiwib3duZXIiOnsiaWQiOjIzMzcyLCJuYW1lIjoibGJhcmN6aW92YSIsInVzZXJuYW1lIjoi
+        bGJhcmN6aW92YSIsInN0YXRlIjoiYWN0aXZlIiwiYXZhdGFyX3VybCI6Imh0dHBzOi8vc2VjdXJl
+        LmdyYXZhdGFyLmNvbS9hdmF0YXIvOWM4ZDlhMjg4MTUxYThlNTYzNTQ3ZTA4MmM1OTFmMmE/cz04
+        MFx1MDAyNmQ9aWRlbnRpY29uIiwid2ViX3VybCI6Imh0dHBzOi8vZ2l0bGFiLmdub21lLm9yZy9s
+        YmFyY3ppb3ZhIn0sInJlc29sdmVfb3V0ZGF0ZWRfZGlmZl9kaXNjdXNzaW9ucyI6ZmFsc2UsImNv
+        bnRhaW5lcl9yZWdpc3RyeV9lbmFibGVkIjpmYWxzZSwiaXNzdWVzX2VuYWJsZWQiOnRydWUsIm1l
+        cmdlX3JlcXVlc3RzX2VuYWJsZWQiOnRydWUsIndpa2lfZW5hYmxlZCI6dHJ1ZSwiam9ic19lbmFi
+        bGVkIjp0cnVlLCJzbmlwcGV0c19lbmFibGVkIjp0cnVlLCJpc3N1ZXNfYWNjZXNzX2xldmVsIjoi
+        ZW5hYmxlZCIsInJlcG9zaXRvcnlfYWNjZXNzX2xldmVsIjoiZW5hYmxlZCIsIm1lcmdlX3JlcXVl
+        c3RzX2FjY2Vzc19sZXZlbCI6ImVuYWJsZWQiLCJ3aWtpX2FjY2Vzc19sZXZlbCI6ImVuYWJsZWQi
+        LCJidWlsZHNfYWNjZXNzX2xldmVsIjoiZW5hYmxlZCIsInNuaXBwZXRzX2FjY2Vzc19sZXZlbCI6
+        ImVuYWJsZWQiLCJzaGFyZWRfcnVubmVyc19lbmFibGVkIjp0cnVlLCJsZnNfZW5hYmxlZCI6dHJ1
+        ZSwiY3JlYXRvcl9pZCI6MjMzNzIsImltcG9ydF9zdGF0dXMiOiJub25lIiwib3Blbl9pc3N1ZXNf
+        Y291bnQiOjIsImNpX2RlZmF1bHRfZ2l0X2RlcHRoIjo1MCwicHVibGljX2pvYnMiOnRydWUsImJ1
+        aWxkX3RpbWVvdXQiOjM2MDAsImF1dG9fY2FuY2VsX3BlbmRpbmdfcGlwZWxpbmVzIjoiZW5hYmxl
+        ZCIsImJ1aWxkX2NvdmVyYWdlX3JlZ2V4IjpudWxsLCJjaV9jb25maWdfcGF0aCI6bnVsbCwic2hh
+        cmVkX3dpdGhfZ3JvdXBzIjpbXSwib25seV9hbGxvd19tZXJnZV9pZl9waXBlbGluZV9zdWNjZWVk
+        cyI6ZmFsc2UsInJlcXVlc3RfYWNjZXNzX2VuYWJsZWQiOmZhbHNlLCJvbmx5X2FsbG93X21lcmdl
+        X2lmX2FsbF9kaXNjdXNzaW9uc19hcmVfcmVzb2x2ZWQiOmZhbHNlLCJwcmludGluZ19tZXJnZV9y
+        ZXF1ZXN0X2xpbmtfZW5hYmxlZCI6dHJ1ZSwibWVyZ2VfbWV0aG9kIjoibWVyZ2UiLCJhdXRvX2Rl
+        dm9wc19lbmFibGVkIjpmYWxzZSwiYXV0b19kZXZvcHNfZGVwbG95X3N0cmF0ZWd5IjoiY29udGlu
+        dW91cyIsInBlcm1pc3Npb25zIjp7InByb2plY3RfYWNjZXNzIjpudWxsLCJncm91cF9hY2Nlc3Mi
+        Om51bGx9fQ==
+      exception: null
+      headers:
+        Cache-Control: max-age=0, private, must-revalidate
+        Connection: close
+        Content-Length: '2743'
+        Content-Type: application/json
+        Date: Tue, 20 Aug 2019 08:44:04 GMT
+        Etag: W/"3d64260698e5bc8ee04d8db9147f735f"
+        Server: Apache/2.4.6 (Red Hat Enterprise Linux)
+        Strict-Transport-Security: max-age=15768000;includeSubdomains
+        Vary: Origin
+        X-Content-Type-Options: nosniff
+        X-Frame-Options: SAMEORIGIN
+        X-Request-Id: qeIeetbApm8
+        X-Runtime: '0.156572'
+      json:
+        _links:
+          events: https://gitlab.gnome.org/api/v4/projects/8420/events
+          issues: https://gitlab.gnome.org/api/v4/projects/8420/issues
+          labels: https://gitlab.gnome.org/api/v4/projects/8420/labels
+          members: https://gitlab.gnome.org/api/v4/projects/8420/members
+          merge_requests: https://gitlab.gnome.org/api/v4/projects/8420/merge_requests
+          repo_branches: https://gitlab.gnome.org/api/v4/projects/8420/repository/branches
+          self: https://gitlab.gnome.org/api/v4/projects/8420
+        archived: false
+        auto_cancel_pending_pipelines: enabled
+        auto_devops_deploy_strategy: continuous
+        auto_devops_enabled: false
+        avatar_url: null
+        build_coverage_regex: null
+        build_timeout: 3600
+        builds_access_level: enabled
+        ci_config_path: null
+        ci_default_git_depth: 50
+        container_registry_enabled: false
+        created_at: '2019-08-14T10:00:10.152Z'
+        creator_id: 23372
+        default_branch: master
+        description: ''
+        empty_repo: false
+        forks_count: 0
+        http_url_to_repo: https://gitlab.gnome.org/lbarcziova/testing-ogr-repo.git
+        id: 8420
+        import_status: none
+        issues_access_level: enabled
+        issues_enabled: true
+        jobs_enabled: true
+        last_activity_at: '2019-08-14T13:56:00.537Z'
+        lfs_enabled: true
+        merge_method: merge
+        merge_requests_access_level: enabled
+        merge_requests_enabled: true
+        name: testing ogr repo
+        name_with_namespace: lbarcziova / testing ogr repo
+        namespace:
+          avatar_url: https://secure.gravatar.com/avatar/9c8d9a288151a8e563547e082c591f2a?s=80&d=identicon
+          full_path: lbarcziova
+          id: 23403
+          kind: user
+          name: lbarcziova
+          parent_id: null
+          path: lbarcziova
+          web_url: https://gitlab.gnome.org/lbarcziova
+        only_allow_merge_if_all_discussions_are_resolved: false
+        only_allow_merge_if_pipeline_succeeds: false
+        open_issues_count: 2
+        owner:
+          avatar_url: https://secure.gravatar.com/avatar/9c8d9a288151a8e563547e082c591f2a?s=80&d=identicon
+          id: 23372
+          name: lbarcziova
+          state: active
+          username: lbarcziova
+          web_url: https://gitlab.gnome.org/lbarcziova
+        path: testing-ogr-repo
+        path_with_namespace: lbarcziova/testing-ogr-repo
+        permissions:
+          group_access: null
+          project_access: null
+        printing_merge_request_link_enabled: true
+        public_jobs: true
+        readme_url: https://gitlab.gnome.org/lbarcziova/testing-ogr-repo/blob/master/README.md
+        repository_access_level: enabled
+        request_access_enabled: false
+        resolve_outdated_diff_discussions: false
+        shared_runners_enabled: true
+        shared_with_groups: []
+        snippets_access_level: enabled
+        snippets_enabled: true
+        ssh_url_to_repo: git@gitlab.gnome.org:lbarcziova/testing-ogr-repo.git
+        star_count: 0
+        tag_list: []
+        visibility: public
+        web_url: https://gitlab.gnome.org/lbarcziova/testing-ogr-repo
+        wiki_access_level: enabled
+        wiki_enabled: true
+      links: {}
+      ok: true
+      reason: OK
+      status_code: 200
+  /user:
+    OrderedDict([('query_data', {}), ('streamed', False)]):
+    - content: !!binary |
+        eyJpZCI6MzUxOCwibmFtZSI6IkZyYW50acWhZWsgTGFjaG1hbiIsInVzZXJuYW1lIjoibGFjaG1h
+        bmZyYW50aXNlayIsInN0YXRlIjoiYWN0aXZlIiwiYXZhdGFyX3VybCI6Imh0dHBzOi8vc2VjdXJl
+        LmdyYXZhdGFyLmNvbS9hdmF0YXIvNWEyZTdmNjcxMGJmZjQ3Yjk0ZDI0YjQ0YjU1ZmQ3Zjc/cz04
+        MFx1MDAyNmQ9aWRlbnRpY29uIiwid2ViX3VybCI6Imh0dHBzOi8vZ2l0bGFiLmdub21lLm9yZy9s
+        YWNobWFuZnJhbnRpc2VrIiwiY3JlYXRlZF9hdCI6IjIwMTgtMDUtMDdUMjI6MTE6NTQuMDExWiIs
+        ImJpbyI6bnVsbCwibG9jYXRpb24iOm51bGwsInB1YmxpY19lbWFpbCI6IiIsInNreXBlIjoiIiwi
+        bGlua2VkaW4iOiIiLCJ0d2l0dGVyIjoiIiwid2Vic2l0ZV91cmwiOiIiLCJvcmdhbml6YXRpb24i
+        Om51bGwsImxhc3Rfc2lnbl9pbl9hdCI6IjIwMTktMDgtMTVUMDg6MDA6MjcuODY2WiIsImNvbmZp
+        cm1lZF9hdCI6IjIwMTgtMDUtMDdUMjI6MTE6NTMuMjA3WiIsImxhc3RfYWN0aXZpdHlfb24iOiIy
+        MDE5LTA4LTIwIiwiZW1haWwiOiJsYWNobWFuZnJhbnRpc2VrQGdtYWlsLmNvbSIsInRoZW1lX2lk
+        IjoxLCJjb2xvcl9zY2hlbWVfaWQiOjEsInByb2plY3RzX2xpbWl0IjoxMDAsImN1cnJlbnRfc2ln
+        bl9pbl9hdCI6IjIwMTktMDgtMjBUMDg6MDU6MjIuODg1WiIsImlkZW50aXRpZXMiOlt7InByb3Zp
+        ZGVyIjoiZ2l0bGFiIiwiZXh0ZXJuX3VpZCI6IjQzMzY3MCJ9XSwiY2FuX2NyZWF0ZV9ncm91cCI6
+        ZmFsc2UsImNhbl9jcmVhdGVfcHJvamVjdCI6dHJ1ZSwidHdvX2ZhY3Rvcl9lbmFibGVkIjpmYWxz
+        ZSwiZXh0ZXJuYWwiOmZhbHNlLCJwcml2YXRlX3Byb2ZpbGUiOmZhbHNlfQ==
+      exception: null
+      headers:
+        Cache-Control: max-age=0, private, must-revalidate
+        Connection: close
+        Content-Length: '841'
+        Content-Type: application/json
+        Date: Tue, 20 Aug 2019 08:44:03 GMT
+        Etag: W/"677aa91d48972ed9ad05f26b1e4b8f26"
+        Server: Apache/2.4.6 (Red Hat Enterprise Linux)
+        Strict-Transport-Security: max-age=15768000;includeSubdomains
+        Vary: Origin
+        X-Content-Type-Options: nosniff
+        X-Frame-Options: SAMEORIGIN
+        X-Request-Id: 9VFLZa8M813
+        X-Runtime: '0.062319'
+      json:
+        avatar_url: https://secure.gravatar.com/avatar/5a2e7f6710bff47b94d24b44b55fd7f7?s=80&d=identicon
+        bio: null
+        can_create_group: false
+        can_create_project: true
+        color_scheme_id: 1
+        confirmed_at: '2018-05-07T22:11:53.207Z'
+        created_at: '2018-05-07T22:11:54.011Z'
+        current_sign_in_at: '2019-08-20T08:05:22.885Z'
+        email: lachmanfrantisek@gmail.com
+        external: false
+        id: 3518
+        identities:
+        - extern_uid: '433670'
+          provider: gitlab
+        last_activity_on: '2019-08-20'
+        last_sign_in_at: '2019-08-15T08:00:27.866Z'
+        linkedin: ''
+        location: null
+        name: "Franti\u0161ek Lachman"
+        organization: null
+        private_profile: false
+        projects_limit: 100
+        public_email: ''
+        skype: ''
+        state: active
+        theme_id: 1
+        twitter: ''
+        two_factor_enabled: false
+        username: lachmanfrantisek
+        web_url: https://gitlab.gnome.org/lachmanfrantisek
+        website_url: ''
+      links: {}
+      ok: true
+      reason: OK
+      status_code: 200

--- a/tests/integration/test_gitlab.py
+++ b/tests/integration/test_gitlab.py
@@ -29,7 +29,7 @@ class GitlabTests(unittest.TestCase):
             self.token = "some_token"
 
         self.service = GitlabService(
-            token=self.token, url="https://gitlab.gnome.org", ssl_verify=True
+            token=self.token, instance_url="https://gitlab.gnome.org", ssl_verify=True
         )
 
         self.project = self.service.get_project(

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -2,10 +2,11 @@ import pytest
 from flexmock import Mock
 from flexmock import flexmock
 
-from ogr import PagureService, GitlabService
+from ogr import PagureService, GitlabService, GithubService
 from ogr.exceptions import OgrException
 from ogr.factory import get_service_class, get_project
-from ogr.services.github import GithubService, GithubProject
+from ogr.services.github import GithubProject
+from ogr.services.gitlab import GitlabProject
 from ogr.services.pagure import PagureProject
 
 
@@ -143,6 +144,16 @@ def test_get_service_class_not_found(url, mapping):
                 ),
             ],
             "right-project",
+        ),
+        (
+            "https://gitlab.gnome.org/lbarcziova/testing-ogr-repo",
+            None,
+            None,
+            GitlabProject(
+                repo="testing-ogr-repo",
+                namespace="lbarcziova",
+                service=GitlabService(instance_url="https://gitlab.gnome.org"),
+            ),
         ),
     ],
 )

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -2,7 +2,7 @@ import pytest
 from flexmock import Mock
 from flexmock import flexmock
 
-from ogr import PagureService
+from ogr import PagureService, GitlabService
 from ogr.exceptions import OgrException
 from ogr.factory import get_service_class, get_project
 from ogr.services.github import GithubService, GithubProject
@@ -27,6 +27,9 @@ from ogr.services.pagure import PagureProject
         ),
         ("https://src.fedoraproject.org/rpms/python-ogr", None, PagureService),
         ("https://pagure.io/ogr", None, PagureService),
+        ("https://pagure.something.com/ogr", None, PagureService),
+        ("https://gitlab.com/someone/project", None, GitlabService),
+        ("https://gitlab.abcd.def/someone/project", None, GitlabService),
     ],
 )
 def test_get_service_class(url, mapping, result):


### PR DESCRIPTION
- Remove repo specific methods from GitlabService.
- Make the creation of gitlab objects lazy.
- Add tests for gitlab service-mapping.
- Make the pagure service mapping more general.
- Add gitlab to service mapping.