### PR TITLE
Remove trailing slash from URLs before parsing

### DIFF
--- a/ogr/parsing.py
+++ b/ogr/parsing.py
@@ -90,6 +90,10 @@ def parse_git_repo(potential_url: str) -> Optional[RepoUrl]:
     if not potential_url:
         return None
 
+    # Remove trailing '/' from 1-7 to ensure parsing works as expected.
+    if potential_url[-1] == "/":
+        potential_url = potential_url.rstrip("/")
+
     # transform 4-6 to a URL-like string, so that we can handle it together with 1-3
     if "@" in potential_url:
         split = potential_url.split("@")

--- a/tests/unit/test_parsing.py
+++ b/tests/unit/test_parsing.py
@@ -68,8 +68,8 @@ from ogr.parsing import parse_git_repo, RepoUrl
                 username=None,
                 namespace="namespace",
                 scheme="https",
-                hostname="host.name"
-            )
+                hostname="host.name",
+            ),
         ),
     ],
 )

--- a/tests/unit/test_parsing.py
+++ b/tests/unit/test_parsing.py
@@ -61,6 +61,16 @@ from ogr.parsing import parse_git_repo, RepoUrl
                 is_fork=True,
             ),
         ),
+        (
+            "https://host.name/namespace/repo/",
+            RepoUrl(
+                repo="repo",
+                username=None,
+                namespace="namespace",
+                scheme="https",
+                hostname="host.name"
+            )
+        ),
     ],
 )
 def test_parse_git_repo(url, result):


### PR DESCRIPTION
Hello there 👋 

This came up in my `good-first-issue` search and seemed like a fairly straightforward bug to fix.

I decided to treat it as a data problem and check for the existence of a trailing slash in a simple if statement. It worked in the test cases I passed it, and should be pretty straightforward to debug. 

Open to any/all criticism. Thanks for all you do!