### PR TITLE
Fix GitHub commit flags

### DIFF
--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -556,8 +556,11 @@ class CommitFlag:
         uid: Optional[str] = None,
         url: Optional[str] = None,
     ) -> None:
+        self.uid = uid
+        self.project = project
+        self.commit = commit
+
         if commit and state and context:
-            self.commit = commit
             self.state = state
             self.context = context
             self.comment = comment
@@ -565,8 +568,6 @@ class CommitFlag:
         else:
             self._raw_commit_flag = raw_commit_flag
             self._from_raw_commit_flag()
-        self.uid = uid
-        self.project = project
 
     def __str__(self) -> str:
         return (

--- a/ogr/services/github/flag.py
+++ b/ogr/services/github/flag.py
@@ -43,6 +43,8 @@ class GithubCommitFlag(CommitFlag):
         self.state = self._state_from_str(self._raw_commit_flag.state)
         self.context = self._raw_commit_flag.context
         self.comment = self._raw_commit_flag.description
+        self.url = self._raw_commit_flag.target_url
+        self.uid = self._raw_commit_flag.id
 
     @staticmethod
     def get(project: "ogr_github.GithubProject", commit: str) -> List["CommitFlag"]:
@@ -50,7 +52,9 @@ class GithubCommitFlag(CommitFlag):
 
         try:
             return [
-                GithubCommitFlag(raw_commit_flag=raw_status, project=project)
+                GithubCommitFlag(
+                    raw_commit_flag=raw_status, project=project, commit=commit
+                )
                 for raw_status in statuses
             ]
         except UnknownObjectException:

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -3,13 +3,13 @@ import unittest
 
 import pytest
 from github import GithubException, UnknownObjectException
+from requre import RequreTestCase
+from requre.storage import PersistentObjectStorage
+from requre.utils import StorageMode
 
 from ogr import GithubService
 from ogr.abstract import PRStatus, IssueStatus, CommitStatus
 from ogr.exceptions import GithubAPIException
-from requre.storage import PersistentObjectStorage
-from requre.utils import StorageMode
-from requre import RequreTestCase
 
 
 class GithubTests(RequreTestCase):
@@ -307,12 +307,17 @@ class GenericCommands(GithubTests):
         assert status.comment == "testing description"
 
     def test_get_commit_statuses(self):
-        statuses = self.ogr_project.get_commit_statuses(
-            commit="c891a9e4ac01e6575f3fd66cf1b7db2f52f10128"
-        )
+        commit = "c891a9e4ac01e6575f3fd66cf1b7db2f52f10128"
+        statuses = self.ogr_project.get_commit_statuses(commit=commit)
         assert statuses
         assert len(statuses) >= 26
-        assert statuses[-1].comment.startswith("Testing the trimming")
+        last_flag = statuses[-1]
+        assert last_flag.comment.startswith("Testing the trimming")
+        assert last_flag.url == "https://github.com/packit-service/ogr"
+        assert last_flag.commit == commit
+        assert last_flag.state == CommitStatus.success
+        assert last_flag.context == "test"
+        assert last_flag.uid
 
     def test_set_commit_status_long_description(self):
         long_description = (


### PR DESCRIPTION
- Set missing info in GitHub commit flags.
- Test was improved to cover that.