### PR TITLE
Fix integration tests

### DIFF
--- a/tests/integration/test_factory.py
+++ b/tests/integration/test_factory.py
@@ -3,6 +3,7 @@ import unittest
 
 from ogr import GithubService, PagureService, get_project, GitlabService
 from requre.storage import PersistentObjectStorage
+from requre.utils import StorageMode
 from ogr.services.github import GithubProject
 from ogr.services.gitlab import GitlabProject
 from ogr.services.pagure import PagureProject
@@ -26,13 +27,19 @@ class FactoryTests(unittest.TestCase):
         )
         PersistentObjectStorage().storage_file = persistent_data_file
 
-        if PersistentObjectStorage().is_write_mode and not self.github_token:
+        if (
+            PersistentObjectStorage().mode == StorageMode.write
+            and not self.github_token
+        ):
             raise EnvironmentError("please set GITHUB_TOKEN env variables")
 
-        if PersistentObjectStorage().is_write_mode and not self.pagure_token:
+        if (
+            PersistentObjectStorage().mode == StorageMode.write
+            and not self.pagure_token
+        ):
             raise EnvironmentError("please set PAGURE_TOKEN env variables")
 
-        if PersistentObjectStorage().is_write_mode and not os.environ.get(
+        if PersistentObjectStorage() == StorageMode.write and not os.environ.get(
             "GITLAB_TOKEN"
         ):
             raise EnvironmentError("please set GITLAB_TOKEN env variables")

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -8,6 +8,7 @@ from ogr import GithubService
 from ogr.abstract import PRStatus, IssueStatus
 from ogr.exceptions import GithubAPIException
 from requre.storage import PersistentObjectStorage
+from requre.utils import StorageMode
 
 DATA_DIR = "test_data"
 PERSISTENT_DATA_PREFIX = os.path.join(
@@ -25,7 +26,7 @@ class GithubTests(unittest.TestCase):
         )
         PersistentObjectStorage().storage_file = persistent_data_file
 
-        if PersistentObjectStorage().is_write_mode and (not self.token):
+        if PersistentObjectStorage().mode == StorageMode.write and (not self.token):
             raise EnvironmentError("please set GITHUB_TOKEN env variables")
 
         self.service = GithubService(token=self.token)

--- a/tests/integration/test_github_app.py
+++ b/tests/integration/test_github_app.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from ogr import GithubService
 from requre.storage import PersistentObjectStorage
+from requre.utils import StorageMode
 
 DATA_DIR = "test_data"
 PERSISTENT_DATA_PREFIX = os.path.join(
@@ -36,7 +37,7 @@ class GithubTests(unittest.TestCase):
         )
         PersistentObjectStorage().storage_file = persistent_data_file
 
-        if PersistentObjectStorage().is_write_mode and (
+        if PersistentObjectStorage().mode == StorageMode.write and (
             not self.github_app_id or not self.github_app_private_key_path
         ):
             raise EnvironmentError(

--- a/tests/integration/test_github_readonly.py
+++ b/tests/integration/test_github_readonly.py
@@ -3,6 +3,7 @@ import unittest
 
 from ogr import GithubService
 from requre.storage import PersistentObjectStorage
+from requre.utils import StorageMode
 
 DATA_DIR = "test_data"
 PERSISTENT_DATA_PREFIX = os.path.join(
@@ -18,7 +19,7 @@ class ReadOnly(unittest.TestCase):
             PERSISTENT_DATA_PREFIX, f"test_github_data_{test_name}.yaml"
         )
         PersistentObjectStorage().storage_file = persistent_data_file
-        if PersistentObjectStorage().is_write_mode and not self.token:
+        if PersistentObjectStorage().mode == StorageMode.write and not self.token:
             raise EnvironmentError("please set GITHUB_TOKEN env variables")
 
         self.service = GithubService(token=self.token, read_only=True)

--- a/tests/integration/test_gitlab.py
+++ b/tests/integration/test_gitlab.py
@@ -6,6 +6,7 @@ from gitlab import GitlabGetError
 
 from ogr.exceptions import GitlabAPIException
 from requre.storage import PersistentObjectStorage
+from requre.utils import StorageMode
 from ogr.abstract import PRStatus, IssueStatus
 from ogr.services.gitlab import GitlabService
 
@@ -24,8 +25,7 @@ class GitlabTests(unittest.TestCase):
             PERSISTENT_DATA_PREFIX, f"test_gitlab_data_{test_name}.yaml"
         )
         PersistentObjectStorage().storage_file = persistent_data_file
-
-        if PersistentObjectStorage().is_write_mode and not self.token:
+        if PersistentObjectStorage().mode == StorageMode.write and not self.token:
             raise EnvironmentError("please set GITLAB_TOKEN env variables")
         elif not self.token:
             self.token = "some_token"

--- a/tests/integration/test_pagure.py
+++ b/tests/integration/test_pagure.py
@@ -4,6 +4,7 @@ import unittest
 import pytest
 
 from requre.storage import PersistentObjectStorage
+from requre.utils import StorageMode
 
 from ogr import PagureService
 from ogr.abstract import PRStatus, IssueStatus
@@ -25,7 +26,7 @@ class PagureTests(unittest.TestCase):
 
         PersistentObjectStorage().storage_file = self.persistent_data_file
 
-        if PersistentObjectStorage().is_write_mode and (not self.token):
+        if PersistentObjectStorage().mode == StorageMode.write and (not self.token):
             raise EnvironmentError("please set PAGURE_TOKEN env variables")
 
         self.service = PagureService(token=self.token, instance_url="https://pagure.io")
@@ -331,7 +332,7 @@ class PagureProjectTokenCommands(PagureTests):
 
         PersistentObjectStorage().storage_file = self.persistent_data_file
 
-        if PersistentObjectStorage().is_write_mode and (not self.token):
+        if PersistentObjectStorage().mode == StorageMode.write and (not self.token):
             raise EnvironmentError("please set PAGURE_OGR_TEST_TOKEN env variables")
 
         self.service = PagureService(token=self.token, instance_url="https://pagure.io")


### PR DESCRIPTION
Closes #281 
After change in requre integration tests fails. 
Change PersistentObjectStorage().is_write_mode to PersistentObjectStorage().mode == StorageMode.write

Zuul allow to add relation between repos, maybe this is a option to prevent that situation, but I don't know how looks policy about that in packit-service. 
