### PR TITLE
Do not use tokens and keys in the __str__ methods

### DIFF
--- a/ogr/services/github/service.py
+++ b/ogr/services/github/service.py
@@ -30,8 +30,8 @@ from ogr.abstract import GitUser
 from ogr.exceptions import GithubAPIException
 from ogr.factory import use_for_service
 from ogr.services.base import BaseGitService
-from ogr.services.github.user import GithubUser
 from ogr.services.github.project import GithubProject
+from ogr.services.github.user import GithubUser
 
 
 @use_for_service("github.com")
@@ -77,12 +77,17 @@ class GithubService(BaseGitService):
         return None
 
     def __str__(self) -> str:
-        token_str = f", token='{self.token}'" if self.token else ""
+        token_str = (
+            f", token='{self.token[:1]}***{self.token[-1:]}'" if self.token else ""
+        )
         github_app_id_str = (
-            f", github_app_id='{self.github_app_id}'" if self.github_app_id else ""
+            f", github_app_id='{self.github_app_id[:1]}***{self.github_app_id[-1:]}'"
+            if self.github_app_id
+            else ""
         )
         github_app_private_key_str = (
-            f", github_app_private_key='{self._github_app_private_key}'"
+            f", github_app_private_key"
+            f"='{self._github_app_private_key[:1]}***{self._github_app_private_key[-1:]}'"
             if self._github_app_private_key
             else ""
         )
@@ -91,12 +96,21 @@ class GithubService(BaseGitService):
             if self.github_app_private_key_path
             else ""
         )
-        str_result = (
-            f"GithubService(read_only={self.read_only}"
-            f"{token_str}{github_app_id_str}"
-            f"{github_app_private_key_str}{github_app_private_key_path_str})"
+
+        readonly_str = f", read_only=True" if self.read_only else ""
+        arguments = (
+            f"{token_str}"
+            f"{github_app_id_str}"
+            f"{github_app_private_key_str}"
+            f"{github_app_private_key_path_str}"
+            f"{readonly_str}"
         )
-        return str_result
+
+        if arguments:
+            # remove the first '- '
+            arguments = arguments[2:]
+
+        return f"GithubService({arguments})"
 
     def __eq__(self, o: object) -> bool:
         if not issubclass(o.__class__, GithubService):

--- a/ogr/services/gitlab/service.py
+++ b/ogr/services/gitlab/service.py
@@ -25,8 +25,8 @@ import gitlab
 from ogr.abstract import GitService, GitUser
 from ogr.exceptions import GitlabAPIException
 from ogr.factory import use_for_service
-from ogr.services.gitlab.user import GitlabUser
 from ogr.services.gitlab.project import GitlabProject
+from ogr.services.gitlab.user import GitlabUser
 
 
 @use_for_service("gitlab")
@@ -56,11 +56,14 @@ class GitlabService(GitService):
         return GitlabUser(service=self)
 
     def __str__(self) -> str:
-        token_str = f", token='{self.token}'" if self.token else ""
+        token_str = (
+            f", token='{self.token[:1]}***{self.token[-1:]}'" if self.token else ""
+        )
+        ssl_str = f", ssl_verify=False" if not self.ssl_verify else ""
         str_result = (
             f"GitlabService(instance_url='{self.instance_url}'"
-            f"{token_str}, "
-            f"ssl_verify={self.ssl_verify})"
+            f"{token_str}"
+            f"{ssl_str})"
         )
         return str_result
 

--- a/ogr/services/pagure/service.py
+++ b/ogr/services/pagure/service.py
@@ -29,9 +29,9 @@ from ogr.exceptions import PagureAPIException, OgrException
 from ogr.factory import use_for_service
 from ogr.parsing import parse_git_repo
 from ogr.services.base import BaseGitService
-from ogr.utils import RequestResponse
 from ogr.services.pagure.project import PagureProject
 from ogr.services.pagure.user import PagureUser
+from ogr.utils import RequestResponse
 
 logger = logging.getLogger(__name__)
 
@@ -65,12 +65,17 @@ class PagureService(BaseGitService):
         self.header = {"Authorization": "token " + self._token} if self._token else {}
 
     def __str__(self) -> str:
-        token_str = f", token='{self._token}'" if self._token else ""
+        token_str = (
+            f", token='{self._token[:1]}***{self._token[-1:]}'" if self._token else ""
+        )
+        insecure_str = f", insecure=True" if self.insecure else ""
+        readonly_str = f", read_only=True" if self.read_only else ""
+
         str_result = (
             f"PagureService(instance_url='{self.instance_url}'"
-            f"{token_str}, "
-            f"read_only={self.read_only}, "
-            f"insecure={self.insecure})"
+            f"{token_str}"
+            f"{readonly_str}"
+            f"{insecure_str})"
         )
         return str_result
 


### PR DESCRIPTION
- Do not use tokens/private_keys in the `__str__` methods.
  - used `set`/`not set` instead
  - reason: We've started to show logs publicly in the packit-service and it can be easy to forget about this "feature".