### PR TITLE
packit.xml: set upstream_package_name

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -5,6 +5,9 @@ synced_files:
 # https://packit.dev/docs/configuration/#top-level-keys
 downstream_package_name: python-ogr
 upstream_project_url: https://github.com/packit-service/ogr
+# we are setting this so we can use packit from ogr's dist-git
+# packit can't know what's the upstream name when running from distgit
+upstream_package_name: ogr
 actions:
   # we need this b/c `git archive` doesn't put all the metadata in the tarball:
   #   LookupError: setuptools-scm was unable to detect version for '/builddir/build/BUILD/ogr-0.11.1'.


### PR DESCRIPTION
we are setting this so we can use packit from ogr's dist-git
packit can't know what's the upstream name when running from distgit