### PR TITLE
Add url diff to PullRequest

### DIFF
--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -91,6 +91,7 @@ class PullRequest:
         source_branch: str,
         target_branch: str,
         created: datetime.datetime,
+        diff_url: str,
     ) -> None:
         self.title = title
         self.id = id
@@ -101,6 +102,7 @@ class PullRequest:
         self.source_branch = source_branch
         self.target_branch = target_branch
         self.created = created
+        self.diff_url = diff_url
 
     def __str__(self) -> str:
         description = (
@@ -117,6 +119,7 @@ class PullRequest:
             f"source_branch='{self.source_branch}', "
             f"target_branch='{self.target_branch}', "
             f"created='{self.created}'), "
+            f"diff_url='{self.diff_url}'), "
         )
 
 

--- a/ogr/read_only.py
+++ b/ogr/read_only.py
@@ -110,6 +110,7 @@ class GitProjectReadOnly:
             url=cls.url,
             author=cls.author,
             created=datetime.datetime.now(),
+            diff_url="/".join([cls.url, "files"]),
         )
         return output
 

--- a/ogr/services/github/project.py
+++ b/ogr/services/github/project.py
@@ -594,6 +594,7 @@ class GithubProject(BaseGitProject):
             source_branch=github_pr.head.ref,
             target_branch=github_pr.base.ref,
             created=github_pr.created_at,
+            diff_url="/".join([github_pr.html_url, "files"]),
         )
 
     def _release_from_github_object(

--- a/ogr/services/gitlab/project.py
+++ b/ogr/services/gitlab/project.py
@@ -616,6 +616,7 @@ class GitlabProject(BaseGitProject):
             source_branch=gitlab_pr.source_branch,
             target_branch=gitlab_pr.target_branch,
             created=gitlab_pr.created_at,
+            diff_url="/".join([gitlab_pr.web_url, "diffs"]),
         )
 
     @staticmethod

--- a/ogr/services/pagure/project.py
+++ b/ogr/services/pagure/project.py
@@ -475,23 +475,20 @@ class PagureProject(BaseGitProject):
         )
 
     def _pr_from_pagure_dict(self, pr_dict: dict) -> PullRequest:
+        url = self._get_project_url(
+            "pull-request", str(pr_dict["id"]), add_api_endpoint_part=False
+        )
         return PullRequest(
             title=pr_dict["title"],
             id=pr_dict["id"],
             status=PRStatus[pr_dict["status"].lower()],
-            url="/".join(
-                [
-                    self.service.instance_url,
-                    pr_dict["project"]["url_path"],
-                    "pull-request",
-                    str(pr_dict["id"]),
-                ]
-            ),
+            url=url,
             description=pr_dict["initial_comment"],
             author=pr_dict["user"]["name"],
             source_branch=pr_dict["branch_from"],
             target_branch=pr_dict["branch"],
             created=datetime.datetime.fromtimestamp(int(pr_dict["date_created"])),
+            diff_url=url + "#request_diff",
         )
 
     @staticmethod

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -387,6 +387,8 @@ class PullRequests(GithubTests):
         assert pr_info
         assert pr_info.title == "WIP: API"
         assert pr_info.status == PRStatus.merged
+        assert pr_info.url == "https://github.com/packit-service/ogr/pull/1"
+        assert pr_info.diff_url == "https://github.com/packit-service/ogr/pull/1/files"
 
     def test_all_pr_commits(self):
         commits = self.ogr_project.get_all_pr_commits(pr_id=1)

--- a/tests/integration/test_gitlab.py
+++ b/tests/integration/test_gitlab.py
@@ -269,6 +269,14 @@ class PullRequests(GitlabTests):
         assert pr_info
         assert pr_info.title == "change"
         assert pr_info.description == "description of mergerequest"
+        assert (
+            pr_info.url
+            == "https://gitlab.com/packit-service/ogr-tests/merge_requests/1"
+        )
+        assert (
+            pr_info.diff_url
+            == "https://gitlab.com/packit-service/ogr-tests/merge_requests/1/diffs"
+        )
 
     def test_get_all_pr_commits(self):
         commits = self.project.get_all_pr_commits(pr_id=1)

--- a/tests/integration/test_pagure.py
+++ b/tests/integration/test_pagure.py
@@ -263,6 +263,11 @@ class PullRequests(PagureTests):
         assert pr_info
         assert pr_info.title.startswith("Add README file")
         assert pr_info.status == PRStatus.merged
+        assert pr_info.url == "https://pagure.io/ogr-tests/pull-request/1"
+        assert (
+            pr_info.diff_url
+            == "https://pagure.io/ogr-tests/pull-request/1#request_diff"
+        )
 
 
 class Forks(PagureTests):


### PR DESCRIPTION
Closes #211

I added diff url to PullRequest.

Implementation:
- [x] BasePullRequest
- [x] Github
- [x] Gitlab
- [x] Pagure

But I found diff url in api for github, so I "guess" url. 
But for github there are two option "/files"  (consistent with other services) or ".diff"  (consistent with Github api).

For example:
https://github.com/packit-service/ogr/pull/1/files
and 
https://patch-diff.githubusercontent.com/raw/packit-service/ogr/pull/1.diff

I think ".files" looks better and that option was in issue as example, that why I chose this one. But if you want I can change to github api option ".diff" 

For others services I couldn't find in api, so I "guess" url. 
