### PR TITLE
Add support for tags when creating pagure issues.

### DIFF
--- a/ogr/services/pagure/issue.py
+++ b/ogr/services/pagure/issue.py
@@ -74,12 +74,23 @@ class PagureIssue(BaseIssue):
     def created(self) -> datetime.datetime:
         return datetime.datetime.fromtimestamp(int(self._raw_issue["date_created"]))
 
+    @property
+    def labels(self) -> List[str]:
+        return self._raw_issue["tags"]
+
     def __str__(self) -> str:
         return "Pagure" + super().__str__()
 
     @staticmethod
-    def create(project: "ogr_pagure.PagureProject", title: str, body: str) -> "Issue":
+    def create(
+        project: "ogr_pagure.PagureProject",
+        title: str,
+        body: str,
+        labels: Optional[List[str]] = None,
+    ) -> "Issue":
         payload = {"title": title, "issue_content": body}
+        if labels is not None:
+            payload["tag"] = ",".join(labels)
         new_issue = project._call_project_api("new_issue", data=payload, method="POST")[
             "issue"
         ]

--- a/ogr/services/pagure/project.py
+++ b/ogr/services/pagure/project.py
@@ -208,8 +208,10 @@ class PagureProject(BaseGitProject):
     def get_issue(self, issue_id: int) -> Issue:
         return PagureIssue.get(project=self, id=issue_id)
 
-    def create_issue(self, title: str, body: str) -> Issue:
-        return PagureIssue.create(project=self, title=title, body=body)
+    def create_issue(
+        self, title: str, body: str, labels: Optional[List[str]] = None
+    ) -> Issue:
+        return PagureIssue.create(project=self, title=title, body=body, labels=labels)
 
     def get_pr_list(
         self, status: PRStatus = PRStatus.open, assignee=None, author=None


### PR DESCRIPTION
This commit allows to pass a list of tags to pagure's create_issue method.

Signed-off-by: Clement Verna <cverna@tutanota.com>