### PR TITLE
GitLab pagination

### DIFF
--- a/ogr/services/gitlab/flag.py
+++ b/ogr/services/gitlab/flag.py
@@ -66,7 +66,7 @@ class GitlabCommitFlag(CommitFlag):
             logger.error(f"Commit {commit} was not found.")
             raise GitlabAPIException(f"Commit {commit} was not found.")
 
-        raw_statuses = commit_object.statuses.list()
+        raw_statuses = commit_object.statuses.list(all=True)
         return [
             GitlabCommitFlag(raw_commit_flag=raw_status, project=project)
             for raw_status in raw_statuses

--- a/ogr/services/gitlab/project.py
+++ b/ogr/services/gitlab/project.py
@@ -332,7 +332,7 @@ class GitlabProject(BaseGitProject):
         self.service.change_token(new_token)
 
     def get_branches(self) -> List[str]:
-        return [branch.name for branch in self.gitlab_repo.branches.list()]
+        return [branch.name for branch in self.gitlab_repo.branches.list(all=True)]
 
     def get_file_content(self, path, ref="master") -> str:
         try:
@@ -396,7 +396,7 @@ class GitlabProject(BaseGitProject):
             raise OperationNotSupported(
                 "This version of python-gitlab does not support release, please upgrade."
             )
-        releases = self.gitlab_repo.releases.list()
+        releases = self.gitlab_repo.releases.list(all=True)
         return [
             self._release_from_gitlab_object(
                 raw_release=release,

--- a/tests/integration/test_data/test_gitlab/tests.integration.test_gitlab.GenericCommands.test_branches_pagination.yaml
+++ b/tests/integration/test_data/test_gitlab/tests.integration.test_gitlab.GenericCommands.test_branches_pagination.yaml
@@ -1,0 +1,965 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectFull
+  version_storage_file: 2
+unittest.case:
+  tests.integration.test_gitlab:
+    ogr.services.gitlab.project:
+      gitlab.exceptions:
+        gitlab.mixins:
+          gitlab:
+            requre.objects:
+              requests.sessions:
+                send:
+                - metadata:
+                    latency: 0.2989082336425781
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      _links:
+                        events: https://gitlab.com/api/v4/projects/3163647/events
+                        issues: https://gitlab.com/api/v4/projects/3163647/issues
+                        labels: https://gitlab.com/api/v4/projects/3163647/labels
+                        members: https://gitlab.com/api/v4/projects/3163647/members
+                        merge_requests: https://gitlab.com/api/v4/projects/3163647/merge_requests
+                        repo_branches: https://gitlab.com/api/v4/projects/3163647/repository/branches
+                        self: https://gitlab.com/api/v4/projects/3163647
+                      approvals_before_merge: 1
+                      archived: false
+                      auto_cancel_pending_pipelines: enabled
+                      auto_devops_deploy_strategy: continuous
+                      auto_devops_enabled: false
+                      autoclose_referenced_issues: true
+                      avatar_url: null
+                      build_coverage_regex: '^\slines\.{6}: (\d+.\d%) \(\d+ of \d+
+                        lines\)'
+                      build_timeout: 3600
+                      builds_access_level: enabled
+                      can_create_merge_request_in: true
+                      ci_config_path: ''
+                      ci_default_git_depth: null
+                      container_registry_enabled: true
+                      created_at: '2017-04-22T20:56:58.929Z'
+                      creator_id: 267665
+                      default_branch: master
+                      description: Clone of the GNU Wget2 repository for collaboration
+                        via GitLab
+                      emails_disabled: false
+                      empty_repo: false
+                      external_authorization_classification_label: ''
+                      forking_access_level: enabled
+                      forks_count: 82
+                      http_url_to_repo: https://gitlab.com/gnuwget/wget2.git
+                      id: 3163647
+                      import_status: finished
+                      issues_access_level: enabled
+                      issues_enabled: true
+                      jobs_enabled: true
+                      last_activity_at: '2020-04-22T11:49:16.336Z'
+                      lfs_enabled: true
+                      marked_for_deletion_at: null
+                      marked_for_deletion_on: null
+                      merge_method: ff
+                      merge_requests_access_level: enabled
+                      merge_requests_enabled: true
+                      mirror: false
+                      name: wget2
+                      name_with_namespace: Wget / wget2
+                      namespace:
+                        avatar_url: /uploads/-/system/group/avatar/1530779/wget-logo2.png
+                        full_path: gnuwget
+                        id: 1530779
+                        kind: group
+                        name: Wget
+                        parent_id: null
+                        path: gnuwget
+                        web_url: https://gitlab.com/groups/gnuwget
+                      only_allow_merge_if_all_discussions_are_resolved: true
+                      only_allow_merge_if_pipeline_succeeds: true
+                      open_issues_count: 99
+                      packages_enabled: false
+                      pages_access_level: enabled
+                      path: wget2
+                      path_with_namespace: gnuwget/wget2
+                      permissions:
+                        group_access: null
+                        project_access: null
+                      printing_merge_request_link_enabled: true
+                      public_jobs: true
+                      readme_url: https://gitlab.com/gnuwget/wget2/-/blob/master/README.md
+                      remove_source_branch_after_merge: null
+                      repository_access_level: enabled
+                      request_access_enabled: true
+                      resolve_outdated_diff_discussions: false
+                      service_desk_address: null
+                      service_desk_enabled: false
+                      shared_runners_enabled: true
+                      shared_with_groups: []
+                      snippets_access_level: enabled
+                      snippets_enabled: true
+                      ssh_url_to_repo: git@gitlab.com:gnuwget/wget2.git
+                      star_count: 161
+                      suggestion_commit_message: null
+                      tag_list: []
+                      visibility: public
+                      web_url: https://gitlab.com/gnuwget/wget2
+                      wiki_access_level: enabled
+                      wiki_enabled: true
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f69ca0922cba0-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"260820cdad7ee1377d1488d6854f7fa0"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-04-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '1'
+                      RateLimit-Remaining: '599'
+                      RateLimit-Reset: '1587559286'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:26 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: Y6LHnkwr1e3
+                      X-Runtime: '0.078393'
+                      cf-request-id: 02438072490000cba0788a6200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.49645137786865234
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                    - can_push: false
+                      commit:
+                        author_email: anikethgireesh@gmail.com
+                        author_name: Aniketh Gireesh
+                        authored_date: '2019-03-29T15:50:38.000+00:00'
+                        committed_date: '2019-03-29T16:03:35.000+00:00'
+                        committer_email: darnir@gnu.org
+                        committer_name: Darshit Shah
+                        created_at: '2019-03-29T16:03:35.000+00:00'
+                        id: 6f3814f417439d2b3888fdd7d60290ddd78cd194
+                        message: Add Last-Modified and Content-Type to CSV stats
+                        parent_ids: null
+                        short_id: 6f3814f4
+                        title: Add Last-Modified and Content-Type to CSV stats
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/6f3814f417439d2b3888fdd7d60290ddd78cd194
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: false
+                      name: Aniketh01/wget2-add_Last-Modified
+                      protected: false
+                    - can_push: false
+                      commit:
+                        author_email: tim.ruehsen@gmx.de
+                        author_name: "Tim R\xFChsen"
+                        authored_date: '2020-04-12T17:31:22.000+00:00'
+                        committed_date: '2020-04-12T17:31:22.000+00:00'
+                        committer_email: tim.ruehsen@gmx.de
+                        committer_name: "Tim R\xFChsen"
+                        created_at: '2020-04-12T17:31:22.000+00:00'
+                        id: 61b2095dbf33874c93b54176569b119850483de6
+                        message: Fix warning when converting void * to function pointer
+                        parent_ids: null
+                        short_id: 61b2095d
+                        title: Fix warning when converting void * to function pointer
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/61b2095dbf33874c93b54176569b119850483de6
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: false
+                      name: aschwab1
+                      protected: false
+                    - can_push: false
+                      commit:
+                        author_email: tim.ruehsen@gmx.de
+                        author_name: "Tim R\xFChsen"
+                        authored_date: '2017-04-13T15:02:40.000+00:00'
+                        committed_date: '2017-04-13T15:02:40.000+00:00'
+                        committer_email: tim.ruehsen@gmx.de
+                        committer_name: "Tim R\xFChsen"
+                        created_at: '2017-04-13T15:02:40.000+00:00'
+                        id: c52e093bca759125127d29a2bcd7dd2731452891
+                        message: '* src/job.c (job_validate_file): Fix --chunk-size
+                          for partially existing files'
+                        parent_ids: null
+                        short_id: c52e093b
+                        title: '* src/job.c (job_validate_file): Fix --chunk-size
+                          for partially existing files'
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/c52e093bca759125127d29a2bcd7dd2731452891
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: false
+                      name: chunk-size
+                      protected: false
+                    - can_push: false
+                      commit:
+                        author_email: tim.ruehsen@gmx.de
+                        author_name: "Tim R\xFChsen"
+                        authored_date: '2020-03-17T14:21:04.000+00:00'
+                        committed_date: '2020-03-17T15:49:35.000+00:00'
+                        committer_email: tim.ruehsen@gmx.de
+                        committer_name: "Tim R\xFChsen"
+                        created_at: '2020-03-17T15:49:35.000+00:00'
+                        id: cfdb75096443e8435cffb9c0f36fad92eaf048e7
+                        message: '* libwget/dns_cache.c (wget_dns_cache_add): Fix
+                          bitwise to logical OR (cppcheck)'
+                        parent_ids: null
+                        short_id: cfdb7509
+                        title: '* libwget/dns_cache.c (wget_dns_cache_add): Fix bitwise
+                          to logical OR (cppcheck)'
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/cfdb75096443e8435cffb9c0f36fad92eaf048e7
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: true
+                      name: coverity-scan
+                      protected: false
+                    - can_push: false
+                      commit:
+                        author_email: tim.ruehsen@gmx.de
+                        author_name: "Tim R\xFChsen"
+                        authored_date: '2016-12-26T21:26:24.000+00:00'
+                        committed_date: '2017-01-25T09:33:59.000+00:00'
+                        committer_email: tim.ruehsen@gmx.de
+                        committer_name: "Tim R\xFChsen"
+                        created_at: '2017-01-25T09:33:59.000+00:00'
+                        id: 5b7f015bd6dfde5bcef593bee83a715bab5a1753
+                        message: Add initial debian/ files
+                        parent_ids: null
+                        short_id: 5b7f015b
+                        title: Add initial debian/ files
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/5b7f015bd6dfde5bcef593bee83a715bab5a1753
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: false
+                      name: debian
+                      protected: false
+                    - can_push: false
+                      commit:
+                        author_email: kumarmallikarjuna1@gmail.com
+                        author_name: Kumar Mallikarjuna
+                        authored_date: '2019-07-27T13:35:27.000+00:00'
+                        committed_date: '2019-07-29T19:17:25.000+00:00'
+                        committer_email: tim.ruehsen@gmx.de
+                        committer_name: "Tim R\xFChsen"
+                        created_at: '2019-07-29T19:17:25.000+00:00'
+                        id: 633353c10c6afe917f86062708bb9d5f4ca635ea
+                        message: '* tests/libtest.c: Resolved tests failure due to
+                          OCSP'
+                        parent_ids: null
+                        short_id: 633353c1
+                        title: '* tests/libtest.c: Resolved tests failure due to OCSP'
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/633353c10c6afe917f86062708bb9d5f4ca635ea
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: false
+                      name: gsoc-http2-testsuite
+                      protected: true
+                    - can_push: false
+                      commit:
+                        author_email: kumarmallikarjuna1@gmail.com
+                        author_name: Kumar Mallikarjuna
+                        authored_date: '2019-07-23T09:07:47.000+00:00'
+                        committed_date: '2019-07-23T17:20:14.000+00:00'
+                        committer_email: kumarmallikarjuna1@gmail.com
+                        committer_name: Kumar Mallikarjuna
+                        created_at: '2019-07-23T17:20:14.000+00:00'
+                        id: 45795637b91767cab1dca5a8d76126e3fcbc7526
+                        message: '* tests/certs/ocsp/README.md: Added README for generating
+                          generating certificates and responses'
+                        parent_ids: null
+                        short_id: '45795637'
+                        title: '* tests/certs/ocsp/README.md: Added README for generating
+                          generating certificates and responses'
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/45795637b91767cab1dca5a8d76126e3fcbc7526
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: true
+                      name: gsoc-ocsp-responder
+                      protected: true
+                    - can_push: false
+                      commit:
+                        author_email: kumarmallikarjuna1@gmail.com
+                        author_name: Kumar Mallikarjuna
+                        authored_date: '2019-07-24T11:26:20.000+00:00'
+                        committed_date: '2019-07-24T11:55:44.000+00:00'
+                        committer_email: kumarmallikarjuna1@gmail.com
+                        committer_name: Kumar Mallikarjuna
+                        created_at: '2019-07-24T11:55:44.000+00:00'
+                        id: 2f1b89958c80c4b47633883aa19cb7a358aed55f
+                        message: '* tests/certs/ocsp/README.md: Added README for generating
+                          generating certificates and response'
+                        parent_ids: null
+                        short_id: 2f1b8995
+                        title: '* tests/certs/ocsp/README.md: Added README for generating
+                          generating certificates and response'
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/2f1b89958c80c4b47633883aa19cb7a358aed55f
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: true
+                      name: gsoc-ocsp-stapling
+                      protected: true
+                    - can_push: false
+                      commit:
+                        author_email: rootkea@gmail.com
+                        author_name: Avinash Sonawane
+                        authored_date: '2017-09-02T08:00:28.000+00:00'
+                        committed_date: '2017-09-02T08:00:28.000+00:00'
+                        committer_email: rootkea@gmail.com
+                        committer_name: Avinash Sonawane
+                        created_at: '2017-09-02T08:00:28.000+00:00'
+                        id: 2d5321125c68fb7c43dbaa5550b013b817eea293
+                        message: Use context variable instead of local static variable
+                        parent_ids: null
+                        short_id: 2d532112
+                        title: Use context variable instead of local static variable
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/2d5321125c68fb7c43dbaa5550b013b817eea293
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: false
+                      name: gsoc-rootkea
+                      protected: true
+                    - can_push: false
+                      commit:
+                        author_email: a@juaristi.eus
+                        author_name: Ander Juaristi
+                        authored_date: '2018-05-18T10:08:20.000+00:00'
+                        committed_date: '2018-05-18T10:08:20.000+00:00'
+                        committer_email: a@juaristi.eus
+                        committer_name: Ander Juaristi
+                        created_at: '2018-05-18T10:08:20.000+00:00'
+                        id: 0531ad36390c8ee35ed365b00a9802db6e273edf
+                        message: 'dns.c: Initial import'
+                        parent_ids: null
+                        short_id: 0531ad36
+                        title: 'dns.c: Initial import'
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/0531ad36390c8ee35ed365b00a9802db6e273edf
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: false
+                      name: gsoc18-doh-ajuaristi
+                      protected: false
+                    - can_push: false
+                      commit:
+                        author_email: tim.ruehsen@gmx.de
+                        author_name: "Tim R\xFChsen"
+                        authored_date: '2020-04-22T11:45:35.000+00:00'
+                        committed_date: '2020-04-22T11:49:08.000+00:00'
+                        committer_email: tim.ruehsen@gmx.de
+                        committer_name: "Tim R\xFChsen"
+                        created_at: '2020-04-22T11:49:08.000+00:00'
+                        id: cb20de8e01e3a79f2818e7e8012cadfcbd58df35
+                        message: Remove CR and LF from URLs
+                        parent_ids: null
+                        short_id: cb20de8e
+                        title: Remove CR and LF from URLs
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/cb20de8e01e3a79f2818e7e8012cadfcbd58df35
+                      default: true
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: false
+                      name: master
+                      protected: true
+                    - can_push: false
+                      commit:
+                        author_email: tim.ruehsen@gmx.de
+                        author_name: "Tim R\xFChsen"
+                        authored_date: '2017-05-16T19:31:32.000+00:00'
+                        committed_date: '2017-05-16T19:31:32.000+00:00'
+                        committer_email: tim.ruehsen@gmx.de
+                        committer_name: "Tim R\xFChsen"
+                        created_at: '2017-05-16T19:31:32.000+00:00'
+                        id: 4f557e8121aafeddc3825ce1ca16613ef8706bff
+                        message: Mew test test-redirection-loop
+                        parent_ids: null
+                        short_id: 4f557e81
+                        title: Mew test test-redirection-loop
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/4f557e8121aafeddc3825ce1ca16613ef8706bff
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: false
+                      name: test-redirection-loop
+                      protected: false
+                    - can_push: false
+                      commit:
+                        author_email: tim.ruehsen@gmx.de
+                        author_name: "Tim R\xFChsen"
+                        authored_date: '2017-05-16T19:31:32.000+00:00'
+                        committed_date: '2017-12-18T21:00:41.000+00:00'
+                        committer_email: tim.ruehsen@gmx.de
+                        committer_name: "Tim R\xFChsen"
+                        created_at: '2017-12-18T21:00:41.000+00:00'
+                        id: b93e702a313b3acb137b6a2c2b5a22e6ce364a2c
+                        message: Mew test test-redirection-loop
+                        parent_ids: null
+                        short_id: b93e702a
+                        title: Mew test test-redirection-loop
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/b93e702a313b3acb137b6a2c2b5a22e6ce364a2c
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: false
+                      name: test-redirection-loop2
+                      protected: false
+                    - can_push: false
+                      commit:
+                        author_email: dalmemail@gmail.com
+                        author_name: DalmeGNU
+                        authored_date: '2018-09-27T22:15:23.000+00:00'
+                        committed_date: '2018-10-09T17:26:31.000+00:00'
+                        committer_email: tim.ruehsen@gmx.de
+                        committer_name: "Tim R\xFChsen"
+                        created_at: '2018-10-09T17:26:31.000+00:00'
+                        id: 74eb6f38d561afc043c7a7c459a00a3cfa58dc4a
+                        message: '* benchmarks/benchmark.sh: Change paths to wget
+                          & curl binaries'
+                        parent_ids: null
+                        short_id: 74eb6f38
+                        title: '* benchmarks/benchmark.sh: Change paths to wget &
+                          curl binaries'
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/74eb6f38d561afc043c7a7c459a00a3cfa58dc4a
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: false
+                      name: tmp-benchmarks
+                      protected: false
+                    - can_push: false
+                      commit:
+                        author_email: tim.ruehsen@gmx.de
+                        author_name: "Tim R\xFChsen"
+                        authored_date: '2017-05-28T19:11:01.000+00:00'
+                        committed_date: '2017-12-17T16:26:00.000+00:00'
+                        committer_email: tim.ruehsen@gmx.de
+                        committer_name: "Tim R\xFChsen"
+                        created_at: '2017-12-17T16:26:00.000+00:00'
+                        id: bb9663fe5b458368ea60b04a1c9b73301b25c5ba
+                        message: '* tests/test.c: More code coverage for wget_buffer_printf()'
+                        parent_ids: null
+                        short_id: bb9663fe
+                        title: '* tests/test.c: More code coverage for wget_buffer_printf()'
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/bb9663fe5b458368ea60b04a1c9b73301b25c5ba
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: false
+                      name: tmp-buffer-printf
+                      protected: false
+                    - can_push: false
+                      commit:
+                        author_email: tim.ruehsen@gmx.de
+                        author_name: "Tim R\xFChsen"
+                        authored_date: '2020-02-10T19:49:00.000+00:00'
+                        committed_date: '2020-02-10T19:49:00.000+00:00'
+                        committer_email: tim.ruehsen@gmx.de
+                        committer_name: "Tim R\xFChsen"
+                        created_at: '2020-02-10T19:49:00.000+00:00'
+                        id: 886796a939c2cee5f54d625aec9cfcde7589a82b
+                        message: '* .gitlab-ci.yml: Reduce BUILJOBS to nproc + 1'
+                        parent_ids: null
+                        short_id: 886796a9
+                        title: '* .gitlab-ci.yml: Reduce BUILJOBS to nproc + 1'
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/886796a939c2cee5f54d625aec9cfcde7589a82b
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: false
+                      name: tmp-ci-speedup
+                      protected: false
+                    - can_push: false
+                      commit:
+                        author_email: dalmemail@gmail.com
+                        author_name: DalmeGNU
+                        authored_date: '2020-03-25T12:16:34.000+00:00'
+                        committed_date: '2020-03-25T12:16:34.000+00:00'
+                        committer_email: dalmemail@gmail.com
+                        committer_name: DalmeGNU
+                        created_at: '2020-03-25T12:16:34.000+00:00'
+                        id: 8bfa3eb4709fb02b8b1d857e75b10aa8739c54e4
+                        message: Resolve DNS for URLs added on add_url() [skip ci]
+                        parent_ids: null
+                        short_id: 8bfa3eb4
+                        title: Resolve DNS for URLs added on add_url() [skip ci]
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/8bfa3eb4709fb02b8b1d857e75b10aa8739c54e4
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: false
+                      name: tmp-dns-resolver
+                      protected: false
+                    - can_push: false
+                      commit:
+                        author_email: anikethgireesh@gmail.com
+                        author_name: Aniketh01
+                        authored_date: '2018-10-15T07:52:26.000+00:00'
+                        committed_date: '2018-10-15T07:52:26.000+00:00'
+                        committer_email: anikethgireesh@gmail.com
+                        committer_name: Aniketh01
+                        created_at: '2018-10-15T07:52:26.000+00:00'
+                        id: 507d858dfe7324dca2f9caa46f02ddd1fc6988ca
+                        message: Fixed compiler warnings with a harmless type cast
+                        parent_ids: null
+                        short_id: 507d858d
+                        title: Fixed compiler warnings with a harmless type cast
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/507d858dfe7324dca2f9caa46f02ddd1fc6988ca
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: false
+                      name: tmp-doh
+                      protected: false
+                    - can_push: false
+                      commit:
+                        author_email: tim.ruehsen@gmx.de
+                        author_name: "Tim R\xFChsen"
+                        authored_date: '2020-02-26T12:25:42.000+00:00'
+                        committed_date: '2020-03-07T13:06:59.000+00:00'
+                        committer_email: tim.ruehsen@gmx.de
+                        committer_name: "Tim R\xFChsen"
+                        created_at: '2020-03-07T13:06:59.000+00:00'
+                        id: 20841106a05bca29116ce97e716fa137af2da01c
+                        message: Add DoH (DNS over HTTPS) example [skip ci]
+                        parent_ids: null
+                        short_id: '20841106'
+                        title: Add DoH (DNS over HTTPS) example [skip ci]
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/20841106a05bca29116ce97e716fa137af2da01c
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: false
+                      name: tmp-doh-example
+                      protected: false
+                    - can_push: false
+                      commit:
+                        author_email: tim.ruehsen@gmx.de
+                        author_name: "Tim R\xFChsen"
+                        authored_date: '2018-04-10T15:14:31.000+00:00'
+                        committed_date: '2018-05-02T08:27:13.000+00:00'
+                        committer_email: tim.ruehsen@gmx.de
+                        committer_name: "Tim R\xFChsen"
+                        created_at: '2018-05-02T08:27:13.000+00:00'
+                        id: 47bac2ed972c5bee344c1cea159a22cd7f711dc0
+                        message: Add -X/--exclude-directories
+                        parent_ids: null
+                        short_id: 47bac2ed
+                        title: Add -X/--exclude-directories
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/47bac2ed972c5bee344c1cea159a22cd7f711dc0
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: false
+                      name: tmp-exclude-directories
+                      protected: false
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f69cc1fc4cba0-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"b9a4156a2024468c9910d025744c2a02"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-03-lb-gprd
+                      GitLab-SV: localhost
+                      Link: <https://gitlab.com/api/v4/projects/3163647/repository/branches?id=3163647&page=2&per_page=20>;
+                        rel="next", <https://gitlab.com/api/v4/projects/3163647/repository/branches?id=3163647&page=1&per_page=20>;
+                        rel="first", <https://gitlab.com/api/v4/projects/3163647/repository/branches?id=3163647&page=2&per_page=20>;
+                        rel="last"
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '1'
+                      RateLimit-Remaining: '599'
+                      RateLimit-Reset: '1587559286'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:26 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Accept-Encoding, Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Next-Page: '2'
+                      X-Page: '1'
+                      X-Per-Page: '20'
+                      X-Prev-Page: ''
+                      X-Request-Id: O6VWh6ca526
+                      X-Runtime: '0.212457'
+                      X-Total: '28'
+                      X-Total-Pages: '2'
+                      cf-request-id: 024380738b0000cba0788ee200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.6080152988433838
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                    - can_push: false
+                      commit:
+                        author_email: a@juaristi.eus
+                        author_name: Ander Juaristi
+                        authored_date: '2017-09-02T18:42:38.000+00:00'
+                        committed_date: '2017-09-02T18:42:38.000+00:00'
+                        committer_email: a@juaristi.eus
+                        committer_name: Ander Juaristi
+                        created_at: '2017-09-02T18:42:38.000+00:00'
+                        id: 9fa87e4b3435ebd04081d8641d95a960cc0e4527
+                        message: 'HTTP high level API: initial import'
+                        parent_ids: null
+                        short_id: 9fa87e4b
+                        title: 'HTTP high level API: initial import'
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/9fa87e4b3435ebd04081d8641d95a960cc0e4527
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: false
+                      name: tmp-http-highlevel
+                      protected: false
+                    - can_push: false
+                      commit:
+                        author_email: darnir@gnu.org
+                        author_name: Darshit Shah
+                        authored_date: '2018-05-01T13:03:34.000+00:00'
+                        committed_date: '2018-05-01T13:03:34.000+00:00'
+                        committer_email: darnir@gnu.org
+                        committer_name: Darshit Shah
+                        created_at: '2018-05-01T13:03:34.000+00:00'
+                        id: d9e302c1671477b99e3f78defda6bf2b5417f3a3
+                        message: '* src/wget_options.h: Add the const qualifier to
+                          valid options'
+                        parent_ids: null
+                        short_id: d9e302c1
+                        title: '* src/wget_options.h: Add the const qualifier to valid
+                          options'
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/d9e302c1671477b99e3f78defda6bf2b5417f3a3
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: false
+                      name: tmp-options-cleanup
+                      protected: false
+                    - can_push: false
+                      commit:
+                        author_email: tim.ruehsen@gmx.de
+                        author_name: "Tim R\xFChsen"
+                        authored_date: '2018-10-09T10:28:22.000+00:00'
+                        committed_date: '2018-10-09T10:28:22.000+00:00'
+                        committer_email: tim.ruehsen@gmx.de
+                        committer_name: "Tim R\xFChsen"
+                        created_at: '2018-10-09T10:28:22.000+00:00'
+                        id: b9f93597801df7a418e73a22f70c7121805b28fc
+                        message: '* tests/test-include-and-exclude-directories.c:
+                          Use double quote'
+                        parent_ids: null
+                        short_id: b9f93597
+                        title: '* tests/test-include-and-exclude-directories.c: Use
+                          double quote'
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/b9f93597801df7a418e73a22f70c7121805b28fc
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: false
+                      name: tmp-slash-win
+                      protected: false
+                    - can_push: false
+                      commit:
+                        author_email: rohfle@gmail.com
+                        author_name: Rohan Fletcher
+                        authored_date: '2020-02-03T17:51:54.000+00:00'
+                        committed_date: '2020-02-15T19:20:32.000+00:00'
+                        committer_email: tim.ruehsen@gmx.de
+                        committer_name: "Tim R\xFChsen"
+                        created_at: '2020-02-15T19:20:32.000+00:00'
+                        id: bbb263b553dce231d562b903f28322074650f069
+                        message: '* libwget/http.c (wget_http_get_response_cb): calculate
+                          length_inconsistent for http2 responses'
+                        parent_ids: null
+                        short_id: bbb263b5
+                        title: '* libwget/http.c (wget_http_get_response_cb): calculate
+                          length_inconsistent for http2 responses'
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/bbb263b553dce231d562b903f28322074650f069
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: false
+                      name: tmp-test-interrupt-response-http2
+                      protected: false
+                    - can_push: false
+                      commit:
+                        author_email: darnir@gnu.org
+                        author_name: Darshit Shah
+                        authored_date: '2018-05-01T15:21:25.000+00:00'
+                        committed_date: '2018-05-01T15:21:34.000+00:00'
+                        committer_email: darnir@gnu.org
+                        committer_name: Darshit Shah
+                        created_at: '2018-05-01T15:21:34.000+00:00'
+                        id: 4a1490e4a6d069f1010df08a757d35e59365aa57
+                        message: Initial run with indent on wget.h
+                        parent_ids: null
+                        short_id: 4a1490e4
+                        title: Initial run with indent on wget.h
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/4a1490e4a6d069f1010df08a757d35e59365aa57
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: false
+                      name: use-gnu-indent
+                      protected: false
+                    - can_push: false
+                      commit:
+                        author_email: a@juaristi.eus
+                        author_name: Ander Juaristi
+                        authored_date: '2019-08-25T17:19:02.000+00:00'
+                        committed_date: '2019-08-25T17:19:02.000+00:00'
+                        committer_email: a@juaristi.eus
+                        committer_name: Ander Juaristi
+                        created_at: '2019-08-25T17:19:02.000+00:00'
+                        id: 88d281afd32e14b63b82046116d8ef556b82d5eb
+                        message: 'wget2 interactive: initial import [ci skip]'
+                        parent_ids: null
+                        short_id: 88d281af
+                        title: 'wget2 interactive: initial import [ci skip]'
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/88d281afd32e14b63b82046116d8ef556b82d5eb
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: false
+                      name: wget2-interactive
+                      protected: false
+                    - can_push: false
+                      commit:
+                        author_email: a@juaristi.eus
+                        author_name: Ander Juaristi
+                        authored_date: '2020-01-27T19:33:14.000+00:00'
+                        committed_date: '2020-01-27T19:34:45.000+00:00'
+                        committer_email: a@juaristi.eus
+                        committer_name: Ander Juaristi
+                        created_at: '2020-01-27T19:34:45.000+00:00'
+                        id: fa59040f0a16bcd29f7d672db31bba780d3659fd
+                        message: 'OpenSSL: OCSP stapling [skip ci]'
+                        parent_ids: null
+                        short_id: fa59040f
+                        title: 'OpenSSL: OCSP stapling [skip ci]'
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/fa59040f0a16bcd29f7d672db31bba780d3659fd
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: false
+                      name: wget2-openssl-ajuaristi-ocsp
+                      protected: false
+                    - can_push: false
+                      commit:
+                        author_email: a@juaristi.eus
+                        author_name: Ander Juaristi
+                        authored_date: '2019-08-22T08:55:19.000+00:00'
+                        committed_date: '2019-09-10T14:03:22.000+00:00'
+                        committer_email: tim.ruehsen@gmx.de
+                        committer_name: "Tim R\xFChsen"
+                        created_at: '2019-09-10T14:03:22.000+00:00'
+                        id: 9336166960524456bdc73a7e88d4f31bab7c745c
+                        message: 'OpenSSL: TFO staging [ci skip]'
+                        parent_ids: null
+                        short_id: '93361669'
+                        title: 'OpenSSL: TFO staging [ci skip]'
+                        web_url: https://gitlab.com/gnuwget/wget2/-/commit/9336166960524456bdc73a7e88d4f31bab7c745c
+                      default: false
+                      developers_can_merge: false
+                      developers_can_push: false
+                      merged: false
+                      name: wget2-openssl-ajuaristi-rebased
+                      protected: false
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f69cf2995cba0-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"4aa981789d5676d5ca8be9733eade350"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-01-lb-gprd
+                      GitLab-SV: localhost
+                      Link: <https://gitlab.com/api/v4/projects/3163647/repository/branches?id=3163647&page=1&per_page=20>;
+                        rel="prev", <https://gitlab.com/api/v4/projects/3163647/repository/branches?id=3163647&page=1&per_page=20>;
+                        rel="first", <https://gitlab.com/api/v4/projects/3163647/repository/branches?id=3163647&page=2&per_page=20>;
+                        rel="last"
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '2'
+                      RateLimit-Remaining: '598'
+                      RateLimit-Reset: '1587559287'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:27 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Next-Page: ''
+                      X-Page: '2'
+                      X-Per-Page: '20'
+                      X-Prev-Page: '1'
+                      X-Request-Id: TcLDKvmea09
+                      X-Runtime: '0.118213'
+                      X-Total: '28'
+                      X-Total-Pages: '2'
+                      cf-request-id: 024380757b0000cba078923200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+      ogr.services.gitlab.service:
+        gitlab:
+          gitlab.exceptions:
+            gitlab.mixins:
+              gitlab:
+                requre.objects:
+                  requests.sessions:
+                    send:
+                    - metadata:
+                        latency: 0.41922903060913086
+                        module_call_list:
+                        - unittest.case
+                        - tests.integration.test_gitlab
+                        - ogr.services.gitlab.project
+                        - ogr.services.gitlab.service
+                        - gitlab
+                        - gitlab.exceptions
+                        - gitlab.mixins
+                        - gitlab
+                        - requre.objects
+                        - requests.sessions
+                        - send
+                      output:
+                        __store_indicator: 2
+                        _content:
+                          avatar_url: https://assets.gitlab-static.net/uploads/-/system/user/avatar/375555/avatar.png
+                          bio: ''
+                          can_create_group: true
+                          can_create_project: true
+                          color_scheme_id: 4
+                          confirmed_at: '2018-06-07T08:34:01.593Z'
+                          created_at: '2016-01-15T21:12:31.705Z'
+                          current_sign_in_at: '2020-04-22T11:44:25.029Z'
+                          email: matej.focko@outlook.com
+                          external: false
+                          extra_shared_runners_minutes_limit: null
+                          id: 375555
+                          identities: []
+                          job_title: ''
+                          last_activity_on: '2020-04-22'
+                          last_sign_in_at: '2020-04-19T14:53:06.287Z'
+                          linkedin: ''
+                          location: "Ko\u0161ice, Slovakia"
+                          name: Matej Focko
+                          organization: ''
+                          private_profile: false
+                          projects_limit: 100000
+                          public_email: ''
+                          shared_runners_minutes_limit: 2000
+                          skype: ''
+                          state: active
+                          theme_id: 7
+                          twitter: MatejFocko
+                          two_factor_enabled: true
+                          username: mfocko
+                          web_url: https://gitlab.com/mfocko
+                          website_url: ''
+                          work_information: null
+                        _next: null
+                        elapsed: 0.2
+                        encoding: null
+                        headers:
+                          CF-Cache-Status: DYNAMIC
+                          CF-RAY: 587f69c82b15cba0-VIE
+                          Cache-Control: max-age=0, private, must-revalidate
+                          Connection: keep-alive
+                          Content-Encoding: gzip
+                          Content-Type: application/json
+                          Date: Fri, 01 Nov 2019 13-36-03 GMT
+                          Etag: W/"21f0350f34a7799f24e32f7799ac4ea0"
+                          Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                          GitLab-LB: fe-22-lb-gprd
+                          GitLab-SV: localhost
+                          RateLimit-Limit: '600'
+                          RateLimit-Observed: '1'
+                          RateLimit-Remaining: '599'
+                          RateLimit-Reset: '1587559285'
+                          RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:25 GMT
+                          Referrer-Policy: strict-origin-when-cross-origin
+                          Server: cloudflare
+                          Set-Cookie: __cfduid=dd03efd73f16956e2272531be615735851587559225;
+                            expires=Fri, 22-May-20 12:40:25 GMT; path=/; domain=.gitlab.com;
+                            HttpOnly; SameSite=Lax; Secure
+                          Strict-Transport-Security: max-age=31536000
+                          Transfer-Encoding: chunked
+                          Vary: Origin
+                          X-Content-Type-Options: nosniff
+                          X-Frame-Options: SAMEORIGIN
+                          X-Request-Id: ev2QV9DOXk8
+                          X-Runtime: '0.025973'
+                          cf-request-id: 02438071150000cba078881200000001
+                        raw: !!binary ""
+                        reason: OK
+                        status_code: 200

--- a/tests/integration/test_data/test_gitlab/tests.integration.test_gitlab.Releases.test_get_releases_pagination.yaml
+++ b/tests/integration/test_data/test_gitlab/tests.integration.test_gitlab.Releases.test_get_releases_pagination.yaml
@@ -1,0 +1,7359 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectFull
+  version_storage_file: 2
+unittest.case:
+  tests.integration.test_gitlab:
+    ogr.services.gitlab.project:
+      gitlab.exceptions:
+        gitlab.mixins:
+          gitlab:
+            requre.objects:
+              requests.sessions:
+                send:
+                - metadata:
+                    latency: 0.28860926628112793
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      _links:
+                        events: https://gitlab.com/api/v4/projects/4207231/events
+                        issues: https://gitlab.com/api/v4/projects/4207231/issues
+                        labels: https://gitlab.com/api/v4/projects/4207231/labels
+                        members: https://gitlab.com/api/v4/projects/4207231/members
+                        merge_requests: https://gitlab.com/api/v4/projects/4207231/merge_requests
+                        repo_branches: https://gitlab.com/api/v4/projects/4207231/repository/branches
+                        self: https://gitlab.com/api/v4/projects/4207231
+                      approvals_before_merge: 0
+                      archived: false
+                      auto_cancel_pending_pipelines: enabled
+                      auto_devops_deploy_strategy: continuous
+                      auto_devops_enabled: false
+                      autoclose_referenced_issues: true
+                      avatar_url: null
+                      build_coverage_regex: null
+                      build_timeout: 3600
+                      builds_access_level: enabled
+                      can_create_merge_request_in: true
+                      ci_config_path: null
+                      ci_default_git_depth: null
+                      container_registry_enabled: true
+                      created_at: '2017-09-22T03:43:24.544Z'
+                      creator_id: 652402
+                      default_branch: master
+                      description: Graph Visualization Tools
+                      emails_disabled: null
+                      empty_repo: false
+                      external_authorization_classification_label: ''
+                      forking_access_level: enabled
+                      forks_count: 91
+                      http_url_to_repo: https://gitlab.com/graphviz/graphviz.git
+                      id: 4207231
+                      import_status: finished
+                      issues_access_level: enabled
+                      issues_enabled: true
+                      jobs_enabled: true
+                      last_activity_at: '2020-04-22T10:22:15.230Z'
+                      lfs_enabled: true
+                      marked_for_deletion_at: null
+                      marked_for_deletion_on: null
+                      merge_method: merge
+                      merge_requests_access_level: enabled
+                      merge_requests_enabled: true
+                      mirror: false
+                      name: graphviz
+                      name_with_namespace: graphviz / graphviz
+                      namespace:
+                        avatar_url: /uploads/-/system/group/avatar/1996273/Graphviz.png
+                        full_path: graphviz
+                        id: 1996273
+                        kind: group
+                        name: graphviz
+                        parent_id: null
+                        path: graphviz
+                        web_url: https://gitlab.com/groups/graphviz
+                      only_allow_merge_if_all_discussions_are_resolved: false
+                      only_allow_merge_if_pipeline_succeeds: false
+                      open_issues_count: 1206
+                      packages_enabled: null
+                      pages_access_level: enabled
+                      path: graphviz
+                      path_with_namespace: graphviz/graphviz
+                      permissions:
+                        group_access: null
+                        project_access: null
+                      printing_merge_request_link_enabled: true
+                      public_jobs: true
+                      readme_url: https://gitlab.com/graphviz/graphviz/-/blob/master/README.md
+                      remove_source_branch_after_merge: false
+                      repository_access_level: enabled
+                      request_access_enabled: false
+                      resolve_outdated_diff_discussions: false
+                      service_desk_address: incoming+graphviz-graphviz-4207231-issue-@incoming.gitlab.com
+                      service_desk_enabled: true
+                      shared_runners_enabled: true
+                      shared_with_groups: []
+                      snippets_access_level: enabled
+                      snippets_enabled: true
+                      ssh_url_to_repo: git@gitlab.com:graphviz/graphviz.git
+                      star_count: 484
+                      suggestion_commit_message: ''
+                      tag_list: []
+                      visibility: public
+                      web_url: https://gitlab.com/graphviz/graphviz
+                      wiki_access_level: enabled
+                      wiki_enabled: true
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f69f5ad2b597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"decf1586c0610176176629f4e9980c3c"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-14-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '2'
+                      RateLimit-Remaining: '598'
+                      RateLimit-Reset: '1587559293'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:33 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: aK1kOaxGul4
+                      X-Runtime: '0.077097'
+                      cf-request-id: 0243808d890000597c7ebd6200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.5933408737182617
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/2.44.0
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/2.44.0/graphviz-2.44.0.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/2.44.0/graphviz-2.44.0.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/2.44.0/graphviz-2.44.0.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/2.44.0/graphviz-2.44.0.tar
+                      author:
+                        avatar_url: https://assets.gitlab-static.net/uploads/-/system/user/avatar/275623/avatar.png
+                        id: 275623
+                        name: Magnus Jacobsson
+                        state: active
+                        username: magjac
+                        web_url: https://gitlab.com/magjac
+                      commit:
+                        author_email: Magnus.Jacobsson@berotec.se
+                        author_name: Magnus Jacobsson
+                        authored_date: '2020-04-08T09:03:23.000+02:00'
+                        committed_date: '2020-04-08T09:50:01.000+02:00'
+                        committer_email: Magnus.Jacobsson@berotec.se
+                        committer_name: Magnus Jacobsson
+                        created_at: '2020-04-08T09:50:01.000+02:00'
+                        id: 6b0de802c895f86c75360cc67898a07b24f5b5ae
+                        message: 'Stable Release 2.44.0
+
+                          '
+                        parent_ids:
+                        - 9a3cd8ad63f782a0b0419808d53d4fc2c18f5fbd
+                        short_id: 6b0de802
+                        title: Stable Release 2.44.0
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/6b0de802c895f86c75360cc67898a07b24f5b5ae
+                      commit_path: /graphviz/graphviz/-/commit/6b0de802c895f86c75360cc67898a07b24f5b5ae
+                      created_at: '2020-04-08T08:59:10.176Z'
+                      description: See the [ChangeLog](https://gitlab.com/graphviz/graphviz/-/blob/master/ChangeLog)
+                      description_html: <p data-sourcepos="1:1-1:81" dir="auto">See
+                        the <a href="https://gitlab.com/graphviz/graphviz/-/blob/master/ChangeLog">ChangeLog</a></p>
+                      evidences: []
+                      name: 2.44.0
+                      released_at: '2020-04-08T08:59:10.174Z'
+                      tag_name: 2.44.0
+                      tag_path: /graphviz/graphviz/-/tags/2.44.0
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/2.42.4
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/2.42.4/graphviz-2.42.4.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/2.42.4/graphviz-2.42.4.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/2.42.4/graphviz-2.42.4.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/2.42.4/graphviz-2.42.4.tar
+                      author:
+                        avatar_url: https://assets.gitlab-static.net/uploads/-/system/user/avatar/275623/avatar.png
+                        id: 275623
+                        name: Magnus Jacobsson
+                        state: active
+                        username: magjac
+                        web_url: https://gitlab.com/magjac
+                      commit:
+                        author_email: Magnus.Jacobsson@berotec.se
+                        author_name: Magnus Jacobsson
+                        authored_date: '2020-04-06T08:00:22.000+02:00'
+                        committed_date: '2020-04-06T08:00:49.000+02:00'
+                        committer_email: Magnus.Jacobsson@berotec.se
+                        committer_name: Magnus Jacobsson
+                        created_at: '2020-04-06T08:00:49.000+02:00'
+                        id: 466402bb70105dd74282cd9da6bbde9da02a9b3c
+                        message: 'Stable Release 2.42.4
+
+                          '
+                        parent_ids:
+                        - c9f50be33fbd8288d2a26e6dbc6df0f2bebe8882
+                        short_id: 466402bb
+                        title: Stable Release 2.42.4
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/466402bb70105dd74282cd9da6bbde9da02a9b3c
+                      commit_path: /graphviz/graphviz/-/commit/466402bb70105dd74282cd9da6bbde9da02a9b3c
+                      created_at: '2020-04-06T08:02:41.041Z'
+                      description: "See the [ChangeLog](https://gitlab.com/graphviz/graphviz/-/blob/master/ChangeLog)\r\
+                        \n"
+                      description_html: <p data-sourcepos="1:1-1:81" dir="auto">See
+                        the <a href="https://gitlab.com/graphviz/graphviz/-/blob/master/ChangeLog">ChangeLog</a></p>
+                      evidences: []
+                      name: 2.42.4
+                      released_at: '2020-04-06T08:02:41.035Z'
+                      tag_name: 2.42.4
+                      tag_path: /graphviz/graphviz/-/tags/2.42.4
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/Nightly
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/Nightly/graphviz-Nightly.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/Nightly/graphviz-Nightly.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/Nightly/graphviz-Nightly.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/Nightly/graphviz-Nightly.tar
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-12-04T22:07:00.000-05:00'
+                        committed_date: '2016-12-04T22:07:00.000-05:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-12-04T22:07:00.000-05:00'
+                        id: 75f84028871115997f46711872a8740f6e3f4b88
+                        message: 'Merge pull request #1178 from ErwinJanssen/travis-nightly
+
+
+                          Enhanced Travis Nightly Release'
+                        parent_ids:
+                        - b0545a07591fda01fa57b55d30dc6cc734aed0ea
+                        - 438b2612e76a3c8e51df6dae0e53108d6f9b360e
+                        short_id: 75f84028
+                        title: 'Merge pull request #1178 from ErwinJanssen/travis-nightly'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/75f84028871115997f46711872a8740f6e3f4b88
+                      commit_path: /graphviz/graphviz/-/commit/75f84028871115997f46711872a8740f6e3f4b88
+                      created_at: '2016-12-05T03:07:00.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: Nightly
+                      released_at: '2016-12-05T03:07:00.000Z'
+                      tag_name: Nightly
+                      tag_path: /graphviz/graphviz/-/tags/Nightly
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-14e7b24955d481c7b36a
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-14e7b24955d481c7b36a/graphviz-untagged-14e7b24955d481c7b36a.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-14e7b24955d481c7b36a/graphviz-untagged-14e7b24955d481c7b36a.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-14e7b24955d481c7b36a/graphviz-untagged-14e7b24955d481c7b36a.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-14e7b24955d481c7b36a/graphviz-untagged-14e7b24955d481c7b36a.tar
+                      commit:
+                        author_email: emdenrg@google.com
+                        author_name: Emden Gansner
+                        authored_date: '2016-11-28T15:49:10.000-05:00'
+                        committed_date: '2016-11-28T15:49:10.000-05:00'
+                        committer_email: emdenrg@google.com
+                        committer_name: Emden Gansner
+                        created_at: '2016-11-28T15:49:10.000-05:00'
+                        id: 254f6fd7eb579159132c06e10c2957a628421399
+                        message: 'Add regression test for urls appearing in svg output.
+
+                          '
+                        parent_ids:
+                        - e3b4f50920900a7f532e7108d7f920ac77f2f5b4
+                        short_id: 254f6fd7
+                        title: Add regression test for urls appearing in svg output.
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/254f6fd7eb579159132c06e10c2957a628421399
+                      commit_path: /graphviz/graphviz/-/commit/254f6fd7eb579159132c06e10c2957a628421399
+                      created_at: '2016-11-28T20:49:10.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-14e7b24955d481c7b36a
+                      released_at: '2016-11-28T20:49:10.000Z'
+                      tag_name: untagged-14e7b24955d481c7b36a
+                      tag_path: /graphviz/graphviz/-/tags/untagged-14e7b24955d481c7b36a
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-941905a04b09702a353c
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-941905a04b09702a353c/graphviz-untagged-941905a04b09702a353c.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-941905a04b09702a353c/graphviz-untagged-941905a04b09702a353c.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-941905a04b09702a353c/graphviz-untagged-941905a04b09702a353c.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-941905a04b09702a353c/graphviz-untagged-941905a04b09702a353c.tar
+                      commit:
+                        author_email: emdenrg@google.com
+                        author_name: Emden Gansner
+                        authored_date: '2016-11-28T14:24:50.000-05:00'
+                        committed_date: '2016-11-28T14:24:50.000-05:00'
+                        committer_email: emdenrg@google.com
+                        committer_name: Emden Gansner
+                        created_at: '2016-11-28T14:24:50.000-05:00'
+                        id: f8ed3ac5a94537be9631ccad0d8e077fe29bec79
+                        message: 'Print out depth of graph in verbose mode.
+
+                          '
+                        parent_ids:
+                        - 24988602d046b1529d55f7d6a2edcd5406d3313d
+                        short_id: f8ed3ac5
+                        title: Print out depth of graph in verbose mode.
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/f8ed3ac5a94537be9631ccad0d8e077fe29bec79
+                      commit_path: /graphviz/graphviz/-/commit/f8ed3ac5a94537be9631ccad0d8e077fe29bec79
+                      created_at: '2016-11-28T19:24:50.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-941905a04b09702a353c
+                      released_at: '2016-11-28T19:24:50.000Z'
+                      tag_name: untagged-941905a04b09702a353c
+                      tag_path: /graphviz/graphviz/-/tags/untagged-941905a04b09702a353c
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-0a3057e980c64a11875a
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-0a3057e980c64a11875a/graphviz-untagged-0a3057e980c64a11875a.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-0a3057e980c64a11875a/graphviz-untagged-0a3057e980c64a11875a.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-0a3057e980c64a11875a/graphviz-untagged-0a3057e980c64a11875a.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-0a3057e980c64a11875a/graphviz-untagged-0a3057e980c64a11875a.tar
+                      commit:
+                        author_email: emdenrg@google.com
+                        author_name: Emden Gansner
+                        authored_date: '2016-11-28T11:57:41.000-05:00'
+                        committed_date: '2016-11-28T11:57:41.000-05:00'
+                        committer_email: emdenrg@google.com
+                        committer_name: Emden Gansner
+                        created_at: '2016-11-28T11:57:41.000-05:00'
+                        id: 24988602d046b1529d55f7d6a2edcd5406d3313d
+                        message: 'Add minus sign dropped in the conversion added in
+
+                          0258d60cbde273e99abd015da7cb510b195724c3.
+
+                          '
+                        parent_ids:
+                        - ba314a6d41abe6c77af923783cbd0eb4fcb99450
+                        short_id: '24988602'
+                        title: Add minus sign dropped in the conversion added in
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/24988602d046b1529d55f7d6a2edcd5406d3313d
+                      commit_path: /graphviz/graphviz/-/commit/24988602d046b1529d55f7d6a2edcd5406d3313d
+                      created_at: '2016-11-28T16:57:41.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-0a3057e980c64a11875a
+                      released_at: '2016-11-28T16:57:41.000Z'
+                      tag_name: untagged-0a3057e980c64a11875a
+                      tag_path: /graphviz/graphviz/-/tags/untagged-0a3057e980c64a11875a
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-257982c92c56d4315606
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-257982c92c56d4315606/graphviz-untagged-257982c92c56d4315606.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-257982c92c56d4315606/graphviz-untagged-257982c92c56d4315606.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-257982c92c56d4315606/graphviz-untagged-257982c92c56d4315606.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-257982c92c56d4315606/graphviz-untagged-257982c92c56d4315606.tar
+                      commit:
+                        author_email: erg@emdenrg.net
+                        author_name: Emden R. Gansner
+                        authored_date: '2016-11-27T16:43:37.000-05:00'
+                        committed_date: '2016-11-27T16:43:37.000-05:00'
+                        committer_email: erg@emdenrg.net
+                        committer_name: Emden R. Gansner
+                        created_at: '2016-11-27T16:43:37.000-05:00'
+                        id: ba314a6d41abe6c77af923783cbd0eb4fcb99450
+                        message: 'Update man page to include additional widely-used
+                          formats.
+
+                          '
+                        parent_ids:
+                        - cc33ac0239c6fde284847d7d45a84f15dec8c08a
+                        short_id: ba314a6d
+                        title: Update man page to include additional widely-used formats.
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/ba314a6d41abe6c77af923783cbd0eb4fcb99450
+                      commit_path: /graphviz/graphviz/-/commit/ba314a6d41abe6c77af923783cbd0eb4fcb99450
+                      created_at: '2016-11-27T21:43:37.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-257982c92c56d4315606
+                      released_at: '2016-11-27T21:43:37.000Z'
+                      tag_name: untagged-257982c92c56d4315606
+                      tag_path: /graphviz/graphviz/-/tags/untagged-257982c92c56d4315606
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-09292206f9ec6d0f25d8
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-09292206f9ec6d0f25d8/graphviz-untagged-09292206f9ec6d0f25d8.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-09292206f9ec6d0f25d8/graphviz-untagged-09292206f9ec6d0f25d8.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-09292206f9ec6d0f25d8/graphviz-untagged-09292206f9ec6d0f25d8.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-09292206f9ec6d0f25d8/graphviz-untagged-09292206f9ec6d0f25d8.tar
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-11-26T13:03:18.000-05:00'
+                        committed_date: '2016-11-26T13:03:18.000-05:00'
+                        committer_email: john.ellson@comcast.net
+                        committer_name: John Ellson
+                        created_at: '2016-11-26T13:03:18.000-05:00'
+                        id: cc33ac0239c6fde284847d7d45a84f15dec8c08a
+                        message: 'preparing Changelog for 2.40.0 release
+
+                          '
+                        parent_ids:
+                        - 2afa5038ddbae925fe6a20b2b960271fe18a1ae5
+                        short_id: cc33ac02
+                        title: preparing Changelog for 2.40.0 release
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/cc33ac0239c6fde284847d7d45a84f15dec8c08a
+                      commit_path: /graphviz/graphviz/-/commit/cc33ac0239c6fde284847d7d45a84f15dec8c08a
+                      created_at: '2016-11-26T18:03:18.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-09292206f9ec6d0f25d8
+                      released_at: '2016-11-26T18:03:18.000Z'
+                      tag_name: untagged-09292206f9ec6d0f25d8
+                      tag_path: /graphviz/graphviz/-/tags/untagged-09292206f9ec6d0f25d8
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-5efd1411540d5300c05d
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-5efd1411540d5300c05d/graphviz-untagged-5efd1411540d5300c05d.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-5efd1411540d5300c05d/graphviz-untagged-5efd1411540d5300c05d.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-5efd1411540d5300c05d/graphviz-untagged-5efd1411540d5300c05d.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-5efd1411540d5300c05d/graphviz-untagged-5efd1411540d5300c05d.tar
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-11-24T17:14:04.000-05:00'
+                        committed_date: '2016-11-24T17:14:04.000-05:00'
+                        committer_email: john.ellson@comcast.net
+                        committer_name: John Ellson
+                        created_at: '2016-11-24T17:14:04.000-05:00'
+                        id: 2afa5038ddbae925fe6a20b2b960271fe18a1ae5
+                        message: 'update svg and xdot regression reference cases
+
+                          '
+                        parent_ids:
+                        - 0258d60cbde273e99abd015da7cb510b195724c3
+                        short_id: 2afa5038
+                        title: update svg and xdot regression reference cases
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/2afa5038ddbae925fe6a20b2b960271fe18a1ae5
+                      commit_path: /graphviz/graphviz/-/commit/2afa5038ddbae925fe6a20b2b960271fe18a1ae5
+                      created_at: '2016-11-24T22:14:04.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-5efd1411540d5300c05d
+                      released_at: '2016-11-24T22:14:04.000Z'
+                      tag_name: untagged-5efd1411540d5300c05d
+                      tag_path: /graphviz/graphviz/-/tags/untagged-5efd1411540d5300c05d
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-167219c230abbb068c64
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-167219c230abbb068c64/graphviz-untagged-167219c230abbb068c64.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-167219c230abbb068c64/graphviz-untagged-167219c230abbb068c64.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-167219c230abbb068c64/graphviz-untagged-167219c230abbb068c64.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-167219c230abbb068c64/graphviz-untagged-167219c230abbb068c64.tar
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-11-24T14:13:11.000-05:00'
+                        committed_date: '2016-11-24T14:13:11.000-05:00'
+                        committer_email: john.ellson@comcast.net
+                        committer_name: John Ellson
+                        created_at: '2016-11-24T14:13:11.000-05:00'
+                        id: 3fbdc665aa8e30c6b701c9f5d19778cd8a12e821
+                        message: 'change winbuild.html to a relative URL so that it
+                          doesn''t break wgen relocated
+
+                          '
+                        parent_ids:
+                        - 592b9d5be6b38af2b54351c79a725a4115d0664c
+                        short_id: 3fbdc665
+                        title: change winbuild.html to a relative URL so that it doesn't
+                          break wgen relocated
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/3fbdc665aa8e30c6b701c9f5d19778cd8a12e821
+                      commit_path: /graphviz/graphviz/-/commit/3fbdc665aa8e30c6b701c9f5d19778cd8a12e821
+                      created_at: '2016-11-24T19:13:11.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-167219c230abbb068c64
+                      released_at: '2016-11-24T19:13:11.000Z'
+                      tag_name: untagged-167219c230abbb068c64
+                      tag_path: /graphviz/graphviz/-/tags/untagged-167219c230abbb068c64
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-4a0354222931f4cf012e
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-4a0354222931f4cf012e/graphviz-untagged-4a0354222931f4cf012e.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-4a0354222931f4cf012e/graphviz-untagged-4a0354222931f4cf012e.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-4a0354222931f4cf012e/graphviz-untagged-4a0354222931f4cf012e.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-4a0354222931f4cf012e/graphviz-untagged-4a0354222931f4cf012e.tar
+                      commit:
+                        author_email: emdenrg@google.com
+                        author_name: Emden Gansner
+                        authored_date: '2016-11-22T13:33:28.000-05:00'
+                        committed_date: '2016-11-22T13:33:28.000-05:00'
+                        committer_email: emdenrg@google.com
+                        committer_name: Emden Gansner
+                        created_at: '2016-11-22T13:33:28.000-05:00'
+                        id: 245c66135c5e1ca9b4f42061707f80634f84bce8
+                        message: 'Update man page, and fix number of nodes in the
+                          2D Sierpinski graph;
+
+                          fix edge count for 3D Sierpinski in graph_generator.c;
+
+                          modify CLI to use -S for Sierpinski in any dimension.
+
+                          '
+                        parent_ids:
+                        - e4ad5748bc7732b2731baa246a926ba9abc17f81
+                        short_id: 245c6613
+                        title: Update man page, and fix number of nodes in the 2D
+                          Sierpinski graph;
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/245c66135c5e1ca9b4f42061707f80634f84bce8
+                      commit_path: /graphviz/graphviz/-/commit/245c66135c5e1ca9b4f42061707f80634f84bce8
+                      created_at: '2016-11-22T18:33:28.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-4a0354222931f4cf012e
+                      released_at: '2016-11-22T18:33:28.000Z'
+                      tag_name: untagged-4a0354222931f4cf012e
+                      tag_path: /graphviz/graphviz/-/tags/untagged-4a0354222931f4cf012e
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-0a8cda69d4cba78f2e68
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-0a8cda69d4cba78f2e68/graphviz-untagged-0a8cda69d4cba78f2e68.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-0a8cda69d4cba78f2e68/graphviz-untagged-0a8cda69d4cba78f2e68.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-0a8cda69d4cba78f2e68/graphviz-untagged-0a8cda69d4cba78f2e68.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-0a8cda69d4cba78f2e68/graphviz-untagged-0a8cda69d4cba78f2e68.tar
+                      commit:
+                        author_email: emden@users.noreply.github.com
+                        author_name: emden
+                        authored_date: '2016-11-22T11:17:45.000-05:00'
+                        committed_date: '2016-11-22T11:17:45.000-05:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-11-22T11:17:45.000-05:00'
+                        id: e4ad5748bc7732b2731baa246a926ba9abc17f81
+                        message: 'Merge pull request #1171 from HanKruiger/master
+
+
+                          Added generation of tetrix (3d sierpinski) graphs.'
+                        parent_ids:
+                        - 1ef4d51121ba26e3e30ef7609249045952a481fa
+                        - 265eeb66ea0dbb4f7cdeb75dcc5f802d948b40a9
+                        short_id: e4ad5748
+                        title: 'Merge pull request #1171 from HanKruiger/master'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/e4ad5748bc7732b2731baa246a926ba9abc17f81
+                      commit_path: /graphviz/graphviz/-/commit/e4ad5748bc7732b2731baa246a926ba9abc17f81
+                      created_at: '2016-11-22T16:17:45.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-0a8cda69d4cba78f2e68
+                      released_at: '2016-11-22T16:17:45.000Z'
+                      tag_name: untagged-0a8cda69d4cba78f2e68
+                      tag_path: /graphviz/graphviz/-/tags/untagged-0a8cda69d4cba78f2e68
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-348619a7ff77176f7492
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-348619a7ff77176f7492/graphviz-untagged-348619a7ff77176f7492.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-348619a7ff77176f7492/graphviz-untagged-348619a7ff77176f7492.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-348619a7ff77176f7492/graphviz-untagged-348619a7ff77176f7492.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-348619a7ff77176f7492/graphviz-untagged-348619a7ff77176f7492.tar
+                      commit:
+                        author_email: emdenrg@google.com
+                        author_name: Emden Gansner
+                        authored_date: '2016-11-03T16:57:52.000-04:00'
+                        committed_date: '2016-11-03T16:57:52.000-04:00'
+                        committer_email: emdenrg@google.com
+                        committer_name: Emden Gansner
+                        created_at: '2016-11-03T16:57:52.000-04:00'
+                        id: 1ef4d51121ba26e3e30ef7609249045952a481fa
+                        message: 'Revert version ffb894f27874ebd510a8555c28083d6e01eb80b6.
+                          The fix broke other input (rtest/graphs/url.gv).
+
+                          Plus it didn''t fix the problem of repeated ids. We need
+                          to rethink how to handle anchors.
+
+                          '
+                        parent_ids:
+                        - 684e8547a1492e0c17dde990b329b18855dfec2c
+                        short_id: 1ef4d511
+                        title: Revert version ffb894f27874ebd510a8555c28083d6e01eb80b6.
+                          The fix broke other input (rtest/graphs/url.gv).
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/1ef4d51121ba26e3e30ef7609249045952a481fa
+                      commit_path: /graphviz/graphviz/-/commit/1ef4d51121ba26e3e30ef7609249045952a481fa
+                      created_at: '2016-11-03T20:57:52.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-348619a7ff77176f7492
+                      released_at: '2016-11-03T20:57:52.000Z'
+                      tag_name: untagged-348619a7ff77176f7492
+                      tag_path: /graphviz/graphviz/-/tags/untagged-348619a7ff77176f7492
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-c673d4de5b49bfc3ca91
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-c673d4de5b49bfc3ca91/graphviz-untagged-c673d4de5b49bfc3ca91.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-c673d4de5b49bfc3ca91/graphviz-untagged-c673d4de5b49bfc3ca91.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-c673d4de5b49bfc3ca91/graphviz-untagged-c673d4de5b49bfc3ca91.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-c673d4de5b49bfc3ca91/graphviz-untagged-c673d4de5b49bfc3ca91.tar
+                      commit:
+                        author_email: erg@emdenrg.net
+                        author_name: Emden R. Gansner
+                        authored_date: '2016-10-30T17:27:47.000-04:00'
+                        committed_date: '2016-10-30T17:27:47.000-04:00'
+                        committer_email: erg@emdenrg.net
+                        committer_name: Emden R. Gansner
+                        created_at: '2016-10-30T17:27:47.000-04:00'
+                        id: 684e8547a1492e0c17dde990b329b18855dfec2c
+                        message: 'Merge branch ''master'' of https://github.com/ellson/graphviz
+
+                          '
+                        parent_ids:
+                        - 737585d8c19d3e943f7f6c2de7232d6f27d768f2
+                        - c8298e899f0167d34bc9892a4d146e6428906ea5
+                        short_id: 684e8547
+                        title: Merge branch 'master' of https://github.com/ellson/graphviz
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/684e8547a1492e0c17dde990b329b18855dfec2c
+                      commit_path: /graphviz/graphviz/-/commit/684e8547a1492e0c17dde990b329b18855dfec2c
+                      created_at: '2016-10-30T21:27:47.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-c673d4de5b49bfc3ca91
+                      released_at: '2016-10-30T21:27:47.000Z'
+                      tag_name: untagged-c673d4de5b49bfc3ca91
+                      tag_path: /graphviz/graphviz/-/tags/untagged-c673d4de5b49bfc3ca91
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-0abbc2b30eaa01ee0686
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-0abbc2b30eaa01ee0686/graphviz-untagged-0abbc2b30eaa01ee0686.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-0abbc2b30eaa01ee0686/graphviz-untagged-0abbc2b30eaa01ee0686.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-0abbc2b30eaa01ee0686/graphviz-untagged-0abbc2b30eaa01ee0686.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-0abbc2b30eaa01ee0686/graphviz-untagged-0abbc2b30eaa01ee0686.tar
+                      commit:
+                        author_email: emdenrg@google.com
+                        author_name: Emden Gansner
+                        authored_date: '2016-10-28T11:04:06.000-04:00'
+                        committed_date: '2016-10-28T11:04:06.000-04:00'
+                        committer_email: emdenrg@google.com
+                        committer_name: Emden Gansner
+                        created_at: '2016-10-28T11:04:06.000-04:00'
+                        id: c8298e899f0167d34bc9892a4d146e6428906ea5
+                        message: 'Allow user to specify clustering algorithm in gvmap.
+
+                          '
+                        parent_ids:
+                        - a2d1632e7040f7c6bc997592c471297040bb0190
+                        short_id: c8298e89
+                        title: Allow user to specify clustering algorithm in gvmap.
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/c8298e899f0167d34bc9892a4d146e6428906ea5
+                      commit_path: /graphviz/graphviz/-/commit/c8298e899f0167d34bc9892a4d146e6428906ea5
+                      created_at: '2016-10-28T15:04:06.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-0abbc2b30eaa01ee0686
+                      released_at: '2016-10-28T15:04:06.000Z'
+                      tag_name: untagged-0abbc2b30eaa01ee0686
+                      tag_path: /graphviz/graphviz/-/tags/untagged-0abbc2b30eaa01ee0686
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-1520451ef19a8815aefb
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-1520451ef19a8815aefb/graphviz-untagged-1520451ef19a8815aefb.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-1520451ef19a8815aefb/graphviz-untagged-1520451ef19a8815aefb.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-1520451ef19a8815aefb/graphviz-untagged-1520451ef19a8815aefb.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-1520451ef19a8815aefb/graphviz-untagged-1520451ef19a8815aefb.tar
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-10-14T15:28:34.000-04:00'
+                        committed_date: '2016-10-14T15:28:34.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-10-14T15:28:34.000-04:00'
+                        id: a2d1632e7040f7c6bc997592c471297040bb0190
+                        message: 'simplify ksh buildrequire for SuSE builds
+
+                          '
+                        parent_ids:
+                        - ed4e9ae080b0034a9e3af568e58e01a0254d760c
+                        short_id: a2d1632e
+                        title: simplify ksh buildrequire for SuSE builds
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/a2d1632e7040f7c6bc997592c471297040bb0190
+                      commit_path: /graphviz/graphviz/-/commit/a2d1632e7040f7c6bc997592c471297040bb0190
+                      created_at: '2016-10-14T19:28:34.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-1520451ef19a8815aefb
+                      released_at: '2016-10-14T19:28:34.000Z'
+                      tag_name: untagged-1520451ef19a8815aefb
+                      tag_path: /graphviz/graphviz/-/tags/untagged-1520451ef19a8815aefb
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-be0b53127acfad7b5de6
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-be0b53127acfad7b5de6/graphviz-untagged-be0b53127acfad7b5de6.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-be0b53127acfad7b5de6/graphviz-untagged-be0b53127acfad7b5de6.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-be0b53127acfad7b5de6/graphviz-untagged-be0b53127acfad7b5de6.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-be0b53127acfad7b5de6/graphviz-untagged-be0b53127acfad7b5de6.tar
+                      commit:
+                        author_email: emdenrg@google.com
+                        author_name: Emden Gansner
+                        authored_date: '2016-10-12T10:37:02.000-04:00'
+                        committed_date: '2016-10-12T10:37:02.000-04:00'
+                        committer_email: emdenrg@google.com
+                        committer_name: Emden Gansner
+                        created_at: '2016-10-12T10:37:02.000-04:00'
+                        id: ed4e9ae080b0034a9e3af568e58e01a0254d760c
+                        message: 'Complete backbone algorithm; add testing scaffolding.
+
+                          '
+                        parent_ids:
+                        - 0ec14c85a79f21050e79cfe825d297002b9916ff
+                        short_id: ed4e9ae0
+                        title: Complete backbone algorithm; add testing scaffolding.
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/ed4e9ae080b0034a9e3af568e58e01a0254d760c
+                      commit_path: /graphviz/graphviz/-/commit/ed4e9ae080b0034a9e3af568e58e01a0254d760c
+                      created_at: '2016-10-12T14:37:02.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-be0b53127acfad7b5de6
+                      released_at: '2016-10-12T14:37:02.000Z'
+                      tag_name: untagged-be0b53127acfad7b5de6
+                      tag_path: /graphviz/graphviz/-/tags/untagged-be0b53127acfad7b5de6
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-8d75101f9a003883956c
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-8d75101f9a003883956c/graphviz-untagged-8d75101f9a003883956c.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-8d75101f9a003883956c/graphviz-untagged-8d75101f9a003883956c.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-8d75101f9a003883956c/graphviz-untagged-8d75101f9a003883956c.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-8d75101f9a003883956c/graphviz-untagged-8d75101f9a003883956c.tar
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-10-08T14:27:48.000-04:00'
+                        committed_date: '2016-10-08T14:27:48.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-10-08T14:27:48.000-04:00'
+                        id: 0ec14c85a79f21050e79cfe825d297002b9916ff
+                        message: 'missing TCL_EXEC_PREFIX substitution
+
+                          '
+                        parent_ids:
+                        - 10abca6914caddcabdb2af5ed856fa663e45d7d6
+                        short_id: 0ec14c85
+                        title: missing TCL_EXEC_PREFIX substitution
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/0ec14c85a79f21050e79cfe825d297002b9916ff
+                      commit_path: /graphviz/graphviz/-/commit/0ec14c85a79f21050e79cfe825d297002b9916ff
+                      created_at: '2016-10-08T18:27:48.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-8d75101f9a003883956c
+                      released_at: '2016-10-08T18:27:48.000Z'
+                      tag_name: untagged-8d75101f9a003883956c
+                      tag_path: /graphviz/graphviz/-/tags/untagged-8d75101f9a003883956c
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-5fc0363bc76319758ff6
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-5fc0363bc76319758ff6/graphviz-untagged-5fc0363bc76319758ff6.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-5fc0363bc76319758ff6/graphviz-untagged-5fc0363bc76319758ff6.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-5fc0363bc76319758ff6/graphviz-untagged-5fc0363bc76319758ff6.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-5fc0363bc76319758ff6/graphviz-untagged-5fc0363bc76319758ff6.tar
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-10-08T12:24:37.000-04:00'
+                        committed_date: '2016-10-08T12:24:37.000-04:00'
+                        committer_email: john.ellson@comcast.net
+                        committer_name: John Ellson
+                        created_at: '2016-10-08T12:24:37.000-04:00'
+                        id: 10abca6914caddcabdb2af5ed856fa663e45d7d6
+                        message: 'add spinehdr.h to source dstribution
+
+                          '
+                        parent_ids:
+                        - 938d807f51cba03989fec7a8d46f2dadae15e389
+                        short_id: 10abca69
+                        title: add spinehdr.h to source dstribution
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/10abca6914caddcabdb2af5ed856fa663e45d7d6
+                      commit_path: /graphviz/graphviz/-/commit/10abca6914caddcabdb2af5ed856fa663e45d7d6
+                      created_at: '2016-10-08T16:24:37.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-5fc0363bc76319758ff6
+                      released_at: '2016-10-08T16:24:37.000Z'
+                      tag_name: untagged-5fc0363bc76319758ff6
+                      tag_path: /graphviz/graphviz/-/tags/untagged-5fc0363bc76319758ff6
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-a81020c0c01db3e23629
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-a81020c0c01db3e23629/graphviz-untagged-a81020c0c01db3e23629.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-a81020c0c01db3e23629/graphviz-untagged-a81020c0c01db3e23629.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-a81020c0c01db3e23629/graphviz-untagged-a81020c0c01db3e23629.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-a81020c0c01db3e23629/graphviz-untagged-a81020c0c01db3e23629.tar
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-10-08T11:53:26.000-04:00'
+                        committed_date: '2016-10-08T11:53:26.000-04:00'
+                        committer_email: john.ellson@comcast.net
+                        committer_name: John Ellson
+                        created_at: '2016-10-08T11:53:26.000-04:00'
+                        id: 2dc424680466fc6ed2365c2d80cb4393635cf835
+                        message: '#include<spinehdr.h> => #include "spinehdr.h"
+
+                          '
+                        parent_ids:
+                        - caf65438ea717abb0fed3463ec21a0a25680f784
+                        short_id: 2dc42468
+                        title: '#include<spinehdr.h> => #include "spinehdr.h"'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/2dc424680466fc6ed2365c2d80cb4393635cf835
+                      commit_path: /graphviz/graphviz/-/commit/2dc424680466fc6ed2365c2d80cb4393635cf835
+                      created_at: '2016-10-08T15:53:26.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-a81020c0c01db3e23629
+                      released_at: '2016-10-08T15:53:26.000Z'
+                      tag_name: untagged-a81020c0c01db3e23629
+                      tag_path: /graphviz/graphviz/-/tags/untagged-a81020c0c01db3e23629
+                      upcoming_release: false
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f69f79e1d597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"697e853b5b4aa3288ee838d5451ad849"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-24-lb-gprd
+                      GitLab-SV: localhost
+                      Link: <https://gitlab.com/api/v4/projects/4207231/releases?id=4207231&page=2&per_page=20>;
+                        rel="next", <https://gitlab.com/api/v4/projects/4207231/releases?id=4207231&page=1&per_page=20>;
+                        rel="first", <https://gitlab.com/api/v4/projects/4207231/releases?id=4207231&page=3&per_page=20>;
+                        rel="last"
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '3'
+                      RateLimit-Remaining: '597'
+                      RateLimit-Reset: '1587559293'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:33 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Accept-Encoding, Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Next-Page: '2'
+                      X-Page: '1'
+                      X-Per-Page: '20'
+                      X-Prev-Page: ''
+                      X-Request-Id: 9oNvxhu2gE3
+                      X-Runtime: '0.327622'
+                      X-Total: '60'
+                      X-Total-Pages: '3'
+                      cf-request-id: 0243808ec10000597c7ebe1200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.753049373626709
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-20d8043c3b4489073df9
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-20d8043c3b4489073df9/graphviz-untagged-20d8043c3b4489073df9.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-20d8043c3b4489073df9/graphviz-untagged-20d8043c3b4489073df9.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-20d8043c3b4489073df9/graphviz-untagged-20d8043c3b4489073df9.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-20d8043c3b4489073df9/graphviz-untagged-20d8043c3b4489073df9.tar
+                      commit:
+                        author_email: erg@emdenrg.net
+                        author_name: Emden R. Gansner
+                        authored_date: '2016-10-02T17:49:01.000-04:00'
+                        committed_date: '2016-10-02T17:49:01.000-04:00'
+                        committer_email: erg@emdenrg.net
+                        committer_name: Emden R. Gansner
+                        created_at: '2016-10-02T17:49:01.000-04:00'
+                        id: caf65438ea717abb0fed3463ec21a0a25680f784
+                        message: 'Add library for computing Simmelian backbones of
+                          graphs.
+
+                          '
+                        parent_ids:
+                        - 582976380f1f75795d2b7eddf38a575b8ab5b279
+                        short_id: caf65438
+                        title: Add library for computing Simmelian backbones of graphs.
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/caf65438ea717abb0fed3463ec21a0a25680f784
+                      commit_path: /graphviz/graphviz/-/commit/caf65438ea717abb0fed3463ec21a0a25680f784
+                      created_at: '2016-10-02T21:49:01.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-20d8043c3b4489073df9
+                      released_at: '2016-10-02T21:49:01.000Z'
+                      tag_name: untagged-20d8043c3b4489073df9
+                      tag_path: /graphviz/graphviz/-/tags/untagged-20d8043c3b4489073df9
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-1db191c2a75651a2a553
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-1db191c2a75651a2a553/graphviz-untagged-1db191c2a75651a2a553.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-1db191c2a75651a2a553/graphviz-untagged-1db191c2a75651a2a553.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-1db191c2a75651a2a553/graphviz-untagged-1db191c2a75651a2a553.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-1db191c2a75651a2a553/graphviz-untagged-1db191c2a75651a2a553.tar
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-09-27T09:34:24.000-04:00'
+                        committed_date: '2016-09-27T09:34:24.000-04:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-09-27T09:34:24.000-04:00'
+                        id: 582976380f1f75795d2b7eddf38a575b8ab5b279
+                        message: 'Merge pull request #1164 from ErwinJanssen/update-appveyor-dependencies
+
+
+                          Appveyor: update libgd dependencies and build dir'
+                        parent_ids:
+                        - e746dac6b40a6911db36d6243a0c9624abc7d0d7
+                        - 31a02bfebea16c6be9c2bc805d7930af0d64649b
+                        short_id: '58297638'
+                        title: 'Merge pull request #1164 from ErwinJanssen/update-appveyor-dependencies'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/582976380f1f75795d2b7eddf38a575b8ab5b279
+                      commit_path: /graphviz/graphviz/-/commit/582976380f1f75795d2b7eddf38a575b8ab5b279
+                      created_at: '2016-09-27T13:34:24.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-1db191c2a75651a2a553
+                      released_at: '2016-09-27T13:34:24.000Z'
+                      tag_name: untagged-1db191c2a75651a2a553
+                      tag_path: /graphviz/graphviz/-/tags/untagged-1db191c2a75651a2a553
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-026b538d0dba6682fde7
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-026b538d0dba6682fde7/graphviz-untagged-026b538d0dba6682fde7.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-026b538d0dba6682fde7/graphviz-untagged-026b538d0dba6682fde7.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-026b538d0dba6682fde7/graphviz-untagged-026b538d0dba6682fde7.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-026b538d0dba6682fde7/graphviz-untagged-026b538d0dba6682fde7.tar
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-09-19T14:21:06.000-04:00'
+                        committed_date: '2016-09-19T14:21:06.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-09-19T14:21:06.000-04:00'
+                        id: e746dac6b40a6911db36d6243a0c9624abc7d0d7
+                        message: 'Merge branch ''ErwinJanssen-remove-unused''
+
+
+                          (resolved conflict from reinstalled features/common)
+
+                          '
+                        parent_ids:
+                        - 985e7736b11dbd577658f7538070f3a85129dd53
+                        - ec8a1812303950949a4bbef86f2afc27bbba75a4
+                        short_id: e746dac6
+                        title: Merge branch 'ErwinJanssen-remove-unused'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/e746dac6b40a6911db36d6243a0c9624abc7d0d7
+                      commit_path: /graphviz/graphviz/-/commit/e746dac6b40a6911db36d6243a0c9624abc7d0d7
+                      created_at: '2016-09-19T18:21:06.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-026b538d0dba6682fde7
+                      released_at: '2016-09-19T18:21:06.000Z'
+                      tag_name: untagged-026b538d0dba6682fde7
+                      tag_path: /graphviz/graphviz/-/tags/untagged-026b538d0dba6682fde7
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-bc9e6eee63f1f0bce98f
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-bc9e6eee63f1f0bce98f/graphviz-untagged-bc9e6eee63f1f0bce98f.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-bc9e6eee63f1f0bce98f/graphviz-untagged-bc9e6eee63f1f0bce98f.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-bc9e6eee63f1f0bce98f/graphviz-untagged-bc9e6eee63f1f0bce98f.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-bc9e6eee63f1f0bce98f/graphviz-untagged-bc9e6eee63f1f0bce98f.tar
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-09-19T13:13:24.000-04:00'
+                        committed_date: '2016-09-19T13:13:24.000-04:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-09-19T13:13:24.000-04:00'
+                        id: 985e7736b11dbd577658f7538070f3a85129dd53
+                        message: 'Merge pull request #1163 from ErwinJanssen/less-conditional-build
+
+
+                          Less conditional build'
+                        parent_ids:
+                        - 59d5922b6af402cd6a0ee18f987ef56cf5c96064
+                        - e9c3f623715447a95493c6b6966974de21f3db1c
+                        short_id: 985e7736
+                        title: 'Merge pull request #1163 from ErwinJanssen/less-conditional-build'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/985e7736b11dbd577658f7538070f3a85129dd53
+                      commit_path: /graphviz/graphviz/-/commit/985e7736b11dbd577658f7538070f3a85129dd53
+                      created_at: '2016-09-19T17:13:24.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-bc9e6eee63f1f0bce98f
+                      released_at: '2016-09-19T17:13:24.000Z'
+                      tag_name: untagged-bc9e6eee63f1f0bce98f
+                      tag_path: /graphviz/graphviz/-/tags/untagged-bc9e6eee63f1f0bce98f
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-4431b9bde391f1b69fe5
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-4431b9bde391f1b69fe5/graphviz-untagged-4431b9bde391f1b69fe5.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-4431b9bde391f1b69fe5/graphviz-untagged-4431b9bde391f1b69fe5.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-4431b9bde391f1b69fe5/graphviz-untagged-4431b9bde391f1b69fe5.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-4431b9bde391f1b69fe5/graphviz-untagged-4431b9bde391f1b69fe5.tar
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-09-19T13:13:24.000-04:00'
+                        committed_date: '2016-09-19T13:13:24.000-04:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-09-19T13:13:24.000-04:00'
+                        id: 985e7736b11dbd577658f7538070f3a85129dd53
+                        message: 'Merge pull request #1163 from ErwinJanssen/less-conditional-build
+
+
+                          Less conditional build'
+                        parent_ids:
+                        - 59d5922b6af402cd6a0ee18f987ef56cf5c96064
+                        - e9c3f623715447a95493c6b6966974de21f3db1c
+                        short_id: 985e7736
+                        title: 'Merge pull request #1163 from ErwinJanssen/less-conditional-build'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/985e7736b11dbd577658f7538070f3a85129dd53
+                      commit_path: /graphviz/graphviz/-/commit/985e7736b11dbd577658f7538070f3a85129dd53
+                      created_at: '2016-09-19T17:13:24.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-4431b9bde391f1b69fe5
+                      released_at: '2016-09-19T17:13:24.000Z'
+                      tag_name: untagged-4431b9bde391f1b69fe5
+                      tag_path: /graphviz/graphviz/-/tags/untagged-4431b9bde391f1b69fe5
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-a22228c7bd6ed4c2a8f9
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-a22228c7bd6ed4c2a8f9/graphviz-untagged-a22228c7bd6ed4c2a8f9.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-a22228c7bd6ed4c2a8f9/graphviz-untagged-a22228c7bd6ed4c2a8f9.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-a22228c7bd6ed4c2a8f9/graphviz-untagged-a22228c7bd6ed4c2a8f9.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-a22228c7bd6ed4c2a8f9/graphviz-untagged-a22228c7bd6ed4c2a8f9.tar
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-09-08T00:13:48.000-04:00'
+                        committed_date: '2016-09-08T00:13:48.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-09-08T00:13:48.000-04:00'
+                        id: ee4cdc97ef3f9f9107c0d90c58c4afd64f8f8236
+                        message: 'revert change - not right
+
+                          '
+                        parent_ids:
+                        - f5ae75970c48184c2621e61f40cdfc4879825838
+                        short_id: ee4cdc97
+                        title: revert change - not right
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/ee4cdc97ef3f9f9107c0d90c58c4afd64f8f8236
+                      commit_path: /graphviz/graphviz/-/commit/ee4cdc97ef3f9f9107c0d90c58c4afd64f8f8236
+                      created_at: '2016-09-08T04:13:48.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-a22228c7bd6ed4c2a8f9
+                      released_at: '2016-09-08T04:13:48.000Z'
+                      tag_name: untagged-a22228c7bd6ed4c2a8f9
+                      tag_path: /graphviz/graphviz/-/tags/untagged-a22228c7bd6ed4c2a8f9
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-88f8affbb29485590ece
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-88f8affbb29485590ece/graphviz-untagged-88f8affbb29485590ece.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-88f8affbb29485590ece/graphviz-untagged-88f8affbb29485590ece.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-88f8affbb29485590ece/graphviz-untagged-88f8affbb29485590ece.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-88f8affbb29485590ece/graphviz-untagged-88f8affbb29485590ece.tar
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-09-07T19:44:14.000-04:00'
+                        committed_date: '2016-09-07T19:44:14.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-09-07T19:44:14.000-04:00'
+                        id: f5ae75970c48184c2621e61f40cdfc4879825838
+                        message: 'drop some strange casts to cllean up some warnings
+
+                          '
+                        parent_ids:
+                        - 102a8ca3fa7629aac03c4de815681f401b5ec718
+                        short_id: f5ae7597
+                        title: drop some strange casts to cllean up some warnings
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/f5ae75970c48184c2621e61f40cdfc4879825838
+                      commit_path: /graphviz/graphviz/-/commit/f5ae75970c48184c2621e61f40cdfc4879825838
+                      created_at: '2016-09-07T23:44:14.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-88f8affbb29485590ece
+                      released_at: '2016-09-07T23:44:14.000Z'
+                      tag_name: untagged-88f8affbb29485590ece
+                      tag_path: /graphviz/graphviz/-/tags/untagged-88f8affbb29485590ece
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-897b348e31e4e52e8698
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-897b348e31e4e52e8698/graphviz-untagged-897b348e31e4e52e8698.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-897b348e31e4e52e8698/graphviz-untagged-897b348e31e4e52e8698.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-897b348e31e4e52e8698/graphviz-untagged-897b348e31e4e52e8698.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-897b348e31e4e52e8698/graphviz-untagged-897b348e31e4e52e8698.tar
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-09-07T19:19:26.000-04:00'
+                        committed_date: '2016-09-07T19:19:26.000-04:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-09-07T19:19:26.000-04:00'
+                        id: 102a8ca3fa7629aac03c4de815681f401b5ec718
+                        message: 'Merge pull request #1155 from ErwinJanssen/windows-release
+
+
+                          Various improvements to Windows build'
+                        parent_ids:
+                        - 2d0c2c03c403ba47b9ca4b381d25aa96cfa83042
+                        - 3b48e9575c30ae0a82fcf06e18259d532336a415
+                        short_id: 102a8ca3
+                        title: 'Merge pull request #1155 from ErwinJanssen/windows-release'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/102a8ca3fa7629aac03c4de815681f401b5ec718
+                      commit_path: /graphviz/graphviz/-/commit/102a8ca3fa7629aac03c4de815681f401b5ec718
+                      created_at: '2016-09-07T23:19:26.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-897b348e31e4e52e8698
+                      released_at: '2016-09-07T23:19:26.000Z'
+                      tag_name: untagged-897b348e31e4e52e8698
+                      tag_path: /graphviz/graphviz/-/tags/untagged-897b348e31e4e52e8698
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-d1db4ad9a9fa8595330a
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-d1db4ad9a9fa8595330a/graphviz-untagged-d1db4ad9a9fa8595330a.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-d1db4ad9a9fa8595330a/graphviz-untagged-d1db4ad9a9fa8595330a.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-d1db4ad9a9fa8595330a/graphviz-untagged-d1db4ad9a9fa8595330a.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-d1db4ad9a9fa8595330a/graphviz-untagged-d1db4ad9a9fa8595330a.tar
+                      commit:
+                        author_email: erg@emdenrg.net
+                        author_name: Emden R. Gansner
+                        authored_date: '2016-09-05T16:35:47.000-04:00'
+                        committed_date: '2016-09-05T16:35:47.000-04:00'
+                        committer_email: erg@emdenrg.net
+                        committer_name: Emden R. Gansner
+                        created_at: '2016-09-05T16:35:47.000-04:00'
+                        id: bc6488018f3f55ace6b4046645578508643db08b
+                        message: 'Add documentation on json output.
+
+                          '
+                        parent_ids:
+                        - 3c0d713cf7b49231f845cc9b38c800feea1552ab
+                        short_id: bc648801
+                        title: Add documentation on json output.
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/bc6488018f3f55ace6b4046645578508643db08b
+                      commit_path: /graphviz/graphviz/-/commit/bc6488018f3f55ace6b4046645578508643db08b
+                      created_at: '2016-09-05T20:35:47.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-d1db4ad9a9fa8595330a
+                      released_at: '2016-09-05T20:35:47.000Z'
+                      tag_name: untagged-d1db4ad9a9fa8595330a
+                      tag_path: /graphviz/graphviz/-/tags/untagged-d1db4ad9a9fa8595330a
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-153418532a1b01559b57
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-153418532a1b01559b57/graphviz-untagged-153418532a1b01559b57.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-153418532a1b01559b57/graphviz-untagged-153418532a1b01559b57.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-153418532a1b01559b57/graphviz-untagged-153418532a1b01559b57.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-153418532a1b01559b57/graphviz-untagged-153418532a1b01559b57.tar
+                      commit:
+                        author_email: emdenrg@google.com
+                        author_name: Emden Gansner
+                        authored_date: '2016-09-03T13:19:09.000-04:00'
+                        committed_date: '2016-09-03T13:19:09.000-04:00'
+                        committer_email: emdenrg@google.com
+                        committer_name: Emden Gansner
+                        created_at: '2016-09-03T13:19:09.000-04:00'
+                        id: 3c0d713cf7b49231f845cc9b38c800feea1552ab
+                        message: 'Merge branch ''master'' of https://github.com/ellson/graphviz
+
+                          '
+                        parent_ids:
+                        - 6be338ffd3f3fdcbc273c4284f7f741825eae6c3
+                        - d1244c8001e8c681def4c0ff25a91136845c2a75
+                        short_id: 3c0d713c
+                        title: Merge branch 'master' of https://github.com/ellson/graphviz
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/3c0d713cf7b49231f845cc9b38c800feea1552ab
+                      commit_path: /graphviz/graphviz/-/commit/3c0d713cf7b49231f845cc9b38c800feea1552ab
+                      created_at: '2016-09-03T17:19:09.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-153418532a1b01559b57
+                      released_at: '2016-09-03T17:19:09.000Z'
+                      tag_name: untagged-153418532a1b01559b57
+                      tag_path: /graphviz/graphviz/-/tags/untagged-153418532a1b01559b57
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-4bd8dcccfa75989e4d17
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-4bd8dcccfa75989e4d17/graphviz-untagged-4bd8dcccfa75989e4d17.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-4bd8dcccfa75989e4d17/graphviz-untagged-4bd8dcccfa75989e4d17.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-4bd8dcccfa75989e4d17/graphviz-untagged-4bd8dcccfa75989e4d17.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-4bd8dcccfa75989e4d17/graphviz-untagged-4bd8dcccfa75989e4d17.tar
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-08-23T10:45:02.000-04:00'
+                        committed_date: '2016-08-23T10:45:02.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-08-23T10:45:02.000-04:00'
+                        id: d1244c8001e8c681def4c0ff25a91136845c2a75
+                        message: 'convert ''unsigned long'' to ''uint64_t'' for Windows
+                          portability
+
+                          '
+                        parent_ids:
+                        - 5f026ed122a2e1525dab7a6bc192ba7c40a1a7d0
+                        short_id: d1244c80
+                        title: convert 'unsigned long' to 'uint64_t' for Windows portability
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/d1244c8001e8c681def4c0ff25a91136845c2a75
+                      commit_path: /graphviz/graphviz/-/commit/d1244c8001e8c681def4c0ff25a91136845c2a75
+                      created_at: '2016-08-23T14:45:02.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-4bd8dcccfa75989e4d17
+                      released_at: '2016-08-23T14:45:02.000Z'
+                      tag_name: untagged-4bd8dcccfa75989e4d17
+                      tag_path: /graphviz/graphviz/-/tags/untagged-4bd8dcccfa75989e4d17
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-5b049c6cdfd083f5dbf2
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-5b049c6cdfd083f5dbf2/graphviz-untagged-5b049c6cdfd083f5dbf2.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-5b049c6cdfd083f5dbf2/graphviz-untagged-5b049c6cdfd083f5dbf2.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-5b049c6cdfd083f5dbf2/graphviz-untagged-5b049c6cdfd083f5dbf2.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-5b049c6cdfd083f5dbf2/graphviz-untagged-5b049c6cdfd083f5dbf2.tar
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-08-22T19:49:46.000-04:00'
+                        committed_date: '2016-08-22T19:49:46.000-04:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-08-22T19:49:46.000-04:00'
+                        id: 5f026ed122a2e1525dab7a6bc192ba7c40a1a7d0
+                        message: 'Merge pull request #1151 from arjamizo/master
+
+
+                          fix typo TB->BT in docs:shapes'
+                        parent_ids:
+                        - cd3b556caf39f78c82208b217e78a4d70c1684e0
+                        - 29de28fd4e2dc2497bfc1f294c4b67056009cfa2
+                        short_id: 5f026ed1
+                        title: 'Merge pull request #1151 from arjamizo/master'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/5f026ed122a2e1525dab7a6bc192ba7c40a1a7d0
+                      commit_path: /graphviz/graphviz/-/commit/5f026ed122a2e1525dab7a6bc192ba7c40a1a7d0
+                      created_at: '2016-08-22T23:49:46.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-5b049c6cdfd083f5dbf2
+                      released_at: '2016-08-22T23:49:46.000Z'
+                      tag_name: untagged-5b049c6cdfd083f5dbf2
+                      tag_path: /graphviz/graphviz/-/tags/untagged-5b049c6cdfd083f5dbf2
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-f6bbc5576feb1e03c4b8
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-f6bbc5576feb1e03c4b8/graphviz-untagged-f6bbc5576feb1e03c4b8.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-f6bbc5576feb1e03c4b8/graphviz-untagged-f6bbc5576feb1e03c4b8.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-f6bbc5576feb1e03c4b8/graphviz-untagged-f6bbc5576feb1e03c4b8.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-f6bbc5576feb1e03c4b8/graphviz-untagged-f6bbc5576feb1e03c4b8.tar
+                      commit:
+                        author_email: erg@emdenrg.net
+                        author_name: Emden R. Gansner
+                        authored_date: '2016-08-19T07:04:25.000-04:00'
+                        committed_date: '2016-08-19T07:04:25.000-04:00'
+                        committer_email: erg@emdenrg.net
+                        committer_name: Emden R. Gansner
+                        created_at: '2016-08-19T07:04:25.000-04:00'
+                        id: cd3b556caf39f78c82208b217e78a4d70c1684e0
+                        message: 'Replace cluster with subgraph, as the output will
+                          also reflect non-cluster
+
+                          subgraphs.
+
+                          '
+                        parent_ids:
+                        - d7e8b8136aa22301ae3a448c38024f1d049f3d1a
+                        short_id: cd3b556c
+                        title: Replace cluster with subgraph, as the output will also
+                          reflect non-cluster
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/cd3b556caf39f78c82208b217e78a4d70c1684e0
+                      commit_path: /graphviz/graphviz/-/commit/cd3b556caf39f78c82208b217e78a4d70c1684e0
+                      created_at: '2016-08-19T11:04:25.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-f6bbc5576feb1e03c4b8
+                      released_at: '2016-08-19T11:04:25.000Z'
+                      tag_name: untagged-f6bbc5576feb1e03c4b8
+                      tag_path: /graphviz/graphviz/-/tags/untagged-f6bbc5576feb1e03c4b8
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-0dc7cf263f66ae1825bb
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-0dc7cf263f66ae1825bb/graphviz-untagged-0dc7cf263f66ae1825bb.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-0dc7cf263f66ae1825bb/graphviz-untagged-0dc7cf263f66ae1825bb.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-0dc7cf263f66ae1825bb/graphviz-untagged-0dc7cf263f66ae1825bb.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-0dc7cf263f66ae1825bb/graphviz-untagged-0dc7cf263f66ae1825bb.tar
+                      commit:
+                        author_email: erg@emdenrg.net
+                        author_name: Emden R. Gansner
+                        authored_date: '2016-08-17T20:36:28.000-04:00'
+                        committed_date: '2016-08-17T20:36:28.000-04:00'
+                        committer_email: erg@emdenrg.net
+                        committer_name: Emden R. Gansner
+                        created_at: '2016-08-17T20:36:28.000-04:00'
+                        id: d7e8b8136aa22301ae3a448c38024f1d049f3d1a
+                        message: 'Add schema for dot output in json format.
+
+                          '
+                        parent_ids:
+                        - 2c10dbea604a56c49918c8f153440f1919a0797f
+                        short_id: d7e8b813
+                        title: Add schema for dot output in json format.
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/d7e8b8136aa22301ae3a448c38024f1d049f3d1a
+                      commit_path: /graphviz/graphviz/-/commit/d7e8b8136aa22301ae3a448c38024f1d049f3d1a
+                      created_at: '2016-08-18T00:36:28.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-0dc7cf263f66ae1825bb
+                      released_at: '2016-08-18T00:36:28.000Z'
+                      tag_name: untagged-0dc7cf263f66ae1825bb
+                      tag_path: /graphviz/graphviz/-/tags/untagged-0dc7cf263f66ae1825bb
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-1bc5df88610db337fc67
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-1bc5df88610db337fc67/graphviz-untagged-1bc5df88610db337fc67.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-1bc5df88610db337fc67/graphviz-untagged-1bc5df88610db337fc67.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-1bc5df88610db337fc67/graphviz-untagged-1bc5df88610db337fc67.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-1bc5df88610db337fc67/graphviz-untagged-1bc5df88610db337fc67.tar
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-08-17T09:11:10.000-04:00'
+                        committed_date: '2016-08-17T09:11:10.000-04:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-08-17T09:11:10.000-04:00'
+                        id: 2c10dbea604a56c49918c8f153440f1919a0797f
+                        message: 'Merge pull request #1150 from ErwinJanssen/configure-ac
+
+
+                          Removed POSIX version flag from configure.ac'
+                        parent_ids:
+                        - 8123e7b0dfc348c8402516c1302e956dfacec161
+                        - 1d23dfe697f44e77d42462ff71c284617342dd1c
+                        short_id: 2c10dbea
+                        title: 'Merge pull request #1150 from ErwinJanssen/configure-ac'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/2c10dbea604a56c49918c8f153440f1919a0797f
+                      commit_path: /graphviz/graphviz/-/commit/2c10dbea604a56c49918c8f153440f1919a0797f
+                      created_at: '2016-08-17T13:11:10.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-1bc5df88610db337fc67
+                      released_at: '2016-08-17T13:11:10.000Z'
+                      tag_name: untagged-1bc5df88610db337fc67
+                      tag_path: /graphviz/graphviz/-/tags/untagged-1bc5df88610db337fc67
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-383680da5ca9da9f5250
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-383680da5ca9da9f5250/graphviz-untagged-383680da5ca9da9f5250.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-383680da5ca9da9f5250/graphviz-untagged-383680da5ca9da9f5250.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-383680da5ca9da9f5250/graphviz-untagged-383680da5ca9da9f5250.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-383680da5ca9da9f5250/graphviz-untagged-383680da5ca9da9f5250.tar
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-08-16T13:18:55.000-04:00'
+                        committed_date: '2016-08-16T13:18:55.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-08-16T13:18:55.000-04:00'
+                        id: 8123e7b0dfc348c8402516c1302e956dfacec161
+                        message: 'el5 breakage, need ,  in dist target, but not in
+                          install target
+
+                          '
+                        parent_ids:
+                        - 788583c2dde4d8eeff6afca9c23bde567f27473b
+                        short_id: 8123e7b0
+                        title: el5 breakage, need ,  in dist target, but not in install
+                          target
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/8123e7b0dfc348c8402516c1302e956dfacec161
+                      commit_path: /graphviz/graphviz/-/commit/8123e7b0dfc348c8402516c1302e956dfacec161
+                      created_at: '2016-08-16T17:18:55.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-383680da5ca9da9f5250
+                      released_at: '2016-08-16T17:18:55.000Z'
+                      tag_name: untagged-383680da5ca9da9f5250
+                      tag_path: /graphviz/graphviz/-/tags/untagged-383680da5ca9da9f5250
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-d177ed11e0540b07902a
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-d177ed11e0540b07902a/graphviz-untagged-d177ed11e0540b07902a.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-d177ed11e0540b07902a/graphviz-untagged-d177ed11e0540b07902a.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-d177ed11e0540b07902a/graphviz-untagged-d177ed11e0540b07902a.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-d177ed11e0540b07902a/graphviz-untagged-d177ed11e0540b07902a.tar
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-08-16T12:03:03.000-04:00'
+                        committed_date: '2016-08-16T12:03:03.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-08-16T12:03:03.000-04:00'
+                        id: 788583c2dde4d8eeff6afca9c23bde567f27473b
+                        message: 'remove -D_POSIX_C_SOURCE=200112L as it breaks ./configure
+                          test for php.h
+
+                          '
+                        parent_ids:
+                        - 86525777eafc8621591e37e5e3feb15ebe9fbedf
+                        short_id: 788583c2
+                        title: remove -D_POSIX_C_SOURCE=200112L as it breaks ./configure
+                          test for php.h
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/788583c2dde4d8eeff6afca9c23bde567f27473b
+                      commit_path: /graphviz/graphviz/-/commit/788583c2dde4d8eeff6afca9c23bde567f27473b
+                      created_at: '2016-08-16T16:03:03.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-d177ed11e0540b07902a
+                      released_at: '2016-08-16T16:03:03.000Z'
+                      tag_name: untagged-d177ed11e0540b07902a
+                      tag_path: /graphviz/graphviz/-/tags/untagged-d177ed11e0540b07902a
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-95487e465cf6bdb4c605
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-95487e465cf6bdb4c605/graphviz-untagged-95487e465cf6bdb4c605.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-95487e465cf6bdb4c605/graphviz-untagged-95487e465cf6bdb4c605.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-95487e465cf6bdb4c605/graphviz-untagged-95487e465cf6bdb4c605.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-95487e465cf6bdb4c605/graphviz-untagged-95487e465cf6bdb4c605.tar
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-08-15T16:21:54.000-04:00'
+                        committed_date: '2016-08-15T16:21:54.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-08-15T16:21:54.000-04:00'
+                        id: 86525777eafc8621591e37e5e3feb15ebe9fbedf
+                        message: 'Merge branch ''master'' of github.com:/ellson/graphviz
+
+                          '
+                        parent_ids:
+                        - e2a23c828c1d1462065236cdc82362a86db49de5
+                        - c35619db486c6a2453ef0a9de6f541e809037760
+                        short_id: '86525777'
+                        title: Merge branch 'master' of github.com:/ellson/graphviz
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/86525777eafc8621591e37e5e3feb15ebe9fbedf
+                      commit_path: /graphviz/graphviz/-/commit/86525777eafc8621591e37e5e3feb15ebe9fbedf
+                      created_at: '2016-08-15T20:21:54.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-95487e465cf6bdb4c605
+                      released_at: '2016-08-15T20:21:54.000Z'
+                      tag_name: untagged-95487e465cf6bdb4c605
+                      tag_path: /graphviz/graphviz/-/tags/untagged-95487e465cf6bdb4c605
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-950e8f23afa87abe4973
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-950e8f23afa87abe4973/graphviz-untagged-950e8f23afa87abe4973.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-950e8f23afa87abe4973/graphviz-untagged-950e8f23afa87abe4973.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-950e8f23afa87abe4973/graphviz-untagged-950e8f23afa87abe4973.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-950e8f23afa87abe4973/graphviz-untagged-950e8f23afa87abe4973.tar
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-08-13T12:55:44.000-04:00'
+                        committed_date: '2016-08-13T12:55:44.000-04:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-08-13T12:55:44.000-04:00'
+                        id: c35619db486c6a2453ef0a9de6f541e809037760
+                        message: 'Merge pull request #1149 from ErwinJanssen/improve-travis
+
+
+                          Improve Travis + deploy make dist results'
+                        parent_ids:
+                        - 29ed3f9866af9051145f010cb13824b6c7f92866
+                        - 7d41358763116f4289fd125bfe9f9a8676080c5c
+                        short_id: c35619db
+                        title: 'Merge pull request #1149 from ErwinJanssen/improve-travis'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/c35619db486c6a2453ef0a9de6f541e809037760
+                      commit_path: /graphviz/graphviz/-/commit/c35619db486c6a2453ef0a9de6f541e809037760
+                      created_at: '2016-08-13T16:55:44.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-950e8f23afa87abe4973
+                      released_at: '2016-08-13T16:55:44.000Z'
+                      tag_name: untagged-950e8f23afa87abe4973
+                      tag_path: /graphviz/graphviz/-/tags/untagged-950e8f23afa87abe4973
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-0aac90e5c2817176609d
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-0aac90e5c2817176609d/graphviz-untagged-0aac90e5c2817176609d.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-0aac90e5c2817176609d/graphviz-untagged-0aac90e5c2817176609d.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-0aac90e5c2817176609d/graphviz-untagged-0aac90e5c2817176609d.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-0aac90e5c2817176609d/graphviz-untagged-0aac90e5c2817176609d.tar
+                      commit:
+                        author_email: emdenrg@google.com
+                        author_name: Emden Gansner
+                        authored_date: '2016-08-13T08:51:45.000-04:00'
+                        committed_date: '2016-08-13T08:51:45.000-04:00'
+                        committer_email: emdenrg@google.com
+                        committer_name: Emden Gansner
+                        created_at: '2016-08-13T08:51:45.000-04:00'
+                        id: 29ed3f9866af9051145f010cb13824b6c7f92866
+                        message: 'Small formatting change.
+
+                          '
+                        parent_ids:
+                        - 39180176da657656abc7f7f90adf894b85aeabee
+                        short_id: 29ed3f98
+                        title: Small formatting change.
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/29ed3f9866af9051145f010cb13824b6c7f92866
+                      commit_path: /graphviz/graphviz/-/commit/29ed3f9866af9051145f010cb13824b6c7f92866
+                      created_at: '2016-08-13T12:51:45.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-0aac90e5c2817176609d
+                      released_at: '2016-08-13T12:51:45.000Z'
+                      tag_name: untagged-0aac90e5c2817176609d
+                      tag_path: /graphviz/graphviz/-/tags/untagged-0aac90e5c2817176609d
+                      upcoming_release: false
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f69fb6855597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"2ef37558205653b0efed0800d962d182"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-06-lb-gprd
+                      GitLab-SV: localhost
+                      Link: <https://gitlab.com/api/v4/projects/4207231/releases?id=4207231&page=1&per_page=20>;
+                        rel="prev", <https://gitlab.com/api/v4/projects/4207231/releases?id=4207231&page=3&per_page=20>;
+                        rel="next", <https://gitlab.com/api/v4/projects/4207231/releases?id=4207231&page=1&per_page=20>;
+                        rel="first", <https://gitlab.com/api/v4/projects/4207231/releases?id=4207231&page=3&per_page=20>;
+                        rel="last"
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '3'
+                      RateLimit-Remaining: '596'
+                      RateLimit-Reset: '1587559294'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:34 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Accept-Encoding, Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Next-Page: '3'
+                      X-Page: '2'
+                      X-Per-Page: '20'
+                      X-Prev-Page: '1'
+                      X-Request-Id: zKfayM88jv9
+                      X-Runtime: '0.504976'
+                      X-Total: '60'
+                      X-Total-Pages: '3'
+                      cf-request-id: 02438091250000597c7e807200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.6620049476623535
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-c6ce5b1f17878d776124
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-c6ce5b1f17878d776124/graphviz-untagged-c6ce5b1f17878d776124.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-c6ce5b1f17878d776124/graphviz-untagged-c6ce5b1f17878d776124.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-c6ce5b1f17878d776124/graphviz-untagged-c6ce5b1f17878d776124.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-c6ce5b1f17878d776124/graphviz-untagged-c6ce5b1f17878d776124.tar
+                      commit:
+                        author_email: emdenrg@google.com
+                        author_name: Emden Gansner
+                        authored_date: '2016-08-12T17:18:29.000-04:00'
+                        committed_date: '2016-08-12T17:18:29.000-04:00'
+                        committer_email: emdenrg@google.com
+                        committer_name: Emden Gansner
+                        created_at: '2016-08-12T17:18:29.000-04:00'
+                        id: 39180176da657656abc7f7f90adf894b85aeabee
+                        message: 'Edges attached to a cluster were not getting assigned
+                          an index number.
+
+                          '
+                        parent_ids:
+                        - 4b456b630eefb5425696cbb9831ca907d9dd75cb
+                        short_id: '39180176'
+                        title: Edges attached to a cluster were not getting assigned
+                          an index number.
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/39180176da657656abc7f7f90adf894b85aeabee
+                      commit_path: /graphviz/graphviz/-/commit/39180176da657656abc7f7f90adf894b85aeabee
+                      created_at: '2016-08-12T21:18:29.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-c6ce5b1f17878d776124
+                      released_at: '2016-08-12T21:18:29.000Z'
+                      tag_name: untagged-c6ce5b1f17878d776124
+                      tag_path: /graphviz/graphviz/-/tags/untagged-c6ce5b1f17878d776124
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-1aed90cbe517038de3a0
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-1aed90cbe517038de3a0/graphviz-untagged-1aed90cbe517038de3a0.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-1aed90cbe517038de3a0/graphviz-untagged-1aed90cbe517038de3a0.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-1aed90cbe517038de3a0/graphviz-untagged-1aed90cbe517038de3a0.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-1aed90cbe517038de3a0/graphviz-untagged-1aed90cbe517038de3a0.tar
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-08-10T15:00:14.000-04:00'
+                        committed_date: '2016-08-10T15:00:14.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-08-10T15:00:14.000-04:00'
+                        id: 4b456b630eefb5425696cbb9831ca907d9dd75cb
+                        message: 'quote  as it contains spaces when No
+
+                          '
+                        parent_ids:
+                        - 6a0ecb98d2eaa39423e0bb0acb8d0f53e73bed1b
+                        short_id: 4b456b63
+                        title: quote  as it contains spaces when No
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/4b456b630eefb5425696cbb9831ca907d9dd75cb
+                      commit_path: /graphviz/graphviz/-/commit/4b456b630eefb5425696cbb9831ca907d9dd75cb
+                      created_at: '2016-08-10T19:00:14.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-1aed90cbe517038de3a0
+                      released_at: '2016-08-10T19:00:14.000Z'
+                      tag_name: untagged-1aed90cbe517038de3a0
+                      tag_path: /graphviz/graphviz/-/tags/untagged-1aed90cbe517038de3a0
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-27ff95768eb6958bcef7
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-27ff95768eb6958bcef7/graphviz-untagged-27ff95768eb6958bcef7.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-27ff95768eb6958bcef7/graphviz-untagged-27ff95768eb6958bcef7.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-27ff95768eb6958bcef7/graphviz-untagged-27ff95768eb6958bcef7.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-27ff95768eb6958bcef7/graphviz-untagged-27ff95768eb6958bcef7.tar
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-08-09T11:52:33.000-04:00'
+                        committed_date: '2016-08-09T11:52:33.000-04:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-08-09T11:52:33.000-04:00'
+                        id: 3fb678e09a7e832531ca039446789d1f9b391079
+                        message: 'Merge pull request #1148 from ErwinJanssen/unit-test
+
+
+                          Introduction unit test for current commnand line behavior'
+                        parent_ids:
+                        - 91a9749ebf5ae4490ecbdb59803bf79e971508fc
+                        - 4092b6dc38a57c327869127404ce06dfd68c402c
+                        short_id: 3fb678e0
+                        title: 'Merge pull request #1148 from ErwinJanssen/unit-test'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/3fb678e09a7e832531ca039446789d1f9b391079
+                      commit_path: /graphviz/graphviz/-/commit/3fb678e09a7e832531ca039446789d1f9b391079
+                      created_at: '2016-08-09T15:52:33.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-27ff95768eb6958bcef7
+                      released_at: '2016-08-09T15:52:33.000Z'
+                      tag_name: untagged-27ff95768eb6958bcef7
+                      tag_path: /graphviz/graphviz/-/tags/untagged-27ff95768eb6958bcef7
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-cf3150dc2db96b5bb4d6
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-cf3150dc2db96b5bb4d6/graphviz-untagged-cf3150dc2db96b5bb4d6.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-cf3150dc2db96b5bb4d6/graphviz-untagged-cf3150dc2db96b5bb4d6.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-cf3150dc2db96b5bb4d6/graphviz-untagged-cf3150dc2db96b5bb4d6.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-cf3150dc2db96b5bb4d6/graphviz-untagged-cf3150dc2db96b5bb4d6.tar
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-08-01T00:07:57.000-04:00'
+                        committed_date: '2016-08-01T00:07:57.000-04:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-08-01T00:07:57.000-04:00'
+                        id: 91a9749ebf5ae4490ecbdb59803bf79e971508fc
+                        message: 'Merge pull request #1147 from GadgetSteve/master
+
+
+                          Changed README.md reference github for documentation.'
+                        parent_ids:
+                        - 8c3fc96b7a2763e077058edb16cf54c533ae962f
+                        - 1240e4fbe7d3e9cfbd0a35d5237dcc1e41661af0
+                        short_id: 91a9749e
+                        title: 'Merge pull request #1147 from GadgetSteve/master'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/91a9749ebf5ae4490ecbdb59803bf79e971508fc
+                      commit_path: /graphviz/graphviz/-/commit/91a9749ebf5ae4490ecbdb59803bf79e971508fc
+                      created_at: '2016-08-01T04:07:57.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-cf3150dc2db96b5bb4d6
+                      released_at: '2016-08-01T04:07:57.000Z'
+                      tag_name: untagged-cf3150dc2db96b5bb4d6
+                      tag_path: /graphviz/graphviz/-/tags/untagged-cf3150dc2db96b5bb4d6
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-749ecd6837d5c822253e
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-749ecd6837d5c822253e/graphviz-untagged-749ecd6837d5c822253e.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-749ecd6837d5c822253e/graphviz-untagged-749ecd6837d5c822253e.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-749ecd6837d5c822253e/graphviz-untagged-749ecd6837d5c822253e.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-749ecd6837d5c822253e/graphviz-untagged-749ecd6837d5c822253e.tar
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-07-27T04:21:31.000-04:00'
+                        committed_date: '2016-07-27T04:21:31.000-04:00'
+                        committer_email: john.ellson@comcast.net
+                        committer_name: John Ellson
+                        created_at: '2016-07-27T04:21:31.000-04:00'
+                        id: 8c3fc96b7a2763e077058edb16cf54c533ae962f
+                        message: 'some -W flags not available on centos[56]
+
+                          '
+                        parent_ids:
+                        - 3bbc61ad12cfc0c15515a96113098e8605db89e5
+                        short_id: 8c3fc96b
+                        title: some -W flags not available on centos[56]
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/8c3fc96b7a2763e077058edb16cf54c533ae962f
+                      commit_path: /graphviz/graphviz/-/commit/8c3fc96b7a2763e077058edb16cf54c533ae962f
+                      created_at: '2016-07-27T08:21:31.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-749ecd6837d5c822253e
+                      released_at: '2016-07-27T08:21:31.000Z'
+                      tag_name: untagged-749ecd6837d5c822253e
+                      tag_path: /graphviz/graphviz/-/tags/untagged-749ecd6837d5c822253e
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-282a92de118059697b67
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-282a92de118059697b67/graphviz-untagged-282a92de118059697b67.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-282a92de118059697b67/graphviz-untagged-282a92de118059697b67.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-282a92de118059697b67/graphviz-untagged-282a92de118059697b67.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-282a92de118059697b67/graphviz-untagged-282a92de118059697b67.tar
+                      commit:
+                        author_email: emdenrg@google.com
+                        author_name: Emden Gansner
+                        authored_date: '2016-07-26T12:23:16.000-04:00'
+                        committed_date: '2016-07-26T12:23:16.000-04:00'
+                        committer_email: emdenrg@google.com
+                        committer_name: Emden Gansner
+                        created_at: '2016-07-26T12:23:16.000-04:00'
+                        id: 3bbc61ad12cfc0c15515a96113098e8605db89e5
+                        message: 'Fix bug in printing error message about graphs with
+                          loops or multiedges; note port restriction in
+
+                          man page.
+
+                          '
+                        parent_ids:
+                        - 541b872ead985143dae4de91e1c5e426dd0c4280
+                        short_id: 3bbc61ad
+                        title: Fix bug in printing error message about graphs with
+                          loops or multiedges; note port restriction in
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/3bbc61ad12cfc0c15515a96113098e8605db89e5
+                      commit_path: /graphviz/graphviz/-/commit/3bbc61ad12cfc0c15515a96113098e8605db89e5
+                      created_at: '2016-07-26T16:23:16.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-282a92de118059697b67
+                      released_at: '2016-07-26T16:23:16.000Z'
+                      tag_name: untagged-282a92de118059697b67
+                      tag_path: /graphviz/graphviz/-/tags/untagged-282a92de118059697b67
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-3443de97cd58035a8aea
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-3443de97cd58035a8aea/graphviz-untagged-3443de97cd58035a8aea.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-3443de97cd58035a8aea/graphviz-untagged-3443de97cd58035a8aea.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-3443de97cd58035a8aea/graphviz-untagged-3443de97cd58035a8aea.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-3443de97cd58035a8aea/graphviz-untagged-3443de97cd58035a8aea.tar
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-07-25T20:39:50.000-04:00'
+                        committed_date: '2016-07-25T20:39:50.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-07-25T20:39:50.000-04:00'
+                        id: 541b872ead985143dae4de91e1c5e426dd0c4280
+                        message: 'cgraph is not a configure option these days
+
+                          '
+                        parent_ids:
+                        - 775699b8ee69764c65aa7edfa06b1376df0759a3
+                        short_id: 541b872e
+                        title: cgraph is not a configure option these days
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/541b872ead985143dae4de91e1c5e426dd0c4280
+                      commit_path: /graphviz/graphviz/-/commit/541b872ead985143dae4de91e1c5e426dd0c4280
+                      created_at: '2016-07-26T00:39:50.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-3443de97cd58035a8aea
+                      released_at: '2016-07-26T00:39:50.000Z'
+                      tag_name: untagged-3443de97cd58035a8aea
+                      tag_path: /graphviz/graphviz/-/tags/untagged-3443de97cd58035a8aea
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-f5823de05291db506275
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-f5823de05291db506275/graphviz-untagged-f5823de05291db506275.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-f5823de05291db506275/graphviz-untagged-f5823de05291db506275.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-f5823de05291db506275/graphviz-untagged-f5823de05291db506275.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-f5823de05291db506275/graphviz-untagged-f5823de05291db506275.tar
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-07-25T17:15:06.000-04:00'
+                        committed_date: '2016-07-25T17:15:06.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-07-25T17:15:06.000-04:00'
+                        id: dc35219a3d4a3d81943bc17f918afd8410ef85db
+                        message: 'more incompatible warning switches
+
+                          '
+                        parent_ids:
+                        - 1daf345474c78d8e5f36db08c3f6ab5eb664a6de
+                        short_id: dc35219a
+                        title: more incompatible warning switches
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/dc35219a3d4a3d81943bc17f918afd8410ef85db
+                      commit_path: /graphviz/graphviz/-/commit/dc35219a3d4a3d81943bc17f918afd8410ef85db
+                      created_at: '2016-07-25T21:15:06.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-f5823de05291db506275
+                      released_at: '2016-07-25T21:15:06.000Z'
+                      tag_name: untagged-f5823de05291db506275
+                      tag_path: /graphviz/graphviz/-/tags/untagged-f5823de05291db506275
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-9ee5934fa10f12b4043f
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-9ee5934fa10f12b4043f/graphviz-untagged-9ee5934fa10f12b4043f.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-9ee5934fa10f12b4043f/graphviz-untagged-9ee5934fa10f12b4043f.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-9ee5934fa10f12b4043f/graphviz-untagged-9ee5934fa10f12b4043f.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-9ee5934fa10f12b4043f/graphviz-untagged-9ee5934fa10f12b4043f.tar
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-07-22T14:54:51.000-04:00'
+                        committed_date: '2016-07-22T14:54:51.000-04:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-07-22T14:54:51.000-04:00'
+                        id: 9785bdb11f5023d9389cc27e453ccdb8cea1d92b
+                        message: 'Merge pull request #1145 from ErwinJanssen/refactor
+
+
+                          Enable C99, enable more warnings and solve some warnings.'
+                        parent_ids:
+                        - 315aa03eb8a5519aa71e3bb24f4c6d808dd48f77
+                        - 370eb57c659606b07aaaae4a2d1524f23ee74a37
+                        short_id: 9785bdb1
+                        title: 'Merge pull request #1145 from ErwinJanssen/refactor'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/9785bdb11f5023d9389cc27e453ccdb8cea1d92b
+                      commit_path: /graphviz/graphviz/-/commit/9785bdb11f5023d9389cc27e453ccdb8cea1d92b
+                      created_at: '2016-07-22T18:54:51.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-9ee5934fa10f12b4043f
+                      released_at: '2016-07-22T18:54:51.000Z'
+                      tag_name: untagged-9ee5934fa10f12b4043f
+                      tag_path: /graphviz/graphviz/-/tags/untagged-9ee5934fa10f12b4043f
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-1d58b621a7287e0b0a25
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-1d58b621a7287e0b0a25/graphviz-untagged-1d58b621a7287e0b0a25.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-1d58b621a7287e0b0a25/graphviz-untagged-1d58b621a7287e0b0a25.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-1d58b621a7287e0b0a25/graphviz-untagged-1d58b621a7287e0b0a25.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-1d58b621a7287e0b0a25/graphviz-untagged-1d58b621a7287e0b0a25.tar
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-07-22T10:47:02.000-04:00'
+                        committed_date: '2016-07-22T10:47:02.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-07-22T10:47:02.000-04:00'
+                        id: 315aa03eb8a5519aa71e3bb24f4c6d808dd48f77
+                        message: 'add missing layers support in -Tsvgz device
+
+                          '
+                        parent_ids:
+                        - e20964332ea95fa8c23784007d3fca1ce960d6ef
+                        short_id: 315aa03e
+                        title: add missing layers support in -Tsvgz device
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/315aa03eb8a5519aa71e3bb24f4c6d808dd48f77
+                      commit_path: /graphviz/graphviz/-/commit/315aa03eb8a5519aa71e3bb24f4c6d808dd48f77
+                      created_at: '2016-07-22T14:47:02.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-1d58b621a7287e0b0a25
+                      released_at: '2016-07-22T14:47:02.000Z'
+                      tag_name: untagged-1d58b621a7287e0b0a25
+                      tag_path: /graphviz/graphviz/-/tags/untagged-1d58b621a7287e0b0a25
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-1843dff5ba962a1be63b
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-1843dff5ba962a1be63b/graphviz-untagged-1843dff5ba962a1be63b.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-1843dff5ba962a1be63b/graphviz-untagged-1843dff5ba962a1be63b.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-1843dff5ba962a1be63b/graphviz-untagged-1843dff5ba962a1be63b.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-1843dff5ba962a1be63b/graphviz-untagged-1843dff5ba962a1be63b.tar
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-07-21T17:01:01.000-04:00'
+                        committed_date: '2016-07-21T17:01:01.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-07-21T17:01:01.000-04:00'
+                        id: e20964332ea95fa8c23784007d3fca1ce960d6ef
+                        message: 'Merge branch ''master'' of github.com:/ellson/graphviz
+
+                          '
+                        parent_ids:
+                        - 54a3f9b3520e8043c2b52f203e3c3f975eb21240
+                        - 858fe6db9adeedd2a4206f69f415a2147b175256
+                        short_id: e2096433
+                        title: Merge branch 'master' of github.com:/ellson/graphviz
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/e20964332ea95fa8c23784007d3fca1ce960d6ef
+                      commit_path: /graphviz/graphviz/-/commit/e20964332ea95fa8c23784007d3fca1ce960d6ef
+                      created_at: '2016-07-21T21:01:01.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-1843dff5ba962a1be63b
+                      released_at: '2016-07-21T21:01:01.000Z'
+                      tag_name: untagged-1843dff5ba962a1be63b
+                      tag_path: /graphviz/graphviz/-/tags/untagged-1843dff5ba962a1be63b
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-3324163453e4161833a0
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-3324163453e4161833a0/graphviz-untagged-3324163453e4161833a0.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-3324163453e4161833a0/graphviz-untagged-3324163453e4161833a0.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-3324163453e4161833a0/graphviz-untagged-3324163453e4161833a0.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-3324163453e4161833a0/graphviz-untagged-3324163453e4161833a0.tar
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-07-21T17:01:01.000-04:00'
+                        committed_date: '2016-07-21T17:01:01.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-07-21T17:01:01.000-04:00'
+                        id: e20964332ea95fa8c23784007d3fca1ce960d6ef
+                        message: 'Merge branch ''master'' of github.com:/ellson/graphviz
+
+                          '
+                        parent_ids:
+                        - 54a3f9b3520e8043c2b52f203e3c3f975eb21240
+                        - 858fe6db9adeedd2a4206f69f415a2147b175256
+                        short_id: e2096433
+                        title: Merge branch 'master' of github.com:/ellson/graphviz
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/e20964332ea95fa8c23784007d3fca1ce960d6ef
+                      commit_path: /graphviz/graphviz/-/commit/e20964332ea95fa8c23784007d3fca1ce960d6ef
+                      created_at: '2016-07-21T21:01:01.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-3324163453e4161833a0
+                      released_at: '2016-07-21T21:01:01.000Z'
+                      tag_name: untagged-3324163453e4161833a0
+                      tag_path: /graphviz/graphviz/-/tags/untagged-3324163453e4161833a0
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-dca5f3fa2a3476aaf8e3
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-dca5f3fa2a3476aaf8e3/graphviz-untagged-dca5f3fa2a3476aaf8e3.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-dca5f3fa2a3476aaf8e3/graphviz-untagged-dca5f3fa2a3476aaf8e3.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-dca5f3fa2a3476aaf8e3/graphviz-untagged-dca5f3fa2a3476aaf8e3.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-dca5f3fa2a3476aaf8e3/graphviz-untagged-dca5f3fa2a3476aaf8e3.tar
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-07-14T10:16:48.000-04:00'
+                        committed_date: '2016-07-14T10:16:48.000-04:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-07-14T10:16:48.000-04:00'
+                        id: a4bf3c86a6c07d7413acb83627632ce38a473a39
+                        message: 'Merge pull request #1137 from ErwinJanssen/replace-libgd
+
+
+                          Replace in-tree libgd with external build of recent code'
+                        parent_ids:
+                        - f93c5223930c8342045f465fb51667e57bf61e2b
+                        - 15b694bba14be8192adab88e95029aeba5094603
+                        short_id: a4bf3c86
+                        title: 'Merge pull request #1137 from ErwinJanssen/replace-libgd'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/a4bf3c86a6c07d7413acb83627632ce38a473a39
+                      commit_path: /graphviz/graphviz/-/commit/a4bf3c86a6c07d7413acb83627632ce38a473a39
+                      created_at: '2016-07-14T14:16:48.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-dca5f3fa2a3476aaf8e3
+                      released_at: '2016-07-14T14:16:48.000Z'
+                      tag_name: untagged-dca5f3fa2a3476aaf8e3
+                      tag_path: /graphviz/graphviz/-/tags/untagged-dca5f3fa2a3476aaf8e3
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-720ca8034db44a953d87
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-720ca8034db44a953d87/graphviz-untagged-720ca8034db44a953d87.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-720ca8034db44a953d87/graphviz-untagged-720ca8034db44a953d87.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-720ca8034db44a953d87/graphviz-untagged-720ca8034db44a953d87.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-720ca8034db44a953d87/graphviz-untagged-720ca8034db44a953d87.tar
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-07-10T13:29:07.000-04:00'
+                        committed_date: '2016-07-10T13:29:07.000-04:00'
+                        committer_email: john.ellson@comcast.net
+                        committer_name: John Ellson
+                        created_at: '2016-07-10T13:29:07.000-04:00'
+                        id: f93c5223930c8342045f465fb51667e57bf61e2b
+                        message: 'Merge branch ''master'' of github.com:ellson/graphviz
+
+                          '
+                        parent_ids:
+                        - 985ea93521b2b0b6f34459e3ad6ebd1188be226b
+                        - 7550186bc5ca46eb072f387a8bc583aa527713b3
+                        short_id: f93c5223
+                        title: Merge branch 'master' of github.com:ellson/graphviz
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/f93c5223930c8342045f465fb51667e57bf61e2b
+                      commit_path: /graphviz/graphviz/-/commit/f93c5223930c8342045f465fb51667e57bf61e2b
+                      created_at: '2016-07-10T17:29:07.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-720ca8034db44a953d87
+                      released_at: '2016-07-10T17:29:07.000Z'
+                      tag_name: untagged-720ca8034db44a953d87
+                      tag_path: /graphviz/graphviz/-/tags/untagged-720ca8034db44a953d87
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-3c169aaa6280ec506b08
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-3c169aaa6280ec506b08/graphviz-untagged-3c169aaa6280ec506b08.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-3c169aaa6280ec506b08/graphviz-untagged-3c169aaa6280ec506b08.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-3c169aaa6280ec506b08/graphviz-untagged-3c169aaa6280ec506b08.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-3c169aaa6280ec506b08/graphviz-untagged-3c169aaa6280ec506b08.tar
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-07-10T12:12:16.000-04:00'
+                        committed_date: '2016-07-10T12:12:16.000-04:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-07-10T12:12:16.000-04:00'
+                        id: 7550186bc5ca46eb072f387a8bc583aa527713b3
+                        message: 'Merge pull request #1135 from ErwinJanssen/fix-windows-build
+
+
+                          Fix windows build'
+                        parent_ids:
+                        - 65cd40f10c9b1fbdaaf4224a5b11a70e0e397446
+                        - fa7fd5b878a0941f5cd2dcb43440c6aee5e039ad
+                        short_id: 7550186b
+                        title: 'Merge pull request #1135 from ErwinJanssen/fix-windows-build'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/7550186bc5ca46eb072f387a8bc583aa527713b3
+                      commit_path: /graphviz/graphviz/-/commit/7550186bc5ca46eb072f387a8bc583aa527713b3
+                      created_at: '2016-07-10T16:12:16.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-3c169aaa6280ec506b08
+                      released_at: '2016-07-10T16:12:16.000Z'
+                      tag_name: untagged-3c169aaa6280ec506b08
+                      tag_path: /graphviz/graphviz/-/tags/untagged-3c169aaa6280ec506b08
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-7f41f60ca2025e3251ad
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-7f41f60ca2025e3251ad/graphviz-untagged-7f41f60ca2025e3251ad.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-7f41f60ca2025e3251ad/graphviz-untagged-7f41f60ca2025e3251ad.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-7f41f60ca2025e3251ad/graphviz-untagged-7f41f60ca2025e3251ad.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-7f41f60ca2025e3251ad/graphviz-untagged-7f41f60ca2025e3251ad.tar
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-07-10T07:56:58.000-04:00'
+                        committed_date: '2016-07-10T07:56:58.000-04:00'
+                        committer_email: john.ellson@comcast.net
+                        committer_name: John Ellson
+                        created_at: '2016-07-10T07:56:58.000-04:00'
+                        id: 65cd40f10c9b1fbdaaf4224a5b11a70e0e397446
+                        message: ' add ''make dist'' to travis builds
+
+                          '
+                        parent_ids:
+                        - 0aaaa3e8f849ec99afdee4957f389f32cb6aa112
+                        short_id: 65cd40f1
+                        title: ' add ''make dist'' to travis builds'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/65cd40f10c9b1fbdaaf4224a5b11a70e0e397446
+                      commit_path: /graphviz/graphviz/-/commit/65cd40f10c9b1fbdaaf4224a5b11a70e0e397446
+                      created_at: '2016-07-10T11:56:58.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-7f41f60ca2025e3251ad
+                      released_at: '2016-07-10T11:56:58.000Z'
+                      tag_name: untagged-7f41f60ca2025e3251ad
+                      tag_path: /graphviz/graphviz/-/tags/untagged-7f41f60ca2025e3251ad
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-64c3562a21c18efca077
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-64c3562a21c18efca077/graphviz-untagged-64c3562a21c18efca077.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-64c3562a21c18efca077/graphviz-untagged-64c3562a21c18efca077.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-64c3562a21c18efca077/graphviz-untagged-64c3562a21c18efca077.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-64c3562a21c18efca077/graphviz-untagged-64c3562a21c18efca077.tar
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-07-10T06:28:01.000-04:00'
+                        committed_date: '2016-07-10T06:28:01.000-04:00'
+                        committer_email: john.ellson@comcast.net
+                        committer_name: John Ellson
+                        created_at: '2016-07-10T06:28:01.000-04:00'
+                        id: 0aaaa3e8f849ec99afdee4957f389f32cb6aa112
+                        message: 'fix diffimg test code
+
+                          '
+                        parent_ids:
+                        - 751811a5c1631c29eef1ce9f7b7b7a3836e5dc78
+                        short_id: 0aaaa3e8
+                        title: fix diffimg test code
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/0aaaa3e8f849ec99afdee4957f389f32cb6aa112
+                      commit_path: /graphviz/graphviz/-/commit/0aaaa3e8f849ec99afdee4957f389f32cb6aa112
+                      created_at: '2016-07-10T10:28:01.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-64c3562a21c18efca077
+                      released_at: '2016-07-10T10:28:01.000Z'
+                      tag_name: untagged-64c3562a21c18efca077
+                      tag_path: /graphviz/graphviz/-/tags/untagged-64c3562a21c18efca077
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-3e86d2bf29bb52eaf3f6
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-3e86d2bf29bb52eaf3f6/graphviz-untagged-3e86d2bf29bb52eaf3f6.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-3e86d2bf29bb52eaf3f6/graphviz-untagged-3e86d2bf29bb52eaf3f6.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-3e86d2bf29bb52eaf3f6/graphviz-untagged-3e86d2bf29bb52eaf3f6.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-3e86d2bf29bb52eaf3f6/graphviz-untagged-3e86d2bf29bb52eaf3f6.tar
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-07-10T05:07:24.000-04:00'
+                        committed_date: '2016-07-10T05:07:24.000-04:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-07-10T05:07:24.000-04:00'
+                        id: 751811a5c1631c29eef1ce9f7b7b7a3836e5dc78
+                        message: 'Merge pull request #1134 from GadgetSteve/master
+
+
+                          Address #95 by using f suffix on floats in color_palette.c'
+                        parent_ids:
+                        - 752f8a167a35a4ae9ff05e4a44c37f444d1c17f5
+                        - 60643489cc6b53d1cb3e139734bb8f1ce55b0851
+                        short_id: 751811a5
+                        title: 'Merge pull request #1134 from GadgetSteve/master'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/751811a5c1631c29eef1ce9f7b7b7a3836e5dc78
+                      commit_path: /graphviz/graphviz/-/commit/751811a5c1631c29eef1ce9f7b7b7a3836e5dc78
+                      created_at: '2016-07-10T09:07:24.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-3e86d2bf29bb52eaf3f6
+                      released_at: '2016-07-10T09:07:24.000Z'
+                      tag_name: untagged-3e86d2bf29bb52eaf3f6
+                      tag_path: /graphviz/graphviz/-/tags/untagged-3e86d2bf29bb52eaf3f6
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-02d82c4c9d0263e3d595
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-02d82c4c9d0263e3d595/graphviz-untagged-02d82c4c9d0263e3d595.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-02d82c4c9d0263e3d595/graphviz-untagged-02d82c4c9d0263e3d595.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-02d82c4c9d0263e3d595/graphviz-untagged-02d82c4c9d0263e3d595.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-02d82c4c9d0263e3d595/graphviz-untagged-02d82c4c9d0263e3d595.tar
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-07-09T22:04:09.000-04:00'
+                        committed_date: '2016-07-09T22:04:09.000-04:00'
+                        committer_email: john.ellson@comcast.net
+                        committer_name: John Ellson
+                        created_at: '2016-07-09T22:04:09.000-04:00'
+                        id: 752f8a167a35a4ae9ff05e4a44c37f444d1c17f5
+                        message: 'remove rxpencer (unused, unneeded)
+
+                          '
+                        parent_ids:
+                        - 770525ca41a85e3abedbc538e3f19280a946e402
+                        short_id: 752f8a16
+                        title: remove rxpencer (unused, unneeded)
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/752f8a167a35a4ae9ff05e4a44c37f444d1c17f5
+                      commit_path: /graphviz/graphviz/-/commit/752f8a167a35a4ae9ff05e4a44c37f444d1c17f5
+                      created_at: '2016-07-10T02:04:09.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-02d82c4c9d0263e3d595
+                      released_at: '2016-07-10T02:04:09.000Z'
+                      tag_name: untagged-02d82c4c9d0263e3d595
+                      tag_path: /graphviz/graphviz/-/tags/untagged-02d82c4c9d0263e3d595
+                      upcoming_release: false
+                    - _links:
+                        self: https://gitlab.com/graphviz/graphviz/-/releases/untagged-fd4ca25a4ca4e4dc471c
+                      assets:
+                        count: 4
+                        links: []
+                        sources:
+                        - format: zip
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-fd4ca25a4ca4e4dc471c/graphviz-untagged-fd4ca25a4ca4e4dc471c.zip
+                        - format: tar.gz
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-fd4ca25a4ca4e4dc471c/graphviz-untagged-fd4ca25a4ca4e4dc471c.tar.gz
+                        - format: tar.bz2
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-fd4ca25a4ca4e4dc471c/graphviz-untagged-fd4ca25a4ca4e4dc471c.tar.bz2
+                        - format: tar
+                          url: https://gitlab.com/graphviz/graphviz/-/archive/untagged-fd4ca25a4ca4e4dc471c/graphviz-untagged-fd4ca25a4ca4e4dc471c.tar
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-07-09T21:39:41.000-04:00'
+                        committed_date: '2016-07-09T21:39:41.000-04:00'
+                        committer_email: john.ellson@comcast.net
+                        committer_name: John Ellson
+                        created_at: '2016-07-09T21:39:41.000-04:00'
+                        id: 770525ca41a85e3abedbc538e3f19280a946e402
+                        message: 'comment out empty "file:" statement
+
+                          '
+                        parent_ids:
+                        - 8d1d2a8e60ee0c9452540825f8ce0dba4e37e5df
+                        short_id: 770525ca
+                        title: comment out empty "file:" statement
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/770525ca41a85e3abedbc538e3f19280a946e402
+                      commit_path: /graphviz/graphviz/-/commit/770525ca41a85e3abedbc538e3f19280a946e402
+                      created_at: '2016-07-10T01:39:41.000Z'
+                      description: null
+                      description_html: ''
+                      evidences: []
+                      name: untagged-fd4ca25a4ca4e4dc471c
+                      released_at: '2016-07-10T01:39:41.000Z'
+                      tag_name: untagged-fd4ca25a4ca4e4dc471c
+                      tag_path: /graphviz/graphviz/-/tags/untagged-fd4ca25a4ca4e4dc471c
+                      upcoming_release: false
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a004bc4597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"1ef6578f7eb439ce88dbbfee473775ff"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-14-lb-gprd
+                      GitLab-SV: localhost
+                      Link: <https://gitlab.com/api/v4/projects/4207231/releases?id=4207231&page=2&per_page=20>;
+                        rel="prev", <https://gitlab.com/api/v4/projects/4207231/releases?id=4207231&page=1&per_page=20>;
+                        rel="first", <https://gitlab.com/api/v4/projects/4207231/releases?id=4207231&page=3&per_page=20>;
+                        rel="last"
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '4'
+                      RateLimit-Remaining: '596'
+                      RateLimit-Reset: '1587559295'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:35 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Accept-Encoding, Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Next-Page: ''
+                      X-Page: '3'
+                      X-Per-Page: '20'
+                      X-Prev-Page: '2'
+                      X-Request-Id: xPqp5cnmUH7
+                      X-Runtime: '0.420128'
+                      X-Total: '60'
+                      X-Total-Pages: '3'
+                      cf-request-id: 024380942a0000597c7e820200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.263289213180542
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: Magnus.Jacobsson@berotec.se
+                        author_name: Magnus Jacobsson
+                        authored_date: '2020-04-08T09:03:23.000+02:00'
+                        committed_date: '2020-04-08T09:50:01.000+02:00'
+                        committer_email: Magnus.Jacobsson@berotec.se
+                        committer_name: Magnus Jacobsson
+                        created_at: '2020-04-08T09:50:01.000+02:00'
+                        id: 6b0de802c895f86c75360cc67898a07b24f5b5ae
+                        message: 'Stable Release 2.44.0
+
+                          '
+                        parent_ids:
+                        - 9a3cd8ad63f782a0b0419808d53d4fc2c18f5fbd
+                        short_id: 6b0de802
+                        title: Stable Release 2.44.0
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/6b0de802c895f86c75360cc67898a07b24f5b5ae
+                      message: 2.42.4
+                      name: 2.44.0
+                      protected: false
+                      release:
+                        description: See the [ChangeLog](https://gitlab.com/graphviz/graphviz/-/blob/master/ChangeLog)
+                        tag_name: 2.44.0
+                      target: 4ca103365bf177aaa5e000363c5aea00d26b0215
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a048e44597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"b4e79a56d4d46d5e00678fff5f9513ea"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-12-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '5'
+                      RateLimit-Remaining: '595'
+                      RateLimit-Reset: '1587559295'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:35 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: W4qotH1ABz2
+                      X-Runtime: '0.049822'
+                      cf-request-id: 02438096d50000597c7e849200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.2889852523803711
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: Magnus.Jacobsson@berotec.se
+                        author_name: Magnus Jacobsson
+                        authored_date: '2020-04-06T08:00:22.000+02:00'
+                        committed_date: '2020-04-06T08:00:49.000+02:00'
+                        committer_email: Magnus.Jacobsson@berotec.se
+                        committer_name: Magnus Jacobsson
+                        created_at: '2020-04-06T08:00:49.000+02:00'
+                        id: 466402bb70105dd74282cd9da6bbde9da02a9b3c
+                        message: 'Stable Release 2.42.4
+
+                          '
+                        parent_ids:
+                        - c9f50be33fbd8288d2a26e6dbc6df0f2bebe8882
+                        short_id: 466402bb
+                        title: Stable Release 2.42.4
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/466402bb70105dd74282cd9da6bbde9da02a9b3c
+                      message: Stable Release 2.42.4
+                      name: 2.42.4
+                      protected: false
+                      release:
+                        description: "See the [ChangeLog](https://gitlab.com/graphviz/graphviz/-/blob/master/ChangeLog)\r\
+                          \n"
+                        tag_name: 2.42.4
+                      target: cb572824ec330cf3a5780e5ec474cb720e79f57a
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a064f4b597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"bfc2d0d1b350ab7728ff2cf77b237b62"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-17-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '6'
+                      RateLimit-Remaining: '594'
+                      RateLimit-Reset: '1587559295'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:35 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: lJw40jOXSk8
+                      X-Runtime: '0.069636'
+                      cf-request-id: 02438097ed0000597c7e88e200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.39174723625183105
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-12-04T22:07:00.000-05:00'
+                        committed_date: '2016-12-04T22:07:00.000-05:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-12-04T22:07:00.000-05:00'
+                        id: 75f84028871115997f46711872a8740f6e3f4b88
+                        message: 'Merge pull request #1178 from ErwinJanssen/travis-nightly
+
+
+                          Enhanced Travis Nightly Release'
+                        parent_ids:
+                        - b0545a07591fda01fa57b55d30dc6cc734aed0ea
+                        - 438b2612e76a3c8e51df6dae0e53108d6f9b360e
+                        short_id: 75f84028
+                        title: 'Merge pull request #1178 from ErwinJanssen/travis-nightly'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/75f84028871115997f46711872a8740f6e3f4b88
+                      message: ''
+                      name: Nightly
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: Nightly
+                      target: 75f84028871115997f46711872a8740f6e3f4b88
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a083884597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"b9304c83109ba89a5cb2078a28b24289"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-24-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '7'
+                      RateLimit-Remaining: '593'
+                      RateLimit-Reset: '1587559296'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:36 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: PO3NdwI9yA9
+                      X-Runtime: '0.098181'
+                      cf-request-id: 024380991f0000597c7e89b200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.28972291946411133
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: emdenrg@google.com
+                        author_name: Emden Gansner
+                        authored_date: '2016-11-28T15:49:10.000-05:00'
+                        committed_date: '2016-11-28T15:49:10.000-05:00'
+                        committer_email: emdenrg@google.com
+                        committer_name: Emden Gansner
+                        created_at: '2016-11-28T15:49:10.000-05:00'
+                        id: 254f6fd7eb579159132c06e10c2957a628421399
+                        message: 'Add regression test for urls appearing in svg output.
+
+                          '
+                        parent_ids:
+                        - e3b4f50920900a7f532e7108d7f920ac77f2f5b4
+                        short_id: 254f6fd7
+                        title: Add regression test for urls appearing in svg output.
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/254f6fd7eb579159132c06e10c2957a628421399
+                      message: ''
+                      name: untagged-14e7b24955d481c7b36a
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-14e7b24955d481c7b36a
+                      target: 254f6fd7eb579159132c06e10c2957a628421399
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a0aca0f597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"4cf9ef8175bfaa7ad65b46e75d549bf7"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-13-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '8'
+                      RateLimit-Remaining: '592'
+                      RateLimit-Reset: '1587559296'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:36 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: dxaRtarMHy9
+                      X-Runtime: '0.058420'
+                      cf-request-id: 0243809abc0000597c7e8bd200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.289949893951416
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: emdenrg@google.com
+                        author_name: Emden Gansner
+                        authored_date: '2016-11-28T14:24:50.000-05:00'
+                        committed_date: '2016-11-28T14:24:50.000-05:00'
+                        committer_email: emdenrg@google.com
+                        committer_name: Emden Gansner
+                        created_at: '2016-11-28T14:24:50.000-05:00'
+                        id: f8ed3ac5a94537be9631ccad0d8e077fe29bec79
+                        message: 'Print out depth of graph in verbose mode.
+
+                          '
+                        parent_ids:
+                        - 24988602d046b1529d55f7d6a2edcd5406d3313d
+                        short_id: f8ed3ac5
+                        title: Print out depth of graph in verbose mode.
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/f8ed3ac5a94537be9631ccad0d8e077fe29bec79
+                      message: ''
+                      name: untagged-941905a04b09702a353c
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-941905a04b09702a353c
+                      target: f8ed3ac5a94537be9631ccad0d8e077fe29bec79
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a0cbb61597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"44701c5db25cb4e666daaf012d6e8f50"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-20-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '5'
+                      RateLimit-Remaining: '595'
+                      RateLimit-Reset: '1587559296'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:36 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: 5x5Sr7grto
+                      X-Runtime: '0.057650'
+                      cf-request-id: 0243809bf10000597c7e8d1200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.28986072540283203
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: emdenrg@google.com
+                        author_name: Emden Gansner
+                        authored_date: '2016-11-28T11:57:41.000-05:00'
+                        committed_date: '2016-11-28T11:57:41.000-05:00'
+                        committer_email: emdenrg@google.com
+                        committer_name: Emden Gansner
+                        created_at: '2016-11-28T11:57:41.000-05:00'
+                        id: 24988602d046b1529d55f7d6a2edcd5406d3313d
+                        message: 'Add minus sign dropped in the conversion added in
+
+                          0258d60cbde273e99abd015da7cb510b195724c3.
+
+                          '
+                        parent_ids:
+                        - ba314a6d41abe6c77af923783cbd0eb4fcb99450
+                        short_id: '24988602'
+                        title: Add minus sign dropped in the conversion added in
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/24988602d046b1529d55f7d6a2edcd5406d3313d
+                      message: ''
+                      name: untagged-0a3057e980c64a11875a
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-0a3057e980c64a11875a
+                      target: 24988602d046b1529d55f7d6a2edcd5406d3313d
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a0e9cc7597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"f724a028523bf460a302a3649c35865e"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-23-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '9'
+                      RateLimit-Remaining: '591'
+                      RateLimit-Reset: '1587559297'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:37 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: duppnHAXC39
+                      X-Runtime: '0.087150'
+                      cf-request-id: 0243809d1f0000597c7e917200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.28783535957336426
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: erg@emdenrg.net
+                        author_name: Emden R. Gansner
+                        authored_date: '2016-11-27T16:43:37.000-05:00'
+                        committed_date: '2016-11-27T16:43:37.000-05:00'
+                        committer_email: erg@emdenrg.net
+                        committer_name: Emden R. Gansner
+                        created_at: '2016-11-27T16:43:37.000-05:00'
+                        id: ba314a6d41abe6c77af923783cbd0eb4fcb99450
+                        message: 'Update man page to include additional widely-used
+                          formats.
+
+                          '
+                        parent_ids:
+                        - cc33ac0239c6fde284847d7d45a84f15dec8c08a
+                        short_id: ba314a6d
+                        title: Update man page to include additional widely-used formats.
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/ba314a6d41abe6c77af923783cbd0eb4fcb99450
+                      message: ''
+                      name: untagged-257982c92c56d4315606
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-257982c92c56d4315606
+                      target: ba314a6d41abe6c77af923783cbd0eb4fcb99450
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a109ded597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"321f921785e423c43a7ee5e15780fd9e"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-06-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '10'
+                      RateLimit-Remaining: '590'
+                      RateLimit-Reset: '1587559297'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:37 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: PnGXQIPrLw2
+                      X-Runtime: '0.061834'
+                      cf-request-id: 0243809e5c0000597c7e936200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.289264440536499
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-11-26T13:03:18.000-05:00'
+                        committed_date: '2016-11-26T13:03:18.000-05:00'
+                        committer_email: john.ellson@comcast.net
+                        committer_name: John Ellson
+                        created_at: '2016-11-26T13:03:18.000-05:00'
+                        id: cc33ac0239c6fde284847d7d45a84f15dec8c08a
+                        message: 'preparing Changelog for 2.40.0 release
+
+                          '
+                        parent_ids:
+                        - 2afa5038ddbae925fe6a20b2b960271fe18a1ae5
+                        short_id: cc33ac02
+                        title: preparing Changelog for 2.40.0 release
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/cc33ac0239c6fde284847d7d45a84f15dec8c08a
+                      message: ''
+                      name: untagged-09292206f9ec6d0f25d8
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-09292206f9ec6d0f25d8
+                      target: cc33ac0239c6fde284847d7d45a84f15dec8c08a
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a127f07597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"553cb841ead3067676d029094aaf8829"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-08-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '11'
+                      RateLimit-Remaining: '589'
+                      RateLimit-Reset: '1587559297'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:37 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: 6aaoXjbCWU4
+                      X-Runtime: '0.051574'
+                      cf-request-id: 0243809f870000597c7e943200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.2903306484222412
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-11-24T17:14:04.000-05:00'
+                        committed_date: '2016-11-24T17:14:04.000-05:00'
+                        committer_email: john.ellson@comcast.net
+                        committer_name: John Ellson
+                        created_at: '2016-11-24T17:14:04.000-05:00'
+                        id: 2afa5038ddbae925fe6a20b2b960271fe18a1ae5
+                        message: 'update svg and xdot regression reference cases
+
+                          '
+                        parent_ids:
+                        - 0258d60cbde273e99abd015da7cb510b195724c3
+                        short_id: 2afa5038
+                        title: update svg and xdot regression reference cases
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/2afa5038ddbae925fe6a20b2b960271fe18a1ae5
+                      message: ''
+                      name: untagged-5efd1411540d5300c05d
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-5efd1411540d5300c05d
+                      target: 2afa5038ddbae925fe6a20b2b960271fe18a1ae5
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a146fe5597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"8d24b9ff000dbb3bc8d78665c0042bc4"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-04-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '12'
+                      RateLimit-Remaining: '588'
+                      RateLimit-Reset: '1587559298'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:38 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: AjdUk6ZMQh5
+                      X-Runtime: '0.066205'
+                      cf-request-id: 024380a0bf0000597c7e94e200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.46999406814575195
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-11-24T14:13:11.000-05:00'
+                        committed_date: '2016-11-24T14:13:11.000-05:00'
+                        committer_email: john.ellson@comcast.net
+                        committer_name: John Ellson
+                        created_at: '2016-11-24T14:13:11.000-05:00'
+                        id: 3fbdc665aa8e30c6b701c9f5d19778cd8a12e821
+                        message: 'change winbuild.html to a relative URL so that it
+                          doesn''t break wgen relocated
+
+                          '
+                        parent_ids:
+                        - 592b9d5be6b38af2b54351c79a725a4115d0664c
+                        short_id: 3fbdc665
+                        title: change winbuild.html to a relative URL so that it doesn't
+                          break wgen relocated
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/3fbdc665aa8e30c6b701c9f5d19778cd8a12e821
+                      message: ''
+                      name: untagged-167219c230abbb068c64
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-167219c230abbb068c64
+                      target: 3fbdc665aa8e30c6b701c9f5d19778cd8a12e821
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a166909597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"6049be4648050f36056b13e669654c00"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-10-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '11'
+                      RateLimit-Remaining: '589'
+                      RateLimit-Reset: '1587559298'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:38 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: hnHmrzaxp62
+                      X-Runtime: '0.068473'
+                      cf-request-id: 024380a2000000597c7e95a200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.5146017074584961
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: emdenrg@google.com
+                        author_name: Emden Gansner
+                        authored_date: '2016-11-22T13:33:28.000-05:00'
+                        committed_date: '2016-11-22T13:33:28.000-05:00'
+                        committer_email: emdenrg@google.com
+                        committer_name: Emden Gansner
+                        created_at: '2016-11-22T13:33:28.000-05:00'
+                        id: 245c66135c5e1ca9b4f42061707f80634f84bce8
+                        message: 'Update man page, and fix number of nodes in the
+                          2D Sierpinski graph;
+
+                          fix edge count for 3D Sierpinski in graph_generator.c;
+
+                          modify CLI to use -S for Sierpinski in any dimension.
+
+                          '
+                        parent_ids:
+                        - e4ad5748bc7732b2731baa246a926ba9abc17f81
+                        short_id: 245c6613
+                        title: Update man page, and fix number of nodes in the 2D
+                          Sierpinski graph;
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/245c66135c5e1ca9b4f42061707f80634f84bce8
+                      message: ''
+                      name: untagged-4a0354222931f4cf012e
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-4a0354222931f4cf012e
+                      target: 245c66135c5e1ca9b4f42061707f80634f84bce8
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a195abd597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"c924c801f05ee4576dafb993adc5476d"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-21-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '12'
+                      RateLimit-Remaining: '588'
+                      RateLimit-Reset: '1587559299'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:39 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: 49sWuAauRg7
+                      X-Runtime: '0.077427'
+                      cf-request-id: 024380a3db0000597c7e972200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.28475379943847656
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: emden@users.noreply.github.com
+                        author_name: emden
+                        authored_date: '2016-11-22T11:17:45.000-05:00'
+                        committed_date: '2016-11-22T11:17:45.000-05:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-11-22T11:17:45.000-05:00'
+                        id: e4ad5748bc7732b2731baa246a926ba9abc17f81
+                        message: 'Merge pull request #1171 from HanKruiger/master
+
+
+                          Added generation of tetrix (3d sierpinski) graphs.'
+                        parent_ids:
+                        - 1ef4d51121ba26e3e30ef7609249045952a481fa
+                        - 265eeb66ea0dbb4f7cdeb75dcc5f802d948b40a9
+                        short_id: e4ad5748
+                        title: 'Merge pull request #1171 from HanKruiger/master'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/e4ad5748bc7732b2731baa246a926ba9abc17f81
+                      message: ''
+                      name: untagged-0a8cda69d4cba78f2e68
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-0a8cda69d4cba78f2e68
+                      target: e4ad5748bc7732b2731baa246a926ba9abc17f81
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a1ccc96597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"5b0ae5b061996d12a543becbd40fefca"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-06-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '12'
+                      RateLimit-Remaining: '588'
+                      RateLimit-Reset: '1587559299'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:39 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: tiXfUOtIJY
+                      X-Runtime: '0.069665'
+                      cf-request-id: 024380a5f90000597c7e99a200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.390627384185791
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: emdenrg@google.com
+                        author_name: Emden Gansner
+                        authored_date: '2016-11-03T16:57:52.000-04:00'
+                        committed_date: '2016-11-03T16:57:52.000-04:00'
+                        committer_email: emdenrg@google.com
+                        committer_name: Emden Gansner
+                        created_at: '2016-11-03T16:57:52.000-04:00'
+                        id: 1ef4d51121ba26e3e30ef7609249045952a481fa
+                        message: 'Revert version ffb894f27874ebd510a8555c28083d6e01eb80b6.
+                          The fix broke other input (rtest/graphs/url.gv).
+
+                          Plus it didn''t fix the problem of repeated ids. We need
+                          to rethink how to handle anchors.
+
+                          '
+                        parent_ids:
+                        - 684e8547a1492e0c17dde990b329b18855dfec2c
+                        short_id: 1ef4d511
+                        title: Revert version ffb894f27874ebd510a8555c28083d6e01eb80b6.
+                          The fix broke other input (rtest/graphs/url.gv).
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/1ef4d51121ba26e3e30ef7609249045952a481fa
+                      message: ''
+                      name: untagged-348619a7ff77176f7492
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-348619a7ff77176f7492
+                      target: 1ef4d51121ba26e3e30ef7609249045952a481fa
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a1e9d9a597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"17ad53f35af22d0f5c0a5c2db0d53794"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-09-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '12'
+                      RateLimit-Remaining: '587'
+                      RateLimit-Reset: '1587559299'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:39 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: ykmolXoeWj7
+                      X-Runtime: '0.070690'
+                      cf-request-id: 024380a7200000597c7e9ab200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.5060145854949951
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: erg@emdenrg.net
+                        author_name: Emden R. Gansner
+                        authored_date: '2016-10-30T17:27:47.000-04:00'
+                        committed_date: '2016-10-30T17:27:47.000-04:00'
+                        committer_email: erg@emdenrg.net
+                        committer_name: Emden R. Gansner
+                        created_at: '2016-10-30T17:27:47.000-04:00'
+                        id: 684e8547a1492e0c17dde990b329b18855dfec2c
+                        message: 'Merge branch ''master'' of https://github.com/ellson/graphviz
+
+                          '
+                        parent_ids:
+                        - 737585d8c19d3e943f7f6c2de7232d6f27d768f2
+                        - c8298e899f0167d34bc9892a4d146e6428906ea5
+                        short_id: 684e8547
+                        title: Merge branch 'master' of https://github.com/ellson/graphviz
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/684e8547a1492e0c17dde990b329b18855dfec2c
+                      message: ''
+                      name: untagged-c673d4de5b49bfc3ca91
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-c673d4de5b49bfc3ca91
+                      target: 684e8547a1492e0c17dde990b329b18855dfec2c
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a211f09597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"dcdf985081e5d213c2a084102b24a1d7"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-04-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '13'
+                      RateLimit-Remaining: '587'
+                      RateLimit-Reset: '1587559300'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:40 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: fCxKkXypEo
+                      X-Runtime: '0.079827'
+                      cf-request-id: 024380a8ad0000597c7e9b8200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.28597497940063477
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: emdenrg@google.com
+                        author_name: Emden Gansner
+                        authored_date: '2016-10-28T11:04:06.000-04:00'
+                        committed_date: '2016-10-28T11:04:06.000-04:00'
+                        committer_email: emdenrg@google.com
+                        committer_name: Emden Gansner
+                        created_at: '2016-10-28T11:04:06.000-04:00'
+                        id: c8298e899f0167d34bc9892a4d146e6428906ea5
+                        message: 'Allow user to specify clustering algorithm in gvmap.
+
+                          '
+                        parent_ids:
+                        - a2d1632e7040f7c6bc997592c471297040bb0190
+                        short_id: c8298e89
+                        title: Allow user to specify clustering algorithm in gvmap.
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/c8298e899f0167d34bc9892a4d146e6428906ea5
+                      message: ''
+                      name: untagged-0abbc2b30eaa01ee0686
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-0abbc2b30eaa01ee0686
+                      target: c8298e899f0167d34bc9892a4d146e6428906ea5
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a246902597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"0e327df7a932af25286b7bae68950c8f"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-02-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '13'
+                      RateLimit-Remaining: '587'
+                      RateLimit-Reset: '1587559300'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:40 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: dkWcqFqraC1
+                      X-Runtime: '0.069802'
+                      cf-request-id: 024380aabe0000597c7e9d3200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.2947063446044922
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-10-14T15:28:34.000-04:00'
+                        committed_date: '2016-10-14T15:28:34.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-10-14T15:28:34.000-04:00'
+                        id: a2d1632e7040f7c6bc997592c471297040bb0190
+                        message: 'simplify ksh buildrequire for SuSE builds
+
+                          '
+                        parent_ids:
+                        - ed4e9ae080b0034a9e3af568e58e01a0254d760c
+                        short_id: a2d1632e
+                        title: simplify ksh buildrequire for SuSE builds
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/a2d1632e7040f7c6bc997592c471297040bb0190
+                      message: ''
+                      name: untagged-1520451ef19a8815aefb
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-1520451ef19a8815aefb
+                      target: a2d1632e7040f7c6bc997592c471297040bb0190
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a264a17597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"93f2be9550d66ca84a59789ac50ebc0d"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-18-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '14'
+                      RateLimit-Remaining: '586'
+                      RateLimit-Reset: '1587559300'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:40 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: wTzCjinGzt9
+                      X-Runtime: '0.072753'
+                      cf-request-id: 024380abea0000597c7e9e4200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.29986572265625
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: emdenrg@google.com
+                        author_name: Emden Gansner
+                        authored_date: '2016-10-12T10:37:02.000-04:00'
+                        committed_date: '2016-10-12T10:37:02.000-04:00'
+                        committer_email: emdenrg@google.com
+                        committer_name: Emden Gansner
+                        created_at: '2016-10-12T10:37:02.000-04:00'
+                        id: ed4e9ae080b0034a9e3af568e58e01a0254d760c
+                        message: 'Complete backbone algorithm; add testing scaffolding.
+
+                          '
+                        parent_ids:
+                        - 0ec14c85a79f21050e79cfe825d297002b9916ff
+                        short_id: ed4e9ae0
+                        title: Complete backbone algorithm; add testing scaffolding.
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/ed4e9ae080b0034a9e3af568e58e01a0254d760c
+                      message: ''
+                      name: untagged-be0b53127acfad7b5de6
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-be0b53127acfad7b5de6
+                      target: ed4e9ae080b0034a9e3af568e58e01a0254d760c
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a282b4b597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"b18ca1b53762f80d1de9a9a270674b91"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-03-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '15'
+                      RateLimit-Remaining: '585'
+                      RateLimit-Reset: '1587559301'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:41 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: WfEEdQRcAz
+                      X-Runtime: '0.049839'
+                      cf-request-id: 024380ad170000597c7e9ef200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.26050281524658203
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-10-08T14:27:48.000-04:00'
+                        committed_date: '2016-10-08T14:27:48.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-10-08T14:27:48.000-04:00'
+                        id: 0ec14c85a79f21050e79cfe825d297002b9916ff
+                        message: 'missing TCL_EXEC_PREFIX substitution
+
+                          '
+                        parent_ids:
+                        - 10abca6914caddcabdb2af5ed856fa663e45d7d6
+                        short_id: 0ec14c85
+                        title: missing TCL_EXEC_PREFIX substitution
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/0ec14c85a79f21050e79cfe825d297002b9916ff
+                      message: ''
+                      name: untagged-8d75101f9a003883956c
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-8d75101f9a003883956c
+                      target: 0ec14c85a79f21050e79cfe825d297002b9916ff
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a2a2c80597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"5e00443602673db36e8f5d956231bab0"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-06-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '16'
+                      RateLimit-Remaining: '584'
+                      RateLimit-Reset: '1587559301'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:41 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: VPrmmGdWs76
+                      X-Runtime: '0.070005'
+                      cf-request-id: 024380ae5d0000597c7ea05200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.2654867172241211
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-10-08T12:24:37.000-04:00'
+                        committed_date: '2016-10-08T12:24:37.000-04:00'
+                        committer_email: john.ellson@comcast.net
+                        committer_name: John Ellson
+                        created_at: '2016-10-08T12:24:37.000-04:00'
+                        id: 10abca6914caddcabdb2af5ed856fa663e45d7d6
+                        message: 'add spinehdr.h to source dstribution
+
+                          '
+                        parent_ids:
+                        - 938d807f51cba03989fec7a8d46f2dadae15e389
+                        short_id: 10abca69
+                        title: add spinehdr.h to source dstribution
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/10abca6914caddcabdb2af5ed856fa663e45d7d6
+                      message: ''
+                      name: untagged-5fc0363bc76319758ff6
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-5fc0363bc76319758ff6
+                      target: 10abca6914caddcabdb2af5ed856fa663e45d7d6
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a2bed73597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"5402aba6ea35cada604f533423da6174"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-17-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '17'
+                      RateLimit-Remaining: '583'
+                      RateLimit-Reset: '1587559301'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:41 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: ALl9SbNkH28
+                      X-Runtime: '0.070191'
+                      cf-request-id: 024380af740000597c7ea11200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.35048437118530273
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-10-08T11:53:26.000-04:00'
+                        committed_date: '2016-10-08T11:53:26.000-04:00'
+                        committer_email: john.ellson@comcast.net
+                        committer_name: John Ellson
+                        created_at: '2016-10-08T11:53:26.000-04:00'
+                        id: 2dc424680466fc6ed2365c2d80cb4393635cf835
+                        message: '#include<spinehdr.h> => #include "spinehdr.h"
+
+                          '
+                        parent_ids:
+                        - caf65438ea717abb0fed3463ec21a0a25680f784
+                        short_id: 2dc42468
+                        title: '#include<spinehdr.h> => #include "spinehdr.h"'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/2dc424680466fc6ed2365c2d80cb4393635cf835
+                      message: ''
+                      name: untagged-a81020c0c01db3e23629
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-a81020c0c01db3e23629
+                      target: 2dc424680466fc6ed2365c2d80cb4393635cf835
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a2dae8a597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"0365d233e0ef071bf8cbd0990dc91896"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-21-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '18'
+                      RateLimit-Remaining: '582'
+                      RateLimit-Reset: '1587559302'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:42 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: 3Y859eRTCw8
+                      X-Runtime: '0.058355'
+                      cf-request-id: 024380b0880000597c7ea26200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.4010179042816162
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: erg@emdenrg.net
+                        author_name: Emden R. Gansner
+                        authored_date: '2016-10-02T17:49:01.000-04:00'
+                        committed_date: '2016-10-02T17:49:01.000-04:00'
+                        committer_email: erg@emdenrg.net
+                        committer_name: Emden R. Gansner
+                        created_at: '2016-10-02T17:49:01.000-04:00'
+                        id: caf65438ea717abb0fed3463ec21a0a25680f784
+                        message: 'Add library for computing Simmelian backbones of
+                          graphs.
+
+                          '
+                        parent_ids:
+                        - 582976380f1f75795d2b7eddf38a575b8ab5b279
+                        short_id: caf65438
+                        title: Add library for computing Simmelian backbones of graphs.
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/caf65438ea717abb0fed3463ec21a0a25680f784
+                      message: ''
+                      name: untagged-20d8043c3b4489073df9
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-20d8043c3b4489073df9
+                      target: caf65438ea717abb0fed3463ec21a0a25680f784
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a2fdfde597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"876224f3b2139b4d726957f6bf78b684"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-12-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '19'
+                      RateLimit-Remaining: '581'
+                      RateLimit-Reset: '1587559302'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:42 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: 6o7riNHQTxa
+                      X-Runtime: '0.079104'
+                      cf-request-id: 024380b1e30000597c7ea31200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.2580280303955078
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-09-27T09:34:24.000-04:00'
+                        committed_date: '2016-09-27T09:34:24.000-04:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-09-27T09:34:24.000-04:00'
+                        id: 582976380f1f75795d2b7eddf38a575b8ab5b279
+                        message: 'Merge pull request #1164 from ErwinJanssen/update-appveyor-dependencies
+
+
+                          Appveyor: update libgd dependencies and build dir'
+                        parent_ids:
+                        - e746dac6b40a6911db36d6243a0c9624abc7d0d7
+                        - 31a02bfebea16c6be9c2bc805d7930af0d64649b
+                        short_id: '58297638'
+                        title: 'Merge pull request #1164 from ErwinJanssen/update-appveyor-dependencies'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/582976380f1f75795d2b7eddf38a575b8ab5b279
+                      message: ''
+                      name: untagged-1db191c2a75651a2a553
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-1db191c2a75651a2a553
+                      target: 582976380f1f75795d2b7eddf38a575b8ab5b279
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a325970597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"9ca8e11e913f718a1b59d9085617fc65"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-05-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '19'
+                      RateLimit-Remaining: '581'
+                      RateLimit-Reset: '1587559302'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:42 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: HwlsB3cPU45
+                      X-Runtime: '0.071021'
+                      cf-request-id: 024380b37a0000597c7ea44200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.330794095993042
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-09-19T14:21:06.000-04:00'
+                        committed_date: '2016-09-19T14:21:06.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-09-19T14:21:06.000-04:00'
+                        id: e746dac6b40a6911db36d6243a0c9624abc7d0d7
+                        message: 'Merge branch ''ErwinJanssen-remove-unused''
+
+
+                          (resolved conflict from reinstalled features/common)
+
+                          '
+                        parent_ids:
+                        - 985e7736b11dbd577658f7538070f3a85129dd53
+                        - ec8a1812303950949a4bbef86f2afc27bbba75a4
+                        short_id: e746dac6
+                        title: Merge branch 'ErwinJanssen-remove-unused'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/e746dac6b40a6911db36d6243a0c9624abc7d0d7
+                      message: ''
+                      name: untagged-026b538d0dba6682fde7
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-026b538d0dba6682fde7
+                      target: e746dac6b40a6911db36d6243a0c9624abc7d0d7
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a341a92597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"cdda851e6691f8ac77c9a3cc31bbe7a9"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-21-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '16'
+                      RateLimit-Remaining: '584'
+                      RateLimit-Reset: '1587559303'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:43 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: ewO2N4lXmV8
+                      X-Runtime: '0.055206'
+                      cf-request-id: 024380b48e0000597c7ea57200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.29366183280944824
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-09-19T13:13:24.000-04:00'
+                        committed_date: '2016-09-19T13:13:24.000-04:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-09-19T13:13:24.000-04:00'
+                        id: 985e7736b11dbd577658f7538070f3a85129dd53
+                        message: 'Merge pull request #1163 from ErwinJanssen/less-conditional-build
+
+
+                          Less conditional build'
+                        parent_ids:
+                        - 59d5922b6af402cd6a0ee18f987ef56cf5c96064
+                        - e9c3f623715447a95493c6b6966974de21f3db1c
+                        short_id: 985e7736
+                        title: 'Merge pull request #1163 from ErwinJanssen/less-conditional-build'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/985e7736b11dbd577658f7538070f3a85129dd53
+                      message: ''
+                      name: untagged-bc9e6eee63f1f0bce98f
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-bc9e6eee63f1f0bce98f
+                      target: 985e7736b11dbd577658f7538070f3a85129dd53
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a364bf0597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"131c03f34430493ccc7bb8c07963a941"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-18-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '20'
+                      RateLimit-Remaining: '580'
+                      RateLimit-Reset: '1587559303'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:43 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: lQ2iCHSdPk6
+                      X-Runtime: '0.063030'
+                      cf-request-id: 024380b5ef0000597c7ea67200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.3003547191619873
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-09-19T13:13:24.000-04:00'
+                        committed_date: '2016-09-19T13:13:24.000-04:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-09-19T13:13:24.000-04:00'
+                        id: 985e7736b11dbd577658f7538070f3a85129dd53
+                        message: 'Merge pull request #1163 from ErwinJanssen/less-conditional-build
+
+
+                          Less conditional build'
+                        parent_ids:
+                        - 59d5922b6af402cd6a0ee18f987ef56cf5c96064
+                        - e9c3f623715447a95493c6b6966974de21f3db1c
+                        short_id: 985e7736
+                        title: 'Merge pull request #1163 from ErwinJanssen/less-conditional-build'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/985e7736b11dbd577658f7538070f3a85129dd53
+                      message: ''
+                      name: untagged-4431b9bde391f1b69fe5
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-4431b9bde391f1b69fe5
+                      target: 985e7736b11dbd577658f7538070f3a85129dd53
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a382cf9597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"f0e4b346353fa014e3e9eea98a77c817"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-20-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '21'
+                      RateLimit-Remaining: '579'
+                      RateLimit-Reset: '1587559303'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:43 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: VAwVKDQQT87
+                      X-Runtime: '0.062065'
+                      cf-request-id: 024380b7180000597c7ea75200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.491072416305542
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-09-08T00:13:48.000-04:00'
+                        committed_date: '2016-09-08T00:13:48.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-09-08T00:13:48.000-04:00'
+                        id: ee4cdc97ef3f9f9107c0d90c58c4afd64f8f8236
+                        message: 'revert change - not right
+
+                          '
+                        parent_ids:
+                        - f5ae75970c48184c2621e61f40cdfc4879825838
+                        short_id: ee4cdc97
+                        title: revert change - not right
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/ee4cdc97ef3f9f9107c0d90c58c4afd64f8f8236
+                      message: ''
+                      name: untagged-a22228c7bd6ed4c2a8f9
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-a22228c7bd6ed4c2a8f9
+                      target: ee4cdc97ef3f9f9107c0d90c58c4afd64f8f8236
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a3a2e21597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"4041563e7b65518e7afed7bdc42cac8c"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-16-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '21'
+                      RateLimit-Remaining: '579'
+                      RateLimit-Reset: '1587559304'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:44 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: A22sSXPSpO1
+                      X-Runtime: '0.051664'
+                      cf-request-id: 024380b8560000597c7ea80200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.289015531539917
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-09-07T19:44:14.000-04:00'
+                        committed_date: '2016-09-07T19:44:14.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-09-07T19:44:14.000-04:00'
+                        id: f5ae75970c48184c2621e61f40cdfc4879825838
+                        message: 'drop some strange casts to cllean up some warnings
+
+                          '
+                        parent_ids:
+                        - 102a8ca3fa7629aac03c4de815681f401b5ec718
+                        short_id: f5ae7597
+                        title: drop some strange casts to cllean up some warnings
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/f5ae75970c48184c2621e61f40cdfc4879825838
+                      message: ''
+                      name: untagged-88f8affbb29485590ece
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-88f8affbb29485590ece
+                      target: f5ae75970c48184c2621e61f40cdfc4879825838
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a3d582c597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"fe2b49dd19a94c9830f366156709ada5"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-09-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '16'
+                      RateLimit-Remaining: '578'
+                      RateLimit-Reset: '1587559304'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:44 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: 9pUw3hPCUU7
+                      X-Runtime: '0.081052'
+                      cf-request-id: 024380ba540000597c7ea97200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.2991373538970947
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-09-07T19:19:26.000-04:00'
+                        committed_date: '2016-09-07T19:19:26.000-04:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-09-07T19:19:26.000-04:00'
+                        id: 102a8ca3fa7629aac03c4de815681f401b5ec718
+                        message: 'Merge pull request #1155 from ErwinJanssen/windows-release
+
+
+                          Various improvements to Windows build'
+                        parent_ids:
+                        - 2d0c2c03c403ba47b9ca4b381d25aa96cfa83042
+                        - 3b48e9575c30ae0a82fcf06e18259d532336a415
+                        short_id: 102a8ca3
+                        title: 'Merge pull request #1155 from ErwinJanssen/windows-release'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/102a8ca3fa7629aac03c4de815681f401b5ec718
+                      message: ''
+                      name: untagged-897b348e31e4e52e8698
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-897b348e31e4e52e8698
+                      target: 102a8ca3fa7629aac03c4de815681f401b5ec718
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a3f3967597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"1aab1f45d008ed21efed2e47a4b06ccb"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-14-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '23'
+                      RateLimit-Remaining: '577'
+                      RateLimit-Reset: '1587559304'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:44 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: 3ZHqiMafQ3a
+                      X-Runtime: '0.060643'
+                      cf-request-id: 024380bb860000597c7eaa3200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.28577661514282227
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: erg@emdenrg.net
+                        author_name: Emden R. Gansner
+                        authored_date: '2016-09-05T16:35:47.000-04:00'
+                        committed_date: '2016-09-05T16:35:47.000-04:00'
+                        committer_email: erg@emdenrg.net
+                        committer_name: Emden R. Gansner
+                        created_at: '2016-09-05T16:35:47.000-04:00'
+                        id: bc6488018f3f55ace6b4046645578508643db08b
+                        message: 'Add documentation on json output.
+
+                          '
+                        parent_ids:
+                        - 3c0d713cf7b49231f845cc9b38c800feea1552ab
+                        short_id: bc648801
+                        title: Add documentation on json output.
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/bc6488018f3f55ace6b4046645578508643db08b
+                      message: ''
+                      name: untagged-d1db4ad9a9fa8595330a
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-d1db4ad9a9fa8595330a
+                      target: bc6488018f3f55ace6b4046645578508643db08b
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a413b07597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"2f34c96f86723652c774cebdd9c697fa"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-10-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '24'
+                      RateLimit-Remaining: '576'
+                      RateLimit-Reset: '1587559305'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:45 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: 25A76c6pwI8
+                      X-Runtime: '0.058770'
+                      cf-request-id: 024380bcbe0000597c7eaaa200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.3017253875732422
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: emdenrg@google.com
+                        author_name: Emden Gansner
+                        authored_date: '2016-09-03T13:19:09.000-04:00'
+                        committed_date: '2016-09-03T13:19:09.000-04:00'
+                        committer_email: emdenrg@google.com
+                        committer_name: Emden Gansner
+                        created_at: '2016-09-03T13:19:09.000-04:00'
+                        id: 3c0d713cf7b49231f845cc9b38c800feea1552ab
+                        message: 'Merge branch ''master'' of https://github.com/ellson/graphviz
+
+                          '
+                        parent_ids:
+                        - 6be338ffd3f3fdcbc273c4284f7f741825eae6c3
+                        - d1244c8001e8c681def4c0ff25a91136845c2a75
+                        short_id: 3c0d713c
+                        title: Merge branch 'master' of https://github.com/ellson/graphviz
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/3c0d713cf7b49231f845cc9b38c800feea1552ab
+                      message: ''
+                      name: untagged-153418532a1b01559b57
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-153418532a1b01559b57
+                      target: 3c0d713cf7b49231f845cc9b38c800feea1552ab
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a433c44597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"53a6d0aa59abaae68f3b390033d70dbb"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-24-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '25'
+                      RateLimit-Remaining: '575'
+                      RateLimit-Reset: '1587559305'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:45 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: PfPSXnPnMj6
+                      X-Runtime: '0.065006'
+                      cf-request-id: 024380bdfe0000597c7eaaf200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.2749309539794922
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-08-23T10:45:02.000-04:00'
+                        committed_date: '2016-08-23T10:45:02.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-08-23T10:45:02.000-04:00'
+                        id: d1244c8001e8c681def4c0ff25a91136845c2a75
+                        message: 'convert ''unsigned long'' to ''uint64_t'' for Windows
+                          portability
+
+                          '
+                        parent_ids:
+                        - 5f026ed122a2e1525dab7a6bc192ba7c40a1a7d0
+                        short_id: d1244c80
+                        title: convert 'unsigned long' to 'uint64_t' for Windows portability
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/d1244c8001e8c681def4c0ff25a91136845c2a75
+                      message: ''
+                      name: untagged-4bd8dcccfa75989e4d17
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-4bd8dcccfa75989e4d17
+                      target: d1244c8001e8c681def4c0ff25a91136845c2a75
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a451d90597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"bc6e4702f80c555535a321a6859460a0"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-10-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '26'
+                      RateLimit-Remaining: '574'
+                      RateLimit-Reset: '1587559305'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:45 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: m15QqmaR1r4
+                      X-Runtime: '0.067218'
+                      cf-request-id: 024380bf2e0000597c7eabd200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.28814125061035156
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-08-22T19:49:46.000-04:00'
+                        committed_date: '2016-08-22T19:49:46.000-04:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-08-22T19:49:46.000-04:00'
+                        id: 5f026ed122a2e1525dab7a6bc192ba7c40a1a7d0
+                        message: 'Merge pull request #1151 from arjamizo/master
+
+
+                          fix typo TB->BT in docs:shapes'
+                        parent_ids:
+                        - cd3b556caf39f78c82208b217e78a4d70c1684e0
+                        - 29de28fd4e2dc2497bfc1f294c4b67056009cfa2
+                        short_id: 5f026ed1
+                        title: 'Merge pull request #1151 from arjamizo/master'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/5f026ed122a2e1525dab7a6bc192ba7c40a1a7d0
+                      message: ''
+                      name: untagged-5b049c6cdfd083f5dbf2
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-5b049c6cdfd083f5dbf2
+                      target: 5f026ed122a2e1525dab7a6bc192ba7c40a1a7d0
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a46fee1597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"e4038005e71cca7df78459a4f2a88f8f"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-08-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '25'
+                      RateLimit-Remaining: '575'
+                      RateLimit-Reset: '1587559306'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:46 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: xQJM6V9rsp2
+                      X-Runtime: '0.067467'
+                      cf-request-id: 024380c05c0000597c7eacd200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.2995944023132324
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: erg@emdenrg.net
+                        author_name: Emden R. Gansner
+                        authored_date: '2016-08-19T07:04:25.000-04:00'
+                        committed_date: '2016-08-19T07:04:25.000-04:00'
+                        committer_email: erg@emdenrg.net
+                        committer_name: Emden R. Gansner
+                        created_at: '2016-08-19T07:04:25.000-04:00'
+                        id: cd3b556caf39f78c82208b217e78a4d70c1684e0
+                        message: 'Replace cluster with subgraph, as the output will
+                          also reflect non-cluster
+
+                          subgraphs.
+
+                          '
+                        parent_ids:
+                        - d7e8b8136aa22301ae3a448c38024f1d049f3d1a
+                        short_id: cd3b556c
+                        title: Replace cluster with subgraph, as the output will also
+                          reflect non-cluster
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/cd3b556caf39f78c82208b217e78a4d70c1684e0
+                      message: ''
+                      name: untagged-f6bbc5576feb1e03c4b8
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-f6bbc5576feb1e03c4b8
+                      target: cd3b556caf39f78c82208b217e78a4d70c1684e0
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a490887597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"6c62b0a1b4f1429039c68717e415c10b"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-05-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '26'
+                      RateLimit-Remaining: '574'
+                      RateLimit-Reset: '1587559306'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:46 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: fkNRuApYNLa
+                      X-Runtime: '0.055879'
+                      cf-request-id: 024380c1a60000597c7eadf200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.2872636318206787
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: erg@emdenrg.net
+                        author_name: Emden R. Gansner
+                        authored_date: '2016-08-17T20:36:28.000-04:00'
+                        committed_date: '2016-08-17T20:36:28.000-04:00'
+                        committer_email: erg@emdenrg.net
+                        committer_name: Emden R. Gansner
+                        created_at: '2016-08-17T20:36:28.000-04:00'
+                        id: d7e8b8136aa22301ae3a448c38024f1d049f3d1a
+                        message: 'Add schema for dot output in json format.
+
+                          '
+                        parent_ids:
+                        - 2c10dbea604a56c49918c8f153440f1919a0797f
+                        short_id: d7e8b813
+                        title: Add schema for dot output in json format.
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/d7e8b8136aa22301ae3a448c38024f1d049f3d1a
+                      message: ''
+                      name: untagged-0dc7cf263f66ae1825bb
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-0dc7cf263f66ae1825bb
+                      target: d7e8b8136aa22301ae3a448c38024f1d049f3d1a
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a4aca1b597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"d8c7b9e67ea68b8bc57290553fea9e49"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-05-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '27'
+                      RateLimit-Remaining: '573'
+                      RateLimit-Reset: '1587559306'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:46 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: Bl2rF3OaXg8
+                      X-Runtime: '0.076889'
+                      cf-request-id: 024380c2bc0000597c7eaf1200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.2647521495819092
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-08-17T09:11:10.000-04:00'
+                        committed_date: '2016-08-17T09:11:10.000-04:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-08-17T09:11:10.000-04:00'
+                        id: 2c10dbea604a56c49918c8f153440f1919a0797f
+                        message: 'Merge pull request #1150 from ErwinJanssen/configure-ac
+
+
+                          Removed POSIX version flag from configure.ac'
+                        parent_ids:
+                        - 8123e7b0dfc348c8402516c1302e956dfacec161
+                        - 1d23dfe697f44e77d42462ff71c284617342dd1c
+                        short_id: 2c10dbea
+                        title: 'Merge pull request #1150 from ErwinJanssen/configure-ac'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/2c10dbea604a56c49918c8f153440f1919a0797f
+                      message: ''
+                      name: untagged-1bc5df88610db337fc67
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-1bc5df88610db337fc67
+                      target: 2c10dbea604a56c49918c8f153440f1919a0797f
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a4cabca597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"a262b4f99e6db8ed6675a56ae175ea40"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-04-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '28'
+                      RateLimit-Remaining: '572'
+                      RateLimit-Reset: '1587559306'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:46 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: pSOQm2eijE6
+                      X-Runtime: '0.073262'
+                      cf-request-id: 024380c3e40000597c7eb00200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.3280465602874756
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-08-16T13:18:55.000-04:00'
+                        committed_date: '2016-08-16T13:18:55.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-08-16T13:18:55.000-04:00'
+                        id: 8123e7b0dfc348c8402516c1302e956dfacec161
+                        message: 'el5 breakage, need ,  in dist target, but not in
+                          install target
+
+                          '
+                        parent_ids:
+                        - 788583c2dde4d8eeff6afca9c23bde567f27473b
+                        short_id: 8123e7b0
+                        title: el5 breakage, need ,  in dist target, but not in install
+                          target
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/8123e7b0dfc348c8402516c1302e956dfacec161
+                      message: ''
+                      name: untagged-383680da5ca9da9f5250
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-383680da5ca9da9f5250
+                      target: 8123e7b0dfc348c8402516c1302e956dfacec161
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a4e6d46597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"cafe2989f8e03d34ede2dc5fb209add7"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-19-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '26'
+                      RateLimit-Remaining: '574'
+                      RateLimit-Reset: '1587559307'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:47 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: o1hfVfhLXK5
+                      X-Runtime: '0.049060'
+                      cf-request-id: 024380c5000000597c7eb12200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.28989696502685547
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-08-16T12:03:03.000-04:00'
+                        committed_date: '2016-08-16T12:03:03.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-08-16T12:03:03.000-04:00'
+                        id: 788583c2dde4d8eeff6afca9c23bde567f27473b
+                        message: 'remove -D_POSIX_C_SOURCE=200112L as it breaks ./configure
+                          test for php.h
+
+                          '
+                        parent_ids:
+                        - 86525777eafc8621591e37e5e3feb15ebe9fbedf
+                        short_id: 788583c2
+                        title: remove -D_POSIX_C_SOURCE=200112L as it breaks ./configure
+                          test for php.h
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/788583c2dde4d8eeff6afca9c23bde567f27473b
+                      message: ''
+                      name: untagged-d177ed11e0540b07902a
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-d177ed11e0540b07902a
+                      target: 788583c2dde4d8eeff6afca9c23bde567f27473b
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a508eae597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"dbd0ad100d83fadfcb3f1bfb08dd9d13"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-01-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '26'
+                      RateLimit-Remaining: '574'
+                      RateLimit-Reset: '1587559307'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:47 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: lzAnv0pdOa5
+                      X-Runtime: '0.065949'
+                      cf-request-id: 024380c6590000597c7eb2c200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.28806471824645996
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-08-15T16:21:54.000-04:00'
+                        committed_date: '2016-08-15T16:21:54.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-08-15T16:21:54.000-04:00'
+                        id: 86525777eafc8621591e37e5e3feb15ebe9fbedf
+                        message: 'Merge branch ''master'' of github.com:/ellson/graphviz
+
+                          '
+                        parent_ids:
+                        - e2a23c828c1d1462065236cdc82362a86db49de5
+                        - c35619db486c6a2453ef0a9de6f541e809037760
+                        short_id: '86525777'
+                        title: Merge branch 'master' of github.com:/ellson/graphviz
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/86525777eafc8621591e37e5e3feb15ebe9fbedf
+                      message: ''
+                      name: untagged-95487e465cf6bdb4c605
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-95487e465cf6bdb4c605
+                      target: 86525777eafc8621591e37e5e3feb15ebe9fbedf
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a528fd0597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"81921f751fe7067515b0b3e440b1ebdf"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-08-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '27'
+                      RateLimit-Remaining: '573'
+                      RateLimit-Reset: '1587559307'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:47 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: RzpDLM5iQC9
+                      X-Runtime: '0.070596'
+                      cf-request-id: 024380c7940000597c7eb3e200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.28835463523864746
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-08-13T12:55:44.000-04:00'
+                        committed_date: '2016-08-13T12:55:44.000-04:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-08-13T12:55:44.000-04:00'
+                        id: c35619db486c6a2453ef0a9de6f541e809037760
+                        message: 'Merge pull request #1149 from ErwinJanssen/improve-travis
+
+
+                          Improve Travis + deploy make dist results'
+                        parent_ids:
+                        - 29ed3f9866af9051145f010cb13824b6c7f92866
+                        - 7d41358763116f4289fd125bfe9f9a8676080c5c
+                        short_id: c35619db
+                        title: 'Merge pull request #1149 from ErwinJanssen/improve-travis'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/c35619db486c6a2453ef0a9de6f541e809037760
+                      message: ''
+                      name: untagged-950e8f23afa87abe4973
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-950e8f23afa87abe4973
+                      target: c35619db486c6a2453ef0a9de6f541e809037760
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a5468ef597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"8fadb079108906a74afa2dd9e7a722a4"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-16-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '28'
+                      RateLimit-Remaining: '572'
+                      RateLimit-Reset: '1587559308'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:48 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: mJQc3o182g8
+                      X-Runtime: '0.053736'
+                      cf-request-id: 024380c8c20000597c7eb55200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.3527235984802246
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: emdenrg@google.com
+                        author_name: Emden Gansner
+                        authored_date: '2016-08-13T08:51:45.000-04:00'
+                        committed_date: '2016-08-13T08:51:45.000-04:00'
+                        committer_email: emdenrg@google.com
+                        committer_name: Emden Gansner
+                        created_at: '2016-08-13T08:51:45.000-04:00'
+                        id: 29ed3f9866af9051145f010cb13824b6c7f92866
+                        message: 'Small formatting change.
+
+                          '
+                        parent_ids:
+                        - 39180176da657656abc7f7f90adf894b85aeabee
+                        short_id: 29ed3f98
+                        title: Small formatting change.
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/29ed3f9866af9051145f010cb13824b6c7f92866
+                      message: ''
+                      name: untagged-0aac90e5c2817176609d
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-0aac90e5c2817176609d
+                      target: 29ed3f9866af9051145f010cb13824b6c7f92866
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a565a4a597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"544157825bba581fdfb65a709b6b427c"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-22-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '29'
+                      RateLimit-Remaining: '571'
+                      RateLimit-Reset: '1587559308'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:48 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: y0A6EOCjdE8
+                      X-Runtime: '0.166620'
+                      cf-request-id: 024380c9f40000597c7eb5d200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.3206298351287842
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: emdenrg@google.com
+                        author_name: Emden Gansner
+                        authored_date: '2016-08-12T17:18:29.000-04:00'
+                        committed_date: '2016-08-12T17:18:29.000-04:00'
+                        committer_email: emdenrg@google.com
+                        committer_name: Emden Gansner
+                        created_at: '2016-08-12T17:18:29.000-04:00'
+                        id: 39180176da657656abc7f7f90adf894b85aeabee
+                        message: 'Edges attached to a cluster were not getting assigned
+                          an index number.
+
+                          '
+                        parent_ids:
+                        - 4b456b630eefb5425696cbb9831ca907d9dd75cb
+                        short_id: '39180176'
+                        title: Edges attached to a cluster were not getting assigned
+                          an index number.
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/39180176da657656abc7f7f90adf894b85aeabee
+                      message: ''
+                      name: untagged-c6ce5b1f17878d776124
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-c6ce5b1f17878d776124
+                      target: 39180176da657656abc7f7f90adf894b85aeabee
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a58bbe1597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"0d9562986e72f71bd01eb6a53d1427da"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-12-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '29'
+                      RateLimit-Remaining: '571'
+                      RateLimit-Reset: '1587559308'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:48 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: 0qeMa0ll2t8
+                      X-Runtime: '0.067654'
+                      cf-request-id: 024380cb6f0000597c7eb6c200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.29945826530456543
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-08-10T15:00:14.000-04:00'
+                        committed_date: '2016-08-10T15:00:14.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-08-10T15:00:14.000-04:00'
+                        id: 4b456b630eefb5425696cbb9831ca907d9dd75cb
+                        message: 'quote  as it contains spaces when No
+
+                          '
+                        parent_ids:
+                        - 6a0ecb98d2eaa39423e0bb0acb8d0f53e73bed1b
+                        short_id: 4b456b63
+                        title: quote  as it contains spaces when No
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/4b456b630eefb5425696cbb9831ca907d9dd75cb
+                      message: ''
+                      name: untagged-1aed90cbe517038de3a0
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-1aed90cbe517038de3a0
+                      target: 4b456b630eefb5425696cbb9831ca907d9dd75cb
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a5acd69597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"780fc260851aad48e8a46c8171b3ad73"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-16-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '30'
+                      RateLimit-Remaining: '570'
+                      RateLimit-Reset: '1587559309'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:49 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: IXDNVndFCPa
+                      X-Runtime: '0.053059'
+                      cf-request-id: 024380ccb80000597c7eb7d200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.2876780033111572
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-08-09T11:52:33.000-04:00'
+                        committed_date: '2016-08-09T11:52:33.000-04:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-08-09T11:52:33.000-04:00'
+                        id: 3fb678e09a7e832531ca039446789d1f9b391079
+                        message: 'Merge pull request #1148 from ErwinJanssen/unit-test
+
+
+                          Introduction unit test for current commnand line behavior'
+                        parent_ids:
+                        - 91a9749ebf5ae4490ecbdb59803bf79e971508fc
+                        - 4092b6dc38a57c327869127404ce06dfd68c402c
+                        short_id: 3fb678e0
+                        title: 'Merge pull request #1148 from ErwinJanssen/unit-test'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/3fb678e09a7e832531ca039446789d1f9b391079
+                      message: ''
+                      name: untagged-27ff95768eb6958bcef7
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-27ff95768eb6958bcef7
+                      target: 3fb678e09a7e832531ca039446789d1f9b391079
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a5cbf55597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"49f8cce04adfd1f6c771201e9a0a68e9"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-17-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '31'
+                      RateLimit-Remaining: '569'
+                      RateLimit-Reset: '1587559309'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:49 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: EkUjboL0J91
+                      X-Runtime: '0.054878'
+                      cf-request-id: 024380cdef0000597c7eb8d200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.29895544052124023
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-08-01T00:07:57.000-04:00'
+                        committed_date: '2016-08-01T00:07:57.000-04:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-08-01T00:07:57.000-04:00'
+                        id: 91a9749ebf5ae4490ecbdb59803bf79e971508fc
+                        message: 'Merge pull request #1147 from GadgetSteve/master
+
+
+                          Changed README.md reference github for documentation.'
+                        parent_ids:
+                        - 8c3fc96b7a2763e077058edb16cf54c533ae962f
+                        - 1240e4fbe7d3e9cfbd0a35d5237dcc1e41661af0
+                        short_id: 91a9749e
+                        title: 'Merge pull request #1147 from GadgetSteve/master'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/91a9749ebf5ae4490ecbdb59803bf79e971508fc
+                      message: ''
+                      name: untagged-cf3150dc2db96b5bb4d6
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-cf3150dc2db96b5bb4d6
+                      target: 91a9749ebf5ae4490ecbdb59803bf79e971508fc
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a5e892e597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"9622e8f160113b4c7231c0e0651904d7"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-03-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '32'
+                      RateLimit-Remaining: '568'
+                      RateLimit-Reset: '1587559309'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:49 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: E3rG6x5vZg5
+                      X-Runtime: '0.059129'
+                      cf-request-id: 024380cf190000597c7eba7200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.28629088401794434
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-07-27T04:21:31.000-04:00'
+                        committed_date: '2016-07-27T04:21:31.000-04:00'
+                        committer_email: john.ellson@comcast.net
+                        committer_name: John Ellson
+                        created_at: '2016-07-27T04:21:31.000-04:00'
+                        id: 8c3fc96b7a2763e077058edb16cf54c533ae962f
+                        message: 'some -W flags not available on centos[56]
+
+                          '
+                        parent_ids:
+                        - 3bbc61ad12cfc0c15515a96113098e8605db89e5
+                        short_id: 8c3fc96b
+                        title: some -W flags not available on centos[56]
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/8c3fc96b7a2763e077058edb16cf54c533ae962f
+                      message: ''
+                      name: untagged-749ecd6837d5c822253e
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-749ecd6837d5c822253e
+                      target: 8c3fc96b7a2763e077058edb16cf54c533ae962f
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a608ac1597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"e72c4c4d3e20e1b42a00f807d3e93fbb"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-21-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '32'
+                      RateLimit-Remaining: '568'
+                      RateLimit-Reset: '1587559310'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:50 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: iXa5KeNHKt4
+                      X-Runtime: '0.055636'
+                      cf-request-id: 024380d0570000597c7ebc3200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.2883422374725342
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: emdenrg@google.com
+                        author_name: Emden Gansner
+                        authored_date: '2016-07-26T12:23:16.000-04:00'
+                        committed_date: '2016-07-26T12:23:16.000-04:00'
+                        committer_email: emdenrg@google.com
+                        committer_name: Emden Gansner
+                        created_at: '2016-07-26T12:23:16.000-04:00'
+                        id: 3bbc61ad12cfc0c15515a96113098e8605db89e5
+                        message: 'Fix bug in printing error message about graphs with
+                          loops or multiedges; note port restriction in
+
+                          man page.
+
+                          '
+                        parent_ids:
+                        - 541b872ead985143dae4de91e1c5e426dd0c4280
+                        short_id: 3bbc61ad
+                        title: Fix bug in printing error message about graphs with
+                          loops or multiedges; note port restriction in
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/3bbc61ad12cfc0c15515a96113098e8605db89e5
+                      message: ''
+                      name: untagged-282a92de118059697b67
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-282a92de118059697b67
+                      target: 3bbc61ad12cfc0c15515a96113098e8605db89e5
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a627bf5597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"f3b769d1c2c09632a70d1a13f0c7b9fb"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-06-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '33'
+                      RateLimit-Remaining: '567'
+                      RateLimit-Reset: '1587559310'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:50 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: qCwBVDBrSA2
+                      X-Runtime: '0.076540'
+                      cf-request-id: 024380d1880000597c7ebd2200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.38901615142822266
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-07-25T20:39:50.000-04:00'
+                        committed_date: '2016-07-25T20:39:50.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-07-25T20:39:50.000-04:00'
+                        id: 541b872ead985143dae4de91e1c5e426dd0c4280
+                        message: 'cgraph is not a configure option these days
+
+                          '
+                        parent_ids:
+                        - 775699b8ee69764c65aa7edfa06b1376df0759a3
+                        short_id: 541b872e
+                        title: cgraph is not a configure option these days
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/541b872ead985143dae4de91e1c5e426dd0c4280
+                      message: ''
+                      name: untagged-3443de97cd58035a8aea
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-3443de97cd58035a8aea
+                      target: 541b872ead985143dae4de91e1c5e426dd0c4280
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a646d3a597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"85eb3802e4fa4310a310036987f14a2e"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-09-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '34'
+                      RateLimit-Remaining: '566'
+                      RateLimit-Reset: '1587559310'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:50 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: zZJyMs1qUs3
+                      X-Runtime: '0.052274'
+                      cf-request-id: 024380d2bc0000597c7ebe4200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.49115848541259766
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-07-25T17:15:06.000-04:00'
+                        committed_date: '2016-07-25T17:15:06.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-07-25T17:15:06.000-04:00'
+                        id: dc35219a3d4a3d81943bc17f918afd8410ef85db
+                        message: 'more incompatible warning switches
+
+                          '
+                        parent_ids:
+                        - 1daf345474c78d8e5f36db08c3f6ab5eb664a6de
+                        short_id: dc35219a
+                        title: more incompatible warning switches
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/dc35219a3d4a3d81943bc17f918afd8410ef85db
+                      message: ''
+                      name: untagged-f5823de05291db506275
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-f5823de05291db506275
+                      target: dc35219a3d4a3d81943bc17f918afd8410ef85db
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a66ff05597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"21507ab507fc7bfad890da90a0f83435"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-05-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '35'
+                      RateLimit-Remaining: '565'
+                      RateLimit-Reset: '1587559311'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:51 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: IfVL1fP6xP7
+                      X-Runtime: '0.073143'
+                      cf-request-id: 024380d4580000597c7e80f200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.2878391742706299
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-07-22T14:54:51.000-04:00'
+                        committed_date: '2016-07-22T14:54:51.000-04:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-07-22T14:54:51.000-04:00'
+                        id: 9785bdb11f5023d9389cc27e453ccdb8cea1d92b
+                        message: 'Merge pull request #1145 from ErwinJanssen/refactor
+
+
+                          Enable C99, enable more warnings and solve some warnings.'
+                        parent_ids:
+                        - 315aa03eb8a5519aa71e3bb24f4c6d808dd48f77
+                        - 370eb57c659606b07aaaae4a2d1524f23ee74a37
+                        short_id: 9785bdb1
+                        title: 'Merge pull request #1145 from ErwinJanssen/refactor'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/9785bdb11f5023d9389cc27e453ccdb8cea1d92b
+                      message: ''
+                      name: untagged-9ee5934fa10f12b4043f
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-9ee5934fa10f12b4043f
+                      target: 9785bdb11f5023d9389cc27e453ccdb8cea1d92b
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a6a28d3597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"2cc6dc5357ee35bbfdb9b07bbcd3d4ba"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-08-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '33'
+                      RateLimit-Remaining: '567'
+                      RateLimit-Reset: '1587559311'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:51 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: L3tCExrejf9
+                      X-Runtime: '0.061195'
+                      cf-request-id: 024380d65c0000597c7e82f200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.28719091415405273
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-07-22T10:47:02.000-04:00'
+                        committed_date: '2016-07-22T10:47:02.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-07-22T10:47:02.000-04:00'
+                        id: 315aa03eb8a5519aa71e3bb24f4c6d808dd48f77
+                        message: 'add missing layers support in -Tsvgz device
+
+                          '
+                        parent_ids:
+                        - e20964332ea95fa8c23784007d3fca1ce960d6ef
+                        short_id: 315aa03e
+                        title: add missing layers support in -Tsvgz device
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/315aa03eb8a5519aa71e3bb24f4c6d808dd48f77
+                      message: ''
+                      name: untagged-1d58b621a7287e0b0a25
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-1d58b621a7287e0b0a25
+                      target: 315aa03eb8a5519aa71e3bb24f4c6d808dd48f77
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a6c09d7597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"b84bed9bf72a5226a99c81ad347a2989"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-11-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '35'
+                      RateLimit-Remaining: '565'
+                      RateLimit-Reset: '1587559311'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:51 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: Da2dQBLEND6
+                      X-Runtime: '0.051206'
+                      cf-request-id: 024380d7890000597c7e83f200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.2992062568664551
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-07-21T17:01:01.000-04:00'
+                        committed_date: '2016-07-21T17:01:01.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-07-21T17:01:01.000-04:00'
+                        id: e20964332ea95fa8c23784007d3fca1ce960d6ef
+                        message: 'Merge branch ''master'' of github.com:/ellson/graphviz
+
+                          '
+                        parent_ids:
+                        - 54a3f9b3520e8043c2b52f203e3c3f975eb21240
+                        - 858fe6db9adeedd2a4206f69f415a2147b175256
+                        short_id: e2096433
+                        title: Merge branch 'master' of github.com:/ellson/graphviz
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/e20964332ea95fa8c23784007d3fca1ce960d6ef
+                      message: ''
+                      name: untagged-1843dff5ba962a1be63b
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-1843dff5ba962a1be63b
+                      target: e20964332ea95fa8c23784007d3fca1ce960d6ef
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a6dea8b597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"13ceef4d97664b0aeec54a5609a69988"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-14-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '34'
+                      RateLimit-Remaining: '566'
+                      RateLimit-Reset: '1587559312'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:52 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: WZ2BdKw4Si8
+                      X-Runtime: '0.054374'
+                      cf-request-id: 024380d8af0000597c7e844200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.458057165145874
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: ellson@research.att.com
+                        author_name: John Ellson
+                        authored_date: '2016-07-21T17:01:01.000-04:00'
+                        committed_date: '2016-07-21T17:01:01.000-04:00'
+                        committer_email: ellson@research.att.com
+                        committer_name: John Ellson
+                        created_at: '2016-07-21T17:01:01.000-04:00'
+                        id: e20964332ea95fa8c23784007d3fca1ce960d6ef
+                        message: 'Merge branch ''master'' of github.com:/ellson/graphviz
+
+                          '
+                        parent_ids:
+                        - 54a3f9b3520e8043c2b52f203e3c3f975eb21240
+                        - 858fe6db9adeedd2a4206f69f415a2147b175256
+                        short_id: e2096433
+                        title: Merge branch 'master' of github.com:/ellson/graphviz
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/e20964332ea95fa8c23784007d3fca1ce960d6ef
+                      message: ''
+                      name: untagged-3324163453e4161833a0
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-3324163453e4161833a0
+                      target: e20964332ea95fa8c23784007d3fca1ce960d6ef
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a6feb85597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"e9217efc42d9269c301edc069da28fb0"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-10-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '36'
+                      RateLimit-Remaining: '564'
+                      RateLimit-Reset: '1587559312'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:52 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: YC9N5GqsPO5
+                      X-Runtime: '0.076612'
+                      cf-request-id: 024380d9f30000597c7e854200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.31984758377075195
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-07-14T10:16:48.000-04:00'
+                        committed_date: '2016-07-14T10:16:48.000-04:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-07-14T10:16:48.000-04:00'
+                        id: a4bf3c86a6c07d7413acb83627632ce38a473a39
+                        message: 'Merge pull request #1137 from ErwinJanssen/replace-libgd
+
+
+                          Replace in-tree libgd with external build of recent code'
+                        parent_ids:
+                        - f93c5223930c8342045f465fb51667e57bf61e2b
+                        - 15b694bba14be8192adab88e95029aeba5094603
+                        short_id: a4bf3c86
+                        title: 'Merge pull request #1137 from ErwinJanssen/replace-libgd'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/a4bf3c86a6c07d7413acb83627632ce38a473a39
+                      message: ''
+                      name: untagged-dca5f3fa2a3476aaf8e3
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-dca5f3fa2a3476aaf8e3
+                      target: a4bf3c86a6c07d7413acb83627632ce38a473a39
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a72ed95597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"229437a3670fbe568866b76a1f51c181"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-24-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '37'
+                      RateLimit-Remaining: '563'
+                      RateLimit-Reset: '1587559313'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:53 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: 62zxivPrM04
+                      X-Runtime: '0.075822'
+                      cf-request-id: 024380dbd30000597c7e877200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.2944824695587158
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-07-10T13:29:07.000-04:00'
+                        committed_date: '2016-07-10T13:29:07.000-04:00'
+                        committer_email: john.ellson@comcast.net
+                        committer_name: John Ellson
+                        created_at: '2016-07-10T13:29:07.000-04:00'
+                        id: f93c5223930c8342045f465fb51667e57bf61e2b
+                        message: 'Merge branch ''master'' of github.com:ellson/graphviz
+
+                          '
+                        parent_ids:
+                        - 985ea93521b2b0b6f34459e3ad6ebd1188be226b
+                        - 7550186bc5ca46eb072f387a8bc583aa527713b3
+                        short_id: f93c5223
+                        title: Merge branch 'master' of github.com:ellson/graphviz
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/f93c5223930c8342045f465fb51667e57bf61e2b
+                      message: ''
+                      name: untagged-720ca8034db44a953d87
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-720ca8034db44a953d87
+                      target: f93c5223930c8342045f465fb51667e57bf61e2b
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a74fee2597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"9f4933522cc8022b04b234012bff0d40"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-16-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '38'
+                      RateLimit-Remaining: '562'
+                      RateLimit-Reset: '1587559313'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:53 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: Vlyt3G5AyX8
+                      X-Runtime: '0.068648'
+                      cf-request-id: 024380dd190000597c7e88e200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.390460729598999
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-07-10T12:12:16.000-04:00'
+                        committed_date: '2016-07-10T12:12:16.000-04:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-07-10T12:12:16.000-04:00'
+                        id: 7550186bc5ca46eb072f387a8bc583aa527713b3
+                        message: 'Merge pull request #1135 from ErwinJanssen/fix-windows-build
+
+
+                          Fix windows build'
+                        parent_ids:
+                        - 65cd40f10c9b1fbdaaf4224a5b11a70e0e397446
+                        - fa7fd5b878a0941f5cd2dcb43440c6aee5e039ad
+                        short_id: 7550186b
+                        title: 'Merge pull request #1135 from ErwinJanssen/fix-windows-build'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/7550186bc5ca46eb072f387a8bc583aa527713b3
+                      message: ''
+                      name: untagged-3c169aaa6280ec506b08
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-3c169aaa6280ec506b08
+                      target: 7550186bc5ca46eb072f387a8bc583aa527713b3
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a76f802597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"501e10b3f6b60edd28062968da776b31"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-23-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '37'
+                      RateLimit-Remaining: '563'
+                      RateLimit-Reset: '1587559313'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:53 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: noN4479wPL1
+                      X-Runtime: '0.187362'
+                      cf-request-id: 024380de580000597c7e8a0200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.5039777755737305
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-07-10T07:56:58.000-04:00'
+                        committed_date: '2016-07-10T07:56:58.000-04:00'
+                        committer_email: john.ellson@comcast.net
+                        committer_name: John Ellson
+                        created_at: '2016-07-10T07:56:58.000-04:00'
+                        id: 65cd40f10c9b1fbdaaf4224a5b11a70e0e397446
+                        message: ' add ''make dist'' to travis builds
+
+                          '
+                        parent_ids:
+                        - 0aaaa3e8f849ec99afdee4957f389f32cb6aa112
+                        short_id: 65cd40f1
+                        title: ' add ''make dist'' to travis builds'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/65cd40f10c9b1fbdaaf4224a5b11a70e0e397446
+                      message: ''
+                      name: untagged-7f41f60ca2025e3251ad
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-7f41f60ca2025e3251ad
+                      target: 65cd40f10c9b1fbdaaf4224a5b11a70e0e397446
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a79795b597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"0eb4b92c29bf9424a00176e8c43e6968"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-22-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '39'
+                      RateLimit-Remaining: '561'
+                      RateLimit-Reset: '1587559314'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:54 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: x0DLiudZH19
+                      X-Runtime: '0.069864'
+                      cf-request-id: 024380dfe60000597c7e8bb200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.49066853523254395
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-07-10T06:28:01.000-04:00'
+                        committed_date: '2016-07-10T06:28:01.000-04:00'
+                        committer_email: john.ellson@comcast.net
+                        committer_name: John Ellson
+                        created_at: '2016-07-10T06:28:01.000-04:00'
+                        id: 0aaaa3e8f849ec99afdee4957f389f32cb6aa112
+                        message: 'fix diffimg test code
+
+                          '
+                        parent_ids:
+                        - 751811a5c1631c29eef1ce9f7b7b7a3836e5dc78
+                        short_id: 0aaaa3e8
+                        title: fix diffimg test code
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/0aaaa3e8f849ec99afdee4957f389f32cb6aa112
+                      message: ''
+                      name: untagged-64c3562a21c18efca077
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-64c3562a21c18efca077
+                      target: 0aaaa3e8f849ec99afdee4957f389f32cb6aa112
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a7cbb8d597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"070777b291f4d357bec828cd6f3b0d77"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-03-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '38'
+                      RateLimit-Remaining: '562'
+                      RateLimit-Reset: '1587559314'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:54 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: r27wP5wu981
+                      X-Runtime: '0.071089'
+                      cf-request-id: 024380e1f50000597c7e8e6200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.28653526306152344
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-07-10T05:07:24.000-04:00'
+                        committed_date: '2016-07-10T05:07:24.000-04:00'
+                        committer_email: noreply@github.com
+                        committer_name: GitHub
+                        created_at: '2016-07-10T05:07:24.000-04:00'
+                        id: 751811a5c1631c29eef1ce9f7b7b7a3836e5dc78
+                        message: 'Merge pull request #1134 from GadgetSteve/master
+
+
+                          Address #95 by using f suffix on floats in color_palette.c'
+                        parent_ids:
+                        - 752f8a167a35a4ae9ff05e4a44c37f444d1c17f5
+                        - 60643489cc6b53d1cb3e139734bb8f1ce55b0851
+                        short_id: 751811a5
+                        title: 'Merge pull request #1134 from GadgetSteve/master'
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/751811a5c1631c29eef1ce9f7b7b7a3836e5dc78
+                      message: ''
+                      name: untagged-3e86d2bf29bb52eaf3f6
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-3e86d2bf29bb52eaf3f6
+                      target: 751811a5c1631c29eef1ce9f7b7b7a3836e5dc78
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a7feda8597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"78a6826100c6b62e3b26e77383a0eac8"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-02-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '39'
+                      RateLimit-Remaining: '561'
+                      RateLimit-Reset: '1587559315'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:55 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: 61CKhPCeAx6
+                      X-Runtime: '0.053239'
+                      cf-request-id: 024380e3f20000597c7e8f7200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.38789796829223633
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-07-09T22:04:09.000-04:00'
+                        committed_date: '2016-07-09T22:04:09.000-04:00'
+                        committer_email: john.ellson@comcast.net
+                        committer_name: John Ellson
+                        created_at: '2016-07-09T22:04:09.000-04:00'
+                        id: 752f8a167a35a4ae9ff05e4a44c37f444d1c17f5
+                        message: 'remove rxpencer (unused, unneeded)
+
+                          '
+                        parent_ids:
+                        - 770525ca41a85e3abedbc538e3f19280a946e402
+                        short_id: 752f8a16
+                        title: remove rxpencer (unused, unneeded)
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/752f8a167a35a4ae9ff05e4a44c37f444d1c17f5
+                      message: ''
+                      name: untagged-02d82c4c9d0263e3d595
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-02d82c4c9d0263e3d595
+                      target: 752f8a167a35a4ae9ff05e4a44c37f444d1c17f5
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a81dee1597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"0631adcfad0ca91f44e3c026fe0ac56b"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-23-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '40'
+                      RateLimit-Remaining: '560'
+                      RateLimit-Reset: '1587559315'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:55 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: 1NFP8C5eIK6
+                      X-Runtime: '0.175357'
+                      cf-request-id: 024380e5250000597c7e90d200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.3011448383331299
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_gitlab
+                    - ogr.services.gitlab.project
+                    - gitlab.exceptions
+                    - gitlab.mixins
+                    - gitlab
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      commit:
+                        author_email: john.ellson@comcast.net
+                        author_name: John Ellson
+                        authored_date: '2016-07-09T21:39:41.000-04:00'
+                        committed_date: '2016-07-09T21:39:41.000-04:00'
+                        committer_email: john.ellson@comcast.net
+                        committer_name: John Ellson
+                        created_at: '2016-07-09T21:39:41.000-04:00'
+                        id: 770525ca41a85e3abedbc538e3f19280a946e402
+                        message: 'comment out empty "file:" statement
+
+                          '
+                        parent_ids:
+                        - 8d1d2a8e60ee0c9452540825f8ce0dba4e37e5df
+                        short_id: 770525ca
+                        title: comment out empty "file:" statement
+                        web_url: https://gitlab.com/graphviz/graphviz/-/commit/770525ca41a85e3abedbc538e3f19280a946e402
+                      message: ''
+                      name: untagged-fd4ca25a4ca4e4dc471c
+                      protected: false
+                      release:
+                        description: null
+                        tag_name: untagged-fd4ca25a4ca4e4dc471c
+                      target: 770525ca41a85e3abedbc538e3f19280a946e402
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      CF-Cache-Status: DYNAMIC
+                      CF-RAY: 587f6a845887597c-VIE
+                      Cache-Control: max-age=0, private, must-revalidate
+                      Connection: keep-alive
+                      Content-Encoding: gzip
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Etag: W/"ffea342124f3855b6e8e82e5a0cce610"
+                      Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                      GitLab-LB: fe-03-lb-gprd
+                      GitLab-SV: localhost
+                      RateLimit-Limit: '600'
+                      RateLimit-Observed: '40'
+                      RateLimit-Remaining: '560'
+                      RateLimit-Reset: '1587559315'
+                      RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:55 GMT
+                      Referrer-Policy: strict-origin-when-cross-origin
+                      Server: cloudflare
+                      Strict-Transport-Security: max-age=31536000
+                      Transfer-Encoding: chunked
+                      Vary: Origin
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: SAMEORIGIN
+                      X-Request-Id: I3luGTygF03
+                      X-Runtime: '0.057161'
+                      cf-request-id: 024380e6b30000597c7e919200000001
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+      ogr.services.gitlab.service:
+        gitlab:
+          gitlab.exceptions:
+            gitlab.mixins:
+              gitlab:
+                requre.objects:
+                  requests.sessions:
+                    send:
+                    - metadata:
+                        latency: 0.30724477767944336
+                        module_call_list:
+                        - unittest.case
+                        - tests.integration.test_gitlab
+                        - ogr.services.gitlab.project
+                        - ogr.services.gitlab.service
+                        - gitlab
+                        - gitlab.exceptions
+                        - gitlab.mixins
+                        - gitlab
+                        - requre.objects
+                        - requests.sessions
+                        - send
+                      output:
+                        __store_indicator: 2
+                        _content:
+                          avatar_url: https://assets.gitlab-static.net/uploads/-/system/user/avatar/375555/avatar.png
+                          bio: ''
+                          can_create_group: true
+                          can_create_project: true
+                          color_scheme_id: 4
+                          confirmed_at: '2018-06-07T08:34:01.593Z'
+                          created_at: '2016-01-15T21:12:31.705Z'
+                          current_sign_in_at: '2020-04-22T11:44:25.029Z'
+                          email: matej.focko@outlook.com
+                          external: false
+                          extra_shared_runners_minutes_limit: null
+                          id: 375555
+                          identities: []
+                          job_title: ''
+                          last_activity_on: '2020-04-22'
+                          last_sign_in_at: '2020-04-19T14:53:06.287Z'
+                          linkedin: ''
+                          location: "Ko\u0161ice, Slovakia"
+                          name: Matej Focko
+                          organization: ''
+                          private_profile: false
+                          projects_limit: 100000
+                          public_email: ''
+                          shared_runners_minutes_limit: 2000
+                          skype: ''
+                          state: active
+                          theme_id: 7
+                          twitter: MatejFocko
+                          two_factor_enabled: true
+                          username: mfocko
+                          web_url: https://gitlab.com/mfocko
+                          website_url: ''
+                          work_information: null
+                        _next: null
+                        elapsed: 0.2
+                        encoding: null
+                        headers:
+                          CF-Cache-Status: DYNAMIC
+                          CF-RAY: 587f69f40c55597c-VIE
+                          Cache-Control: max-age=0, private, must-revalidate
+                          Connection: keep-alive
+                          Content-Encoding: gzip
+                          Content-Type: application/json
+                          Date: Fri, 01 Nov 2019 13-36-03 GMT
+                          Etag: W/"21f0350f34a7799f24e32f7799ac4ea0"
+                          Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                          GitLab-LB: fe-18-lb-gprd
+                          GitLab-SV: localhost
+                          RateLimit-Limit: '600'
+                          RateLimit-Observed: '2'
+                          RateLimit-Remaining: '598'
+                          RateLimit-Reset: '1587559292'
+                          RateLimit-ResetTime: Wed, 22 Apr 2020 12:41:32 GMT
+                          Referrer-Policy: strict-origin-when-cross-origin
+                          Server: cloudflare
+                          Set-Cookie: __cfduid=d881fef472bff1e6411b0363f5564a7e91587559232;
+                            expires=Fri, 22-May-20 12:40:32 GMT; path=/; domain=.gitlab.com;
+                            HttpOnly; SameSite=Lax; Secure
+                          Strict-Transport-Security: max-age=31536000
+                          Transfer-Encoding: chunked
+                          Vary: Origin
+                          X-Content-Type-Options: nosniff
+                          X-Frame-Options: SAMEORIGIN
+                          X-Request-Id: eHiiklVGwk7
+                          X-Runtime: '0.026469'
+                          cf-request-id: 0243808c860000597c7ebd0200000001
+                        raw: !!binary ""
+                        reason: OK
+                        status_code: 200

--- a/tests/integration/test_gitlab.py
+++ b/tests/integration/test_gitlab.py
@@ -39,6 +39,13 @@ class GenericCommands(GitlabTests):
         assert branches
         assert "master" in branches
 
+    def test_branches_pagination(self):
+        # in time of writing tests using gnuwget/wget2 (28 branches)
+        wget_project = self.service.get_project(repo="wget2", namespace="gnuwget")
+        branches = wget_project.get_branches()
+        assert branches
+        assert len(branches) > 20
+
     def test_get_file(self):
         file_content = self.project.get_file_content("README.md")
         assert file_content
@@ -528,6 +535,16 @@ class Releases(GitlabTests):
         assert releases[-1].title == "test"
         assert releases[-1].tag_name == "0.1.0"
         assert releases[-1].body == "testing release"
+
+    def test_get_releases_pagination(self):
+        # in time of writing tests using graphviz/graphviz (60 releases)
+        graphviz = self.service.get_project(repo="graphviz", namespace="graphviz")
+        try:
+            releases = graphviz.get_releases()
+        except OperationNotSupported:
+            self.skipTest("This version of python-gitlab does not support releases.")
+        assert releases
+        assert len(releases) > 20
 
     def test_get_latest_release(self):
         try:


### PR DESCRIPTION
Supposed to Fix #391 

As far as I understand the `python-gitlab` package, they follow Gitlab's REST API with few additions like `list()` methods on some objects.

-  [x]  (#391) Branches API does neither state returning paginated list or explicitly say it returns *all* branches
   works with `all=True` even though it's not documented in Gitlab API
   -  [x]  will have to try using it at some repository with many branches (default pagination is 20 in other API endpoints) or could you provide the repository that brought this issue to light? ;)
-  [x]  Repository tree - can't find `all` parameter in API, it is used though and there is pagination => should look into that
   same, works even though it's not in the API documentation
-  [x]  Releases list - by API it is paginated, there's no mention of adjusting the count of releases per page nor `all`-parameter
   same, no mention of `all` in docs
-  [x]  Add tests