### PR TITLE
Improve typehints for exceptions.py

### DIFF
--- a/ogr/exceptions.py
+++ b/ogr/exceptions.py
@@ -30,7 +30,10 @@ class PagureAPIException(OgrException):
     """ Exception related to Pagure API """
 
     def __init__(
-        self, *args: object, pagure_error: Optional[str] = None, pagure_response: Optional[Dict[str, str]] = None
+        self,
+        *args: object,
+        pagure_error: Optional[str] = None,
+        pagure_response: Optional[Dict[str, str]] = None
     ) -> None:
         super().__init__(*args)
         self.pagure_error = pagure_error

--- a/ogr/exceptions.py
+++ b/ogr/exceptions.py
@@ -19,7 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from typing import Optional, Dict
+from typing import Optional, Dict, Any
 
 
 class OgrException(Exception):
@@ -33,7 +33,7 @@ class PagureAPIException(OgrException):
         self,
         *args: object,
         pagure_error: Optional[str] = None,
-        pagure_response: Optional[Dict[str, str]] = None
+        pagure_response: Optional[Dict[str, Dict[str, Any]]] = None
     ) -> None:
         super().__init__(*args)
         self.pagure_error = pagure_error

--- a/ogr/exceptions.py
+++ b/ogr/exceptions.py
@@ -19,6 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from typing import Optional, Dict
 
 
 class OgrException(Exception):
@@ -29,7 +30,7 @@ class PagureAPIException(OgrException):
     """ Exception related to Pagure API """
 
     def __init__(
-        self, *args: object, pagure_error: str = None, pagure_response: dict = None
+        self, *args: object, pagure_error: Optional[str] = None, pagure_response: Optional[Dict[str, str]] = None
     ) -> None:
         super().__init__(*args)
         self.pagure_error = pagure_error
@@ -39,7 +40,7 @@ class PagureAPIException(OgrException):
 class GithubAPIException(OgrException):
     """ Exception related to Github API """
 
-    def __init__(self, *args: object, github_error: str = None) -> None:
+    def __init__(self, *args: object, github_error: Optional[str] = None) -> None:
         super().__init__(*args)
         self.github_error = github_error
 
@@ -47,7 +48,7 @@ class GithubAPIException(OgrException):
 class GitlabAPIException(OgrException):
     """ Exception related to Gitlab API """
 
-    def __init__(self, *args: object, gitlab_error: str = None) -> None:
+    def __init__(self, *args: object, gitlab_error: Optional[str] = None) -> None:
         super().__init__(*args)
         self.gitlab_error = gitlab_error
 

--- a/ogr/exceptions.py
+++ b/ogr/exceptions.py
@@ -31,9 +31,9 @@ class PagureAPIException(OgrException):
 
     def __init__(
         self,
-        *args: object,
+        *args: Any,
         pagure_error: Optional[str] = None,
-        pagure_response: Optional[Dict[str, Dict[str, Any]]] = None
+        pagure_response: Optional[Dict[str, Any]] = None
     ) -> None:
         super().__init__(*args)
         self.pagure_error = pagure_error
@@ -43,7 +43,7 @@ class PagureAPIException(OgrException):
 class GithubAPIException(OgrException):
     """ Exception related to Github API """
 
-    def __init__(self, *args: object, github_error: Optional[str] = None) -> None:
+    def __init__(self, *args: Any, github_error: Optional[str] = None) -> None:
         super().__init__(*args)
         self.github_error = github_error
 
@@ -51,7 +51,7 @@ class GithubAPIException(OgrException):
 class GitlabAPIException(OgrException):
     """ Exception related to Gitlab API """
 
-    def __init__(self, *args: object, gitlab_error: Optional[str] = None) -> None:
+    def __init__(self, *args: Any, gitlab_error: Optional[str] = None) -> None:
         super().__init__(*args)
         self.gitlab_error = gitlab_error
 


### PR DESCRIPTION
This pull request intends to fix the strict mypy errors in the exceptions.py file as part of #251. Not sure if the types within the dictionary (str, str) are consistent with how this is used as couldn't see any instances in the codebase where this error is raised with the kwargs filled in.