### PR TITLE
Support GitlabAuthenticationError

### DIFF
--- a/tests/integration/test_gitlab.py
+++ b/tests/integration/test_gitlab.py
@@ -25,7 +25,7 @@ class GitlabTests(unittest.TestCase):
             not self.user or not self.token
         ):
             raise EnvironmentError("please set GITLAB_TOKEN GITLAB_USER env variables")
-        else:
+        elif not self.token:
             self.token = "some_token"
 
         self.service = GitlabService(


### PR DESCRIPTION
- Not overwrite the gitlab token when set on read-mode.
- Support GitlabAuthenticationError in response files as well.