### PR TITLE
Enhance project references in pull requests

### DIFF
--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -365,6 +365,14 @@ class PullRequest:
     def head_commit(self) -> str:
         raise NotImplementedError
 
+    @property
+    def source_project(self) -> "GitProject":
+        raise NotImplementedError()
+
+    @property
+    def target_project(self) -> "GitProject":
+        raise NotImplementedError()
+
     def __str__(self) -> str:
         description = (
             f"{self.description[:10]}..." if self.description is not None else "None"

--- a/ogr/services/base.py
+++ b/ogr/services/base.py
@@ -22,6 +22,7 @@
 
 import datetime
 from typing import List, Optional, Match, Any
+import warnings
 
 from ogr.abstract import (
     GitService,
@@ -285,7 +286,7 @@ class BaseGitProject(GitProject):
 class BasePullRequest(PullRequest):
     def __init__(self, raw_pr: Any, project: "GitProject") -> None:
         self._raw_pr = raw_pr
-        self.project = project
+        self._target_project = project
 
     @property
     def title(self) -> str:
@@ -334,6 +335,18 @@ class BasePullRequest(PullRequest):
     @property
     def labels(self) -> List[Any]:
         raise NotImplementedError()
+
+    @property
+    def target_project(self) -> "GitProject":
+        return self._target_project
+
+    @property
+    def project(self) -> "GitProject":
+        warnings.warn(
+            "Using deprecated property, that will be removed in 0.16.0"
+            " (or 1.0.0 if it comes sooner). Please use target_project."
+        )
+        return self.target_project
 
     def get_comments(
         self, filter_regex: str = None, reverse: bool = False, author: str = None

--- a/ogr/services/github/project.py
+++ b/ogr/services/github/project.py
@@ -167,10 +167,11 @@ class GithubProject(BaseGitProject):
         """
         Return parent project if this project is a fork, otherwise return None
         """
-        if self.is_fork:
-            parent = self.github_repo.parent
-            return GithubProject(parent.name, self.service, parent.owner.login)
-        return None
+        return (
+            self.service.get_project_from_github_repository(self.github_repo.parent)
+            if self.is_fork
+            else None
+        )
 
     def get_branches(self) -> List[str]:
         return [branch.name for branch in self.github_repo.get_branches()]
@@ -381,15 +382,9 @@ class GithubProject(BaseGitProject):
         :return: fork GithubProject instance
         """
         gh_user = self.github_instance.get_user()
-        fork: Repository = gh_user.create_fork(self.github_repo)
-        project = GithubProject(
-            repo=None, service=self.service, namespace=None, github_repo=fork
+        return self.service.get_project_from_github_repository(
+            gh_user.create_fork(self.github_repo)
         )
-        # we're doing this nonsense b/c you can rename a repo and
-        # github would then return the new name
-        project.repo = project.github_repo.name
-        project.namespace = project.github_repo.owner.login
-        return project
 
     def change_token(self, new_token: str):
         raise NotImplementedError
@@ -561,13 +556,7 @@ class GithubProject(BaseGitProject):
         :return: [PagureProject]
         """
         fork_objects = [
-            GithubProject(
-                repo=fork.name,
-                namespace=fork.owner.login,
-                github_repo=fork,
-                service=self.service,
-                read_only=self.read_only,
-            )
+            self.service.get_project_from_github_repository(fork)
             for fork in self.github_repo.get_forks()
         ]
         return fork_objects

--- a/ogr/services/github/pull_request.py
+++ b/ogr/services/github/pull_request.py
@@ -105,15 +105,10 @@ class GithubPullRequest(BasePullRequest):
     @property
     def source_project(self) -> "ogr_github.GithubProject":
         if self._source_project is None:
-            src_github_repo = self._raw_pr.head.repo
-
-            self._source_project = ogr_github.GithubProject(
-                repo=src_github_repo.name,
-                service=self._target_project.service,
-                namespace=src_github_repo.owner.login,
-                github_repo=src_github_repo,
-                read_only=self._target_project.service.read_only,
+            self._source_project = self._target_project.service.get_project_from_github_repository(
+                self._raw_pr.head.repo
             )
+
         return self._source_project
 
     def __str__(self) -> str:

--- a/ogr/services/github/pull_request.py
+++ b/ogr/services/github/pull_request.py
@@ -101,6 +101,9 @@ class GithubPullRequest(BasePullRequest):
     def head_commit(self) -> str:
         return self._raw_pr.head.sha
 
+    def source_project(self) -> "ogr_github.GithubProject":
+        raise NotImplementedError()
+
     def __str__(self) -> str:
         return "Github" + super().__str__()
 

--- a/ogr/services/github/service.py
+++ b/ogr/services/github/service.py
@@ -142,6 +142,17 @@ class GithubService(BaseGitService):
             **kwargs,
         )
 
+    def get_project_from_github_repository(
+        self, github_repo: github.Repository.Repository
+    ) -> "GithubProject":
+        return GithubProject(
+            repo=github_repo.name,
+            namespace=github_repo.owner.login,
+            github_repo=github_repo,
+            service=self,
+            read_only=self.read_only,
+        )
+
     @property
     def user(self) -> GitUser:
         return GithubUser(service=self)

--- a/ogr/services/gitlab/pull_request.py
+++ b/ogr/services/gitlab/pull_request.py
@@ -33,7 +33,8 @@ from ogr.services.gitlab.comments import GitlabPRComment
 
 class GitlabPullRequest(BasePullRequest):
     _raw_pr: _GitlabMergeRequest
-    project: "ogr_gitlab.GitlabProject"
+    _target_project: "ogr_gitlab.GitlabProject"
+    _source_project: "ogr_gitlab.GitlabProject" = None
 
     @property
     def title(self) -> str:
@@ -97,8 +98,14 @@ class GitlabPullRequest(BasePullRequest):
     def head_commit(self) -> str:
         return self._raw_pr.sha
 
+    @property
     def source_project(self) -> "ogr_gitlab.GitlabProject":
-        raise NotImplementedError()
+        if self._source_project is None:
+            source_project_id = self._raw_pr.attributes["source_project_id"]
+            self._source_project = self._target_project.service.get_project(
+                iid=source_project_id
+            )
+        return self._source_project
 
     def __str__(self) -> str:
         return "Gitlab" + super().__str__()

--- a/ogr/services/gitlab/pull_request.py
+++ b/ogr/services/gitlab/pull_request.py
@@ -101,9 +101,8 @@ class GitlabPullRequest(BasePullRequest):
     @property
     def source_project(self) -> "ogr_gitlab.GitlabProject":
         if self._source_project is None:
-            source_project_id = self._raw_pr.attributes["source_project_id"]
-            self._source_project = self._target_project.service.get_project(
-                iid=source_project_id
+            self._source_project = self._target_project.service.get_project_from_project_id(
+                self._raw_pr.attributes["source_project_id"]
             )
         return self._source_project
 

--- a/ogr/services/gitlab/pull_request.py
+++ b/ogr/services/gitlab/pull_request.py
@@ -97,6 +97,9 @@ class GitlabPullRequest(BasePullRequest):
     def head_commit(self) -> str:
         return self._raw_pr.sha
 
+    def source_project(self) -> "ogr_gitlab.GitlabProject":
+        raise NotImplementedError()
+
     def __str__(self) -> str:
         return "Gitlab" + super().__str__()
 

--- a/ogr/services/gitlab/service.py
+++ b/ogr/services/gitlab/service.py
@@ -81,8 +81,17 @@ class GitlabService(GitService):
         return hash(str(self))
 
     def get_project(
-        self, repo=None, namespace=None, is_fork=False, **kwargs
+        self, repo=None, namespace=None, is_fork=False, iid=None, **kwargs
     ) -> "GitlabProject":
+        if iid is not None:
+            gitlab_repo = self.gitlab_instance.projects.get(iid)
+            return GitlabProject(
+                repo=gitlab_repo.attributes["path"],
+                namespace=gitlab_repo.attributes["namespace"]["full_path"],
+                service=self,
+                gitlab_repo=gitlab_repo,
+            )
+
         if is_fork:
             namespace = self.user.get_username()
         return GitlabProject(repo=repo, namespace=namespace, service=self, **kwargs)

--- a/ogr/services/gitlab/service.py
+++ b/ogr/services/gitlab/service.py
@@ -81,20 +81,20 @@ class GitlabService(GitService):
         return hash(str(self))
 
     def get_project(
-        self, repo=None, namespace=None, is_fork=False, iid=None, **kwargs
+        self, repo=None, namespace=None, is_fork=False, **kwargs
     ) -> "GitlabProject":
-        if iid is not None:
-            gitlab_repo = self.gitlab_instance.projects.get(iid)
-            return GitlabProject(
-                repo=gitlab_repo.attributes["path"],
-                namespace=gitlab_repo.attributes["namespace"]["full_path"],
-                service=self,
-                gitlab_repo=gitlab_repo,
-            )
-
         if is_fork:
             namespace = self.user.get_username()
         return GitlabProject(repo=repo, namespace=namespace, service=self, **kwargs)
+
+    def get_project_from_project_id(self, iid: int) -> "GitlabProject":
+        gitlab_repo = self.gitlab_instance.projects.get(iid)
+        return GitlabProject(
+            repo=gitlab_repo.attributes["path"],
+            namespace=gitlab_repo.attributes["namespace"]["full_path"],
+            service=self,
+            gitlab_repo=gitlab_repo,
+        )
 
     def change_token(self, new_token: str) -> None:
         self.token = new_token

--- a/ogr/services/pagure/pull_request.py
+++ b/ogr/services/pagure/pull_request.py
@@ -108,6 +108,10 @@ class PagurePullRequest(BasePullRequest):
     def head_commit(self) -> str:
         return self._raw_pr["commit_stop"]
 
+    @property
+    def source_project(self) -> "ogr_pagure.PagureProject":
+        raise NotImplementedError()
+
     def __str__(self) -> str:
         return "Pagure" + super().__str__()
 

--- a/tests/integration/test_data/test_github/tests.integration.test_github.PullRequests.test_source_project_fork_fork.yaml
+++ b/tests/integration/test_data/test_github/tests.integration.test_github.PullRequests.test_source_project_fork_fork.yaml
@@ -1,0 +1,758 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectFull
+  version_storage_file: 2
+unittest.case:
+  tests.integration.test_github:
+    ogr.services.github.project:
+      ogr.services.github.pull_request:
+        github.Repository:
+          github.Requester:
+            requests.sessions:
+              requre.objects:
+                requests.sessions:
+                  send:
+                  - metadata:
+                      latency: 0.32935333251953125
+                      module_call_list:
+                      - unittest.case
+                      - tests.integration.test_github
+                      - ogr.services.github.project
+                      - ogr.services.github.pull_request
+                      - github.Repository
+                      - github.Requester
+                      - requests.sessions
+                      - requre.objects
+                      - requests.sessions
+                      - send
+                    output:
+                      __store_indicator: 2
+                      _content:
+                        _links:
+                          comments:
+                            href: https://api.github.com/repos/mfocko/hello-world/issues/1/comments
+                          commits:
+                            href: https://api.github.com/repos/mfocko/hello-world/pulls/1/commits
+                          html:
+                            href: https://github.com/mfocko/hello-world/pull/1
+                          issue:
+                            href: https://api.github.com/repos/mfocko/hello-world/issues/1
+                          review_comment:
+                            href: https://api.github.com/repos/mfocko/hello-world/pulls/comments{/number}
+                          review_comments:
+                            href: https://api.github.com/repos/mfocko/hello-world/pulls/1/comments
+                          self:
+                            href: https://api.github.com/repos/mfocko/hello-world/pulls/1
+                          statuses:
+                            href: https://api.github.com/repos/mfocko/hello-world/statuses/cecb73fad313fd3f23b5a0da718937c358d6e952
+                        additions: 0
+                        assignee: null
+                        assignees: []
+                        author_association: OWNER
+                        base:
+                          label: mfocko:master
+                          ref: master
+                          repo:
+                            archive_url: https://api.github.com/repos/mfocko/hello-world/{archive_format}{/ref}
+                            archived: false
+                            assignees_url: https://api.github.com/repos/mfocko/hello-world/assignees{/user}
+                            blobs_url: https://api.github.com/repos/mfocko/hello-world/git/blobs{/sha}
+                            branches_url: https://api.github.com/repos/mfocko/hello-world/branches{/branch}
+                            clone_url: https://github.com/mfocko/hello-world.git
+                            collaborators_url: https://api.github.com/repos/mfocko/hello-world/collaborators{/collaborator}
+                            comments_url: https://api.github.com/repos/mfocko/hello-world/comments{/number}
+                            commits_url: https://api.github.com/repos/mfocko/hello-world/commits{/sha}
+                            compare_url: https://api.github.com/repos/mfocko/hello-world/compare/{base}...{head}
+                            contents_url: https://api.github.com/repos/mfocko/hello-world/contents/{+path}
+                            contributors_url: https://api.github.com/repos/mfocko/hello-world/contributors
+                            created_at: '2019-11-26T18:49:42Z'
+                            default_branch: master
+                            deployments_url: https://api.github.com/repos/mfocko/hello-world/deployments
+                            description: The most progresive command-line tool in
+                              the world.
+                            disabled: false
+                            downloads_url: https://api.github.com/repos/mfocko/hello-world/downloads
+                            events_url: https://api.github.com/repos/mfocko/hello-world/events
+                            fork: true
+                            forks: 0
+                            forks_count: 0
+                            forks_url: https://api.github.com/repos/mfocko/hello-world/forks
+                            full_name: mfocko/hello-world
+                            git_commits_url: https://api.github.com/repos/mfocko/hello-world/git/commits{/sha}
+                            git_refs_url: https://api.github.com/repos/mfocko/hello-world/git/refs{/sha}
+                            git_tags_url: https://api.github.com/repos/mfocko/hello-world/git/tags{/sha}
+                            git_url: git://github.com/mfocko/hello-world.git
+                            has_downloads: true
+                            has_issues: false
+                            has_pages: false
+                            has_projects: true
+                            has_wiki: true
+                            homepage: null
+                            hooks_url: https://api.github.com/repos/mfocko/hello-world/hooks
+                            html_url: https://github.com/mfocko/hello-world
+                            id: 224263392
+                            issue_comment_url: https://api.github.com/repos/mfocko/hello-world/issues/comments{/number}
+                            issue_events_url: https://api.github.com/repos/mfocko/hello-world/issues/events{/number}
+                            issues_url: https://api.github.com/repos/mfocko/hello-world/issues{/number}
+                            keys_url: https://api.github.com/repos/mfocko/hello-world/keys{/key_id}
+                            labels_url: https://api.github.com/repos/mfocko/hello-world/labels{/name}
+                            language: null
+                            languages_url: https://api.github.com/repos/mfocko/hello-world/languages
+                            license:
+                              key: mit
+                              name: MIT License
+                              node_id: MDc6TGljZW5zZTEz
+                              spdx_id: MIT
+                              url: https://api.github.com/licenses/mit
+                            merges_url: https://api.github.com/repos/mfocko/hello-world/merges
+                            milestones_url: https://api.github.com/repos/mfocko/hello-world/milestones{/number}
+                            mirror_url: null
+                            name: hello-world
+                            node_id: MDEwOlJlcG9zaXRvcnkyMjQyNjMzOTI=
+                            notifications_url: https://api.github.com/repos/mfocko/hello-world/notifications{?since,all,participating}
+                            open_issues: 1
+                            open_issues_count: 1
+                            owner:
+                              avatar_url: https://avatars0.githubusercontent.com/u/8149784?v=4
+                              events_url: https://api.github.com/users/mfocko/events{/privacy}
+                              followers_url: https://api.github.com/users/mfocko/followers
+                              following_url: https://api.github.com/users/mfocko/following{/other_user}
+                              gists_url: https://api.github.com/users/mfocko/gists{/gist_id}
+                              gravatar_id: ''
+                              html_url: https://github.com/mfocko
+                              id: 8149784
+                              login: mfocko
+                              node_id: MDQ6VXNlcjgxNDk3ODQ=
+                              organizations_url: https://api.github.com/users/mfocko/orgs
+                              received_events_url: https://api.github.com/users/mfocko/received_events
+                              repos_url: https://api.github.com/users/mfocko/repos
+                              site_admin: false
+                              starred_url: https://api.github.com/users/mfocko/starred{/owner}{/repo}
+                              subscriptions_url: https://api.github.com/users/mfocko/subscriptions
+                              type: User
+                              url: https://api.github.com/users/mfocko
+                            private: false
+                            pulls_url: https://api.github.com/repos/mfocko/hello-world/pulls{/number}
+                            pushed_at: '2020-04-28T18:55:31Z'
+                            releases_url: https://api.github.com/repos/mfocko/hello-world/releases{/id}
+                            size: 16
+                            ssh_url: git@github.com:mfocko/hello-world.git
+                            stargazers_count: 0
+                            stargazers_url: https://api.github.com/repos/mfocko/hello-world/stargazers
+                            statuses_url: https://api.github.com/repos/mfocko/hello-world/statuses/{sha}
+                            subscribers_url: https://api.github.com/repos/mfocko/hello-world/subscribers
+                            subscription_url: https://api.github.com/repos/mfocko/hello-world/subscription
+                            svn_url: https://github.com/mfocko/hello-world
+                            tags_url: https://api.github.com/repos/mfocko/hello-world/tags
+                            teams_url: https://api.github.com/repos/mfocko/hello-world/teams
+                            trees_url: https://api.github.com/repos/mfocko/hello-world/git/trees{/sha}
+                            updated_at: '2019-11-26T18:49:44Z'
+                            url: https://api.github.com/repos/mfocko/hello-world
+                            watchers: 0
+                            watchers_count: 0
+                          sha: 28d30dd1178b9983a0b717c809895500b2a3583b
+                          user:
+                            avatar_url: https://avatars0.githubusercontent.com/u/8149784?v=4
+                            events_url: https://api.github.com/users/mfocko/events{/privacy}
+                            followers_url: https://api.github.com/users/mfocko/followers
+                            following_url: https://api.github.com/users/mfocko/following{/other_user}
+                            gists_url: https://api.github.com/users/mfocko/gists{/gist_id}
+                            gravatar_id: ''
+                            html_url: https://github.com/mfocko
+                            id: 8149784
+                            login: mfocko
+                            node_id: MDQ6VXNlcjgxNDk3ODQ=
+                            organizations_url: https://api.github.com/users/mfocko/orgs
+                            received_events_url: https://api.github.com/users/mfocko/received_events
+                            repos_url: https://api.github.com/users/mfocko/repos
+                            site_admin: false
+                            starred_url: https://api.github.com/users/mfocko/starred{/owner}{/repo}
+                            subscriptions_url: https://api.github.com/users/mfocko/subscriptions
+                            type: User
+                            url: https://api.github.com/users/mfocko
+                        body: ''
+                        changed_files: 0
+                        closed_at: null
+                        comments: 0
+                        comments_url: https://api.github.com/repos/mfocko/hello-world/issues/1/comments
+                        commits: 1
+                        commits_url: https://api.github.com/repos/mfocko/hello-world/pulls/1/commits
+                        created_at: '2020-04-28T18:55:31Z'
+                        deletions: 0
+                        diff_url: https://github.com/mfocko/hello-world/pull/1.diff
+                        draft: false
+                        head:
+                          label: mfocko:rfe-new
+                          ref: rfe-new
+                          repo:
+                            archive_url: https://api.github.com/repos/mfocko/hello-world/{archive_format}{/ref}
+                            archived: false
+                            assignees_url: https://api.github.com/repos/mfocko/hello-world/assignees{/user}
+                            blobs_url: https://api.github.com/repos/mfocko/hello-world/git/blobs{/sha}
+                            branches_url: https://api.github.com/repos/mfocko/hello-world/branches{/branch}
+                            clone_url: https://github.com/mfocko/hello-world.git
+                            collaborators_url: https://api.github.com/repos/mfocko/hello-world/collaborators{/collaborator}
+                            comments_url: https://api.github.com/repos/mfocko/hello-world/comments{/number}
+                            commits_url: https://api.github.com/repos/mfocko/hello-world/commits{/sha}
+                            compare_url: https://api.github.com/repos/mfocko/hello-world/compare/{base}...{head}
+                            contents_url: https://api.github.com/repos/mfocko/hello-world/contents/{+path}
+                            contributors_url: https://api.github.com/repos/mfocko/hello-world/contributors
+                            created_at: '2019-11-26T18:49:42Z'
+                            default_branch: master
+                            deployments_url: https://api.github.com/repos/mfocko/hello-world/deployments
+                            description: The most progresive command-line tool in
+                              the world.
+                            disabled: false
+                            downloads_url: https://api.github.com/repos/mfocko/hello-world/downloads
+                            events_url: https://api.github.com/repos/mfocko/hello-world/events
+                            fork: true
+                            forks: 0
+                            forks_count: 0
+                            forks_url: https://api.github.com/repos/mfocko/hello-world/forks
+                            full_name: mfocko/hello-world
+                            git_commits_url: https://api.github.com/repos/mfocko/hello-world/git/commits{/sha}
+                            git_refs_url: https://api.github.com/repos/mfocko/hello-world/git/refs{/sha}
+                            git_tags_url: https://api.github.com/repos/mfocko/hello-world/git/tags{/sha}
+                            git_url: git://github.com/mfocko/hello-world.git
+                            has_downloads: true
+                            has_issues: false
+                            has_pages: false
+                            has_projects: true
+                            has_wiki: true
+                            homepage: null
+                            hooks_url: https://api.github.com/repos/mfocko/hello-world/hooks
+                            html_url: https://github.com/mfocko/hello-world
+                            id: 224263392
+                            issue_comment_url: https://api.github.com/repos/mfocko/hello-world/issues/comments{/number}
+                            issue_events_url: https://api.github.com/repos/mfocko/hello-world/issues/events{/number}
+                            issues_url: https://api.github.com/repos/mfocko/hello-world/issues{/number}
+                            keys_url: https://api.github.com/repos/mfocko/hello-world/keys{/key_id}
+                            labels_url: https://api.github.com/repos/mfocko/hello-world/labels{/name}
+                            language: null
+                            languages_url: https://api.github.com/repos/mfocko/hello-world/languages
+                            license:
+                              key: mit
+                              name: MIT License
+                              node_id: MDc6TGljZW5zZTEz
+                              spdx_id: MIT
+                              url: https://api.github.com/licenses/mit
+                            merges_url: https://api.github.com/repos/mfocko/hello-world/merges
+                            milestones_url: https://api.github.com/repos/mfocko/hello-world/milestones{/number}
+                            mirror_url: null
+                            name: hello-world
+                            node_id: MDEwOlJlcG9zaXRvcnkyMjQyNjMzOTI=
+                            notifications_url: https://api.github.com/repos/mfocko/hello-world/notifications{?since,all,participating}
+                            open_issues: 1
+                            open_issues_count: 1
+                            owner:
+                              avatar_url: https://avatars0.githubusercontent.com/u/8149784?v=4
+                              events_url: https://api.github.com/users/mfocko/events{/privacy}
+                              followers_url: https://api.github.com/users/mfocko/followers
+                              following_url: https://api.github.com/users/mfocko/following{/other_user}
+                              gists_url: https://api.github.com/users/mfocko/gists{/gist_id}
+                              gravatar_id: ''
+                              html_url: https://github.com/mfocko
+                              id: 8149784
+                              login: mfocko
+                              node_id: MDQ6VXNlcjgxNDk3ODQ=
+                              organizations_url: https://api.github.com/users/mfocko/orgs
+                              received_events_url: https://api.github.com/users/mfocko/received_events
+                              repos_url: https://api.github.com/users/mfocko/repos
+                              site_admin: false
+                              starred_url: https://api.github.com/users/mfocko/starred{/owner}{/repo}
+                              subscriptions_url: https://api.github.com/users/mfocko/subscriptions
+                              type: User
+                              url: https://api.github.com/users/mfocko
+                            private: false
+                            pulls_url: https://api.github.com/repos/mfocko/hello-world/pulls{/number}
+                            pushed_at: '2020-04-28T18:55:31Z'
+                            releases_url: https://api.github.com/repos/mfocko/hello-world/releases{/id}
+                            size: 16
+                            ssh_url: git@github.com:mfocko/hello-world.git
+                            stargazers_count: 0
+                            stargazers_url: https://api.github.com/repos/mfocko/hello-world/stargazers
+                            statuses_url: https://api.github.com/repos/mfocko/hello-world/statuses/{sha}
+                            subscribers_url: https://api.github.com/repos/mfocko/hello-world/subscribers
+                            subscription_url: https://api.github.com/repos/mfocko/hello-world/subscription
+                            svn_url: https://github.com/mfocko/hello-world
+                            tags_url: https://api.github.com/repos/mfocko/hello-world/tags
+                            teams_url: https://api.github.com/repos/mfocko/hello-world/teams
+                            trees_url: https://api.github.com/repos/mfocko/hello-world/git/trees{/sha}
+                            updated_at: '2019-11-26T18:49:44Z'
+                            url: https://api.github.com/repos/mfocko/hello-world
+                            watchers: 0
+                            watchers_count: 0
+                          sha: cecb73fad313fd3f23b5a0da718937c358d6e952
+                          user:
+                            avatar_url: https://avatars0.githubusercontent.com/u/8149784?v=4
+                            events_url: https://api.github.com/users/mfocko/events{/privacy}
+                            followers_url: https://api.github.com/users/mfocko/followers
+                            following_url: https://api.github.com/users/mfocko/following{/other_user}
+                            gists_url: https://api.github.com/users/mfocko/gists{/gist_id}
+                            gravatar_id: ''
+                            html_url: https://github.com/mfocko
+                            id: 8149784
+                            login: mfocko
+                            node_id: MDQ6VXNlcjgxNDk3ODQ=
+                            organizations_url: https://api.github.com/users/mfocko/orgs
+                            received_events_url: https://api.github.com/users/mfocko/received_events
+                            repos_url: https://api.github.com/users/mfocko/repos
+                            site_admin: false
+                            starred_url: https://api.github.com/users/mfocko/starred{/owner}{/repo}
+                            subscriptions_url: https://api.github.com/users/mfocko/subscriptions
+                            type: User
+                            url: https://api.github.com/users/mfocko
+                        html_url: https://github.com/mfocko/hello-world/pull/1
+                        id: 410299046
+                        issue_url: https://api.github.com/repos/mfocko/hello-world/issues/1
+                        labels: []
+                        locked: false
+                        maintainer_can_modify: false
+                        merge_commit_sha: 64cacf9bc7c9bdc2fded02204de202a1778dadf4
+                        mergeable: true
+                        mergeable_state: clean
+                        merged: false
+                        merged_at: null
+                        merged_by: null
+                        milestone: null
+                        node_id: MDExOlB1bGxSZXF1ZXN0NDEwMjk5MDQ2
+                        number: 1
+                        patch_url: https://github.com/mfocko/hello-world/pull/1.patch
+                        rebaseable: true
+                        requested_reviewers: []
+                        requested_teams: []
+                        review_comment_url: https://api.github.com/repos/mfocko/hello-world/pulls/comments{/number}
+                        review_comments: 0
+                        review_comments_url: https://api.github.com/repos/mfocko/hello-world/pulls/1/comments
+                        state: open
+                        statuses_url: https://api.github.com/repos/mfocko/hello-world/statuses/cecb73fad313fd3f23b5a0da718937c358d6e952
+                        title: demo for passed results
+                        updated_at: '2020-04-28T18:55:31Z'
+                        url: https://api.github.com/repos/mfocko/hello-world/pulls/1
+                        user:
+                          avatar_url: https://avatars0.githubusercontent.com/u/8149784?v=4
+                          events_url: https://api.github.com/users/mfocko/events{/privacy}
+                          followers_url: https://api.github.com/users/mfocko/followers
+                          following_url: https://api.github.com/users/mfocko/following{/other_user}
+                          gists_url: https://api.github.com/users/mfocko/gists{/gist_id}
+                          gravatar_id: ''
+                          html_url: https://github.com/mfocko
+                          id: 8149784
+                          login: mfocko
+                          node_id: MDQ6VXNlcjgxNDk3ODQ=
+                          organizations_url: https://api.github.com/users/mfocko/orgs
+                          received_events_url: https://api.github.com/users/mfocko/received_events
+                          repos_url: https://api.github.com/users/mfocko/repos
+                          site_admin: false
+                          starred_url: https://api.github.com/users/mfocko/starred{/owner}{/repo}
+                          subscriptions_url: https://api.github.com/users/mfocko/subscriptions
+                          type: User
+                          url: https://api.github.com/users/mfocko
+                      _next: null
+                      elapsed: 0.2
+                      encoding: utf-8
+                      headers:
+                        Access-Control-Allow-Origin: '*'
+                        Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                          X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+                          X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+                          X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
+                        Cache-Control: private, max-age=60, s-maxage=60
+                        Content-Encoding: gzip
+                        Content-Security-Policy: default-src 'none'
+                        Content-Type: application/json; charset=utf-8
+                        Date: Fri, 01 Nov 2019 13-36-03 GMT
+                        ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                        Last-Modified: Tue, 28 Apr 2020 18:55:31 GMT
+                        Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                        Server: GitHub.com
+                        Status: 200 OK
+                        Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                          preload
+                        Transfer-Encoding: chunked
+                        Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                          Accept, X-Requested-With
+                        X-Accepted-OAuth-Scopes: ''
+                        X-Content-Type-Options: nosniff
+                        X-Frame-Options: deny
+                        X-GitHub-Media-Type: github.v3; format=json
+                        X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                        X-OAuth-Scopes: admin:enterprise, admin:gpg_key, admin:org,
+                          admin:org_hook, admin:public_key, admin:repo_hook, delete:packages,
+                          delete_repo, gist, notifications, read:packages, repo, user,
+                          workflow, write:discussion, write:packages
+                        X-RateLimit-Limit: '5000'
+                        X-RateLimit-Remaining: '4972'
+                        X-RateLimit-Reset: '1572953901'
+                        X-XSS-Protection: 1; mode=block
+                      raw: !!binary ""
+                      reason: OK
+                      status_code: 200
+        ogr.services.github.project:
+          github.MainClass:
+            github.Requester:
+              requests.sessions:
+                requre.objects:
+                  requests.sessions:
+                    send:
+                    - metadata:
+                        latency: 0.49669623374938965
+                        module_call_list:
+                        - unittest.case
+                        - tests.integration.test_github
+                        - ogr.services.github.project
+                        - ogr.services.github.pull_request
+                        - ogr.services.github.project
+                        - github.MainClass
+                        - github.Requester
+                        - requests.sessions
+                        - requre.objects
+                        - requests.sessions
+                        - send
+                      output:
+                        __store_indicator: 2
+                        _content:
+                          allow_merge_commit: true
+                          allow_rebase_merge: true
+                          allow_squash_merge: true
+                          archive_url: https://api.github.com/repos/mfocko/hello-world/{archive_format}{/ref}
+                          archived: false
+                          assignees_url: https://api.github.com/repos/mfocko/hello-world/assignees{/user}
+                          blobs_url: https://api.github.com/repos/mfocko/hello-world/git/blobs{/sha}
+                          branches_url: https://api.github.com/repos/mfocko/hello-world/branches{/branch}
+                          clone_url: https://github.com/mfocko/hello-world.git
+                          collaborators_url: https://api.github.com/repos/mfocko/hello-world/collaborators{/collaborator}
+                          comments_url: https://api.github.com/repos/mfocko/hello-world/comments{/number}
+                          commits_url: https://api.github.com/repos/mfocko/hello-world/commits{/sha}
+                          compare_url: https://api.github.com/repos/mfocko/hello-world/compare/{base}...{head}
+                          contents_url: https://api.github.com/repos/mfocko/hello-world/contents/{+path}
+                          contributors_url: https://api.github.com/repos/mfocko/hello-world/contributors
+                          created_at: '2019-11-26T18:49:42Z'
+                          default_branch: master
+                          delete_branch_on_merge: false
+                          deployments_url: https://api.github.com/repos/mfocko/hello-world/deployments
+                          description: The most progresive command-line tool in the
+                            world.
+                          disabled: false
+                          downloads_url: https://api.github.com/repos/mfocko/hello-world/downloads
+                          events_url: https://api.github.com/repos/mfocko/hello-world/events
+                          fork: true
+                          forks: 0
+                          forks_count: 0
+                          forks_url: https://api.github.com/repos/mfocko/hello-world/forks
+                          full_name: mfocko/hello-world
+                          git_commits_url: https://api.github.com/repos/mfocko/hello-world/git/commits{/sha}
+                          git_refs_url: https://api.github.com/repos/mfocko/hello-world/git/refs{/sha}
+                          git_tags_url: https://api.github.com/repos/mfocko/hello-world/git/tags{/sha}
+                          git_url: git://github.com/mfocko/hello-world.git
+                          has_downloads: true
+                          has_issues: false
+                          has_pages: false
+                          has_projects: true
+                          has_wiki: true
+                          homepage: null
+                          hooks_url: https://api.github.com/repos/mfocko/hello-world/hooks
+                          html_url: https://github.com/mfocko/hello-world
+                          id: 224263392
+                          issue_comment_url: https://api.github.com/repos/mfocko/hello-world/issues/comments{/number}
+                          issue_events_url: https://api.github.com/repos/mfocko/hello-world/issues/events{/number}
+                          issues_url: https://api.github.com/repos/mfocko/hello-world/issues{/number}
+                          keys_url: https://api.github.com/repos/mfocko/hello-world/keys{/key_id}
+                          labels_url: https://api.github.com/repos/mfocko/hello-world/labels{/name}
+                          language: null
+                          languages_url: https://api.github.com/repos/mfocko/hello-world/languages
+                          license:
+                            key: mit
+                            name: MIT License
+                            node_id: MDc6TGljZW5zZTEz
+                            spdx_id: MIT
+                            url: https://api.github.com/licenses/mit
+                          merges_url: https://api.github.com/repos/mfocko/hello-world/merges
+                          milestones_url: https://api.github.com/repos/mfocko/hello-world/milestones{/number}
+                          mirror_url: null
+                          name: hello-world
+                          network_count: 17
+                          node_id: MDEwOlJlcG9zaXRvcnkyMjQyNjMzOTI=
+                          notifications_url: https://api.github.com/repos/mfocko/hello-world/notifications{?since,all,participating}
+                          open_issues: 1
+                          open_issues_count: 1
+                          owner:
+                            avatar_url: https://avatars0.githubusercontent.com/u/8149784?v=4
+                            events_url: https://api.github.com/users/mfocko/events{/privacy}
+                            followers_url: https://api.github.com/users/mfocko/followers
+                            following_url: https://api.github.com/users/mfocko/following{/other_user}
+                            gists_url: https://api.github.com/users/mfocko/gists{/gist_id}
+                            gravatar_id: ''
+                            html_url: https://github.com/mfocko
+                            id: 8149784
+                            login: mfocko
+                            node_id: MDQ6VXNlcjgxNDk3ODQ=
+                            organizations_url: https://api.github.com/users/mfocko/orgs
+                            received_events_url: https://api.github.com/users/mfocko/received_events
+                            repos_url: https://api.github.com/users/mfocko/repos
+                            site_admin: false
+                            starred_url: https://api.github.com/users/mfocko/starred{/owner}{/repo}
+                            subscriptions_url: https://api.github.com/users/mfocko/subscriptions
+                            type: User
+                            url: https://api.github.com/users/mfocko
+                          parent:
+                            archive_url: https://api.github.com/repos/packit-service/hello-world/{archive_format}{/ref}
+                            archived: false
+                            assignees_url: https://api.github.com/repos/packit-service/hello-world/assignees{/user}
+                            blobs_url: https://api.github.com/repos/packit-service/hello-world/git/blobs{/sha}
+                            branches_url: https://api.github.com/repos/packit-service/hello-world/branches{/branch}
+                            clone_url: https://github.com/packit-service/hello-world.git
+                            collaborators_url: https://api.github.com/repos/packit-service/hello-world/collaborators{/collaborator}
+                            comments_url: https://api.github.com/repos/packit-service/hello-world/comments{/number}
+                            commits_url: https://api.github.com/repos/packit-service/hello-world/commits{/sha}
+                            compare_url: https://api.github.com/repos/packit-service/hello-world/compare/{base}...{head}
+                            contents_url: https://api.github.com/repos/packit-service/hello-world/contents/{+path}
+                            contributors_url: https://api.github.com/repos/packit-service/hello-world/contributors
+                            created_at: '2019-05-02T18:54:46Z'
+                            default_branch: master
+                            deployments_url: https://api.github.com/repos/packit-service/hello-world/deployments
+                            description: The most progresive command-line tool in
+                              the world.
+                            disabled: false
+                            downloads_url: https://api.github.com/repos/packit-service/hello-world/downloads
+                            events_url: https://api.github.com/repos/packit-service/hello-world/events
+                            fork: false
+                            forks: 17
+                            forks_count: 17
+                            forks_url: https://api.github.com/repos/packit-service/hello-world/forks
+                            full_name: packit-service/hello-world
+                            git_commits_url: https://api.github.com/repos/packit-service/hello-world/git/commits{/sha}
+                            git_refs_url: https://api.github.com/repos/packit-service/hello-world/git/refs{/sha}
+                            git_tags_url: https://api.github.com/repos/packit-service/hello-world/git/tags{/sha}
+                            git_url: git://github.com/packit-service/hello-world.git
+                            has_downloads: true
+                            has_issues: true
+                            has_pages: false
+                            has_projects: true
+                            has_wiki: true
+                            homepage: null
+                            hooks_url: https://api.github.com/repos/packit-service/hello-world/hooks
+                            html_url: https://github.com/packit-service/hello-world
+                            id: 184635124
+                            issue_comment_url: https://api.github.com/repos/packit-service/hello-world/issues/comments{/number}
+                            issue_events_url: https://api.github.com/repos/packit-service/hello-world/issues/events{/number}
+                            issues_url: https://api.github.com/repos/packit-service/hello-world/issues{/number}
+                            keys_url: https://api.github.com/repos/packit-service/hello-world/keys{/key_id}
+                            labels_url: https://api.github.com/repos/packit-service/hello-world/labels{/name}
+                            language: Python
+                            languages_url: https://api.github.com/repos/packit-service/hello-world/languages
+                            license:
+                              key: mit
+                              name: MIT License
+                              node_id: MDc6TGljZW5zZTEz
+                              spdx_id: MIT
+                              url: https://api.github.com/licenses/mit
+                            merges_url: https://api.github.com/repos/packit-service/hello-world/merges
+                            milestones_url: https://api.github.com/repos/packit-service/hello-world/milestones{/number}
+                            mirror_url: null
+                            name: hello-world
+                            node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+                            notifications_url: https://api.github.com/repos/packit-service/hello-world/notifications{?since,all,participating}
+                            open_issues: 22
+                            open_issues_count: 22
+                            owner:
+                              avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
+                              events_url: https://api.github.com/users/packit-service/events{/privacy}
+                              followers_url: https://api.github.com/users/packit-service/followers
+                              following_url: https://api.github.com/users/packit-service/following{/other_user}
+                              gists_url: https://api.github.com/users/packit-service/gists{/gist_id}
+                              gravatar_id: ''
+                              html_url: https://github.com/packit-service
+                              id: 46870917
+                              login: packit-service
+                              node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                              organizations_url: https://api.github.com/users/packit-service/orgs
+                              received_events_url: https://api.github.com/users/packit-service/received_events
+                              repos_url: https://api.github.com/users/packit-service/repos
+                              site_admin: false
+                              starred_url: https://api.github.com/users/packit-service/starred{/owner}{/repo}
+                              subscriptions_url: https://api.github.com/users/packit-service/subscriptions
+                              type: Organization
+                              url: https://api.github.com/users/packit-service
+                            private: false
+                            pulls_url: https://api.github.com/repos/packit-service/hello-world/pulls{/number}
+                            pushed_at: '2020-04-23T07:49:42Z'
+                            releases_url: https://api.github.com/repos/packit-service/hello-world/releases{/id}
+                            size: 22
+                            ssh_url: git@github.com:packit-service/hello-world.git
+                            stargazers_count: 0
+                            stargazers_url: https://api.github.com/repos/packit-service/hello-world/stargazers
+                            statuses_url: https://api.github.com/repos/packit-service/hello-world/statuses/{sha}
+                            subscribers_url: https://api.github.com/repos/packit-service/hello-world/subscribers
+                            subscription_url: https://api.github.com/repos/packit-service/hello-world/subscription
+                            svn_url: https://github.com/packit-service/hello-world
+                            tags_url: https://api.github.com/repos/packit-service/hello-world/tags
+                            teams_url: https://api.github.com/repos/packit-service/hello-world/teams
+                            trees_url: https://api.github.com/repos/packit-service/hello-world/git/trees{/sha}
+                            updated_at: '2020-04-03T14:38:55Z'
+                            url: https://api.github.com/repos/packit-service/hello-world
+                            watchers: 0
+                            watchers_count: 0
+                          permissions:
+                            admin: true
+                            pull: true
+                            push: true
+                          private: false
+                          pulls_url: https://api.github.com/repos/mfocko/hello-world/pulls{/number}
+                          pushed_at: '2020-04-28T18:55:31Z'
+                          releases_url: https://api.github.com/repos/mfocko/hello-world/releases{/id}
+                          size: 16
+                          source:
+                            archive_url: https://api.github.com/repos/packit-service/hello-world/{archive_format}{/ref}
+                            archived: false
+                            assignees_url: https://api.github.com/repos/packit-service/hello-world/assignees{/user}
+                            blobs_url: https://api.github.com/repos/packit-service/hello-world/git/blobs{/sha}
+                            branches_url: https://api.github.com/repos/packit-service/hello-world/branches{/branch}
+                            clone_url: https://github.com/packit-service/hello-world.git
+                            collaborators_url: https://api.github.com/repos/packit-service/hello-world/collaborators{/collaborator}
+                            comments_url: https://api.github.com/repos/packit-service/hello-world/comments{/number}
+                            commits_url: https://api.github.com/repos/packit-service/hello-world/commits{/sha}
+                            compare_url: https://api.github.com/repos/packit-service/hello-world/compare/{base}...{head}
+                            contents_url: https://api.github.com/repos/packit-service/hello-world/contents/{+path}
+                            contributors_url: https://api.github.com/repos/packit-service/hello-world/contributors
+                            created_at: '2019-05-02T18:54:46Z'
+                            default_branch: master
+                            deployments_url: https://api.github.com/repos/packit-service/hello-world/deployments
+                            description: The most progresive command-line tool in
+                              the world.
+                            disabled: false
+                            downloads_url: https://api.github.com/repos/packit-service/hello-world/downloads
+                            events_url: https://api.github.com/repos/packit-service/hello-world/events
+                            fork: false
+                            forks: 17
+                            forks_count: 17
+                            forks_url: https://api.github.com/repos/packit-service/hello-world/forks
+                            full_name: packit-service/hello-world
+                            git_commits_url: https://api.github.com/repos/packit-service/hello-world/git/commits{/sha}
+                            git_refs_url: https://api.github.com/repos/packit-service/hello-world/git/refs{/sha}
+                            git_tags_url: https://api.github.com/repos/packit-service/hello-world/git/tags{/sha}
+                            git_url: git://github.com/packit-service/hello-world.git
+                            has_downloads: true
+                            has_issues: true
+                            has_pages: false
+                            has_projects: true
+                            has_wiki: true
+                            homepage: null
+                            hooks_url: https://api.github.com/repos/packit-service/hello-world/hooks
+                            html_url: https://github.com/packit-service/hello-world
+                            id: 184635124
+                            issue_comment_url: https://api.github.com/repos/packit-service/hello-world/issues/comments{/number}
+                            issue_events_url: https://api.github.com/repos/packit-service/hello-world/issues/events{/number}
+                            issues_url: https://api.github.com/repos/packit-service/hello-world/issues{/number}
+                            keys_url: https://api.github.com/repos/packit-service/hello-world/keys{/key_id}
+                            labels_url: https://api.github.com/repos/packit-service/hello-world/labels{/name}
+                            language: Python
+                            languages_url: https://api.github.com/repos/packit-service/hello-world/languages
+                            license:
+                              key: mit
+                              name: MIT License
+                              node_id: MDc6TGljZW5zZTEz
+                              spdx_id: MIT
+                              url: https://api.github.com/licenses/mit
+                            merges_url: https://api.github.com/repos/packit-service/hello-world/merges
+                            milestones_url: https://api.github.com/repos/packit-service/hello-world/milestones{/number}
+                            mirror_url: null
+                            name: hello-world
+                            node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+                            notifications_url: https://api.github.com/repos/packit-service/hello-world/notifications{?since,all,participating}
+                            open_issues: 22
+                            open_issues_count: 22
+                            owner:
+                              avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
+                              events_url: https://api.github.com/users/packit-service/events{/privacy}
+                              followers_url: https://api.github.com/users/packit-service/followers
+                              following_url: https://api.github.com/users/packit-service/following{/other_user}
+                              gists_url: https://api.github.com/users/packit-service/gists{/gist_id}
+                              gravatar_id: ''
+                              html_url: https://github.com/packit-service
+                              id: 46870917
+                              login: packit-service
+                              node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                              organizations_url: https://api.github.com/users/packit-service/orgs
+                              received_events_url: https://api.github.com/users/packit-service/received_events
+                              repos_url: https://api.github.com/users/packit-service/repos
+                              site_admin: false
+                              starred_url: https://api.github.com/users/packit-service/starred{/owner}{/repo}
+                              subscriptions_url: https://api.github.com/users/packit-service/subscriptions
+                              type: Organization
+                              url: https://api.github.com/users/packit-service
+                            private: false
+                            pulls_url: https://api.github.com/repos/packit-service/hello-world/pulls{/number}
+                            pushed_at: '2020-04-23T07:49:42Z'
+                            releases_url: https://api.github.com/repos/packit-service/hello-world/releases{/id}
+                            size: 22
+                            ssh_url: git@github.com:packit-service/hello-world.git
+                            stargazers_count: 0
+                            stargazers_url: https://api.github.com/repos/packit-service/hello-world/stargazers
+                            statuses_url: https://api.github.com/repos/packit-service/hello-world/statuses/{sha}
+                            subscribers_url: https://api.github.com/repos/packit-service/hello-world/subscribers
+                            subscription_url: https://api.github.com/repos/packit-service/hello-world/subscription
+                            svn_url: https://github.com/packit-service/hello-world
+                            tags_url: https://api.github.com/repos/packit-service/hello-world/tags
+                            teams_url: https://api.github.com/repos/packit-service/hello-world/teams
+                            trees_url: https://api.github.com/repos/packit-service/hello-world/git/trees{/sha}
+                            updated_at: '2020-04-03T14:38:55Z'
+                            url: https://api.github.com/repos/packit-service/hello-world
+                            watchers: 0
+                            watchers_count: 0
+                          ssh_url: git@github.com:mfocko/hello-world.git
+                          stargazers_count: 0
+                          stargazers_url: https://api.github.com/repos/mfocko/hello-world/stargazers
+                          statuses_url: https://api.github.com/repos/mfocko/hello-world/statuses/{sha}
+                          subscribers_count: 0
+                          subscribers_url: https://api.github.com/repos/mfocko/hello-world/subscribers
+                          subscription_url: https://api.github.com/repos/mfocko/hello-world/subscription
+                          svn_url: https://github.com/mfocko/hello-world
+                          tags_url: https://api.github.com/repos/mfocko/hello-world/tags
+                          teams_url: https://api.github.com/repos/mfocko/hello-world/teams
+                          temp_clone_token: ''
+                          trees_url: https://api.github.com/repos/mfocko/hello-world/git/trees{/sha}
+                          updated_at: '2019-11-26T18:49:44Z'
+                          url: https://api.github.com/repos/mfocko/hello-world
+                          watchers: 0
+                          watchers_count: 0
+                        _next: null
+                        elapsed: 0.2
+                        encoding: utf-8
+                        headers:
+                          Access-Control-Allow-Origin: '*'
+                          Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                            X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+                            X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+                            X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
+                          Cache-Control: private, max-age=60, s-maxage=60
+                          Content-Encoding: gzip
+                          Content-Security-Policy: default-src 'none'
+                          Content-Type: application/json; charset=utf-8
+                          Date: Fri, 01 Nov 2019 13-36-03 GMT
+                          ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                          Last-Modified: Tue, 26 Nov 2019 18:49:44 GMT
+                          Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                          Server: GitHub.com
+                          Status: 200 OK
+                          Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                            preload
+                          Transfer-Encoding: chunked
+                          Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                            Accept, X-Requested-With
+                          X-Accepted-OAuth-Scopes: repo
+                          X-Content-Type-Options: nosniff
+                          X-Frame-Options: deny
+                          X-GitHub-Media-Type: github.v3; format=json
+                          X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                          X-OAuth-Scopes: admin:enterprise, admin:gpg_key, admin:org,
+                            admin:org_hook, admin:public_key, admin:repo_hook, delete:packages,
+                            delete_repo, gist, notifications, read:packages, repo,
+                            user, workflow, write:discussion, write:packages
+                          X-RateLimit-Limit: '5000'
+                          X-RateLimit-Remaining: '4972'
+                          X-RateLimit-Reset: '1572953901'
+                          X-XSS-Protection: 1; mode=block
+                        raw: !!binary ""
+                        reason: OK
+                        status_code: 200

--- a/tests/integration/test_data/test_github/tests.integration.test_github.PullRequests.test_source_project_other_fork_fork.yaml
+++ b/tests/integration/test_data/test_github/tests.integration.test_github.PullRequests.test_source_project_other_fork_fork.yaml
@@ -1,0 +1,754 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectFull
+  version_storage_file: 2
+unittest.case:
+  tests.integration.test_github:
+    ogr.services.github.project:
+      ogr.services.github.pull_request:
+        github.Repository:
+          github.Requester:
+            requests.sessions:
+              requre.objects:
+                requests.sessions:
+                  send:
+                  - metadata:
+                      latency: 0.40042662620544434
+                      module_call_list:
+                      - unittest.case
+                      - tests.integration.test_github
+                      - ogr.services.github.project
+                      - ogr.services.github.pull_request
+                      - github.Repository
+                      - github.Requester
+                      - requests.sessions
+                      - requre.objects
+                      - requests.sessions
+                      - send
+                    output:
+                      __store_indicator: 2
+                      _content:
+                        _links:
+                          comments:
+                            href: https://api.github.com/repos/lachmanfrantisek/hello-world/issues/1/comments
+                          commits:
+                            href: https://api.github.com/repos/lachmanfrantisek/hello-world/pulls/1/commits
+                          html:
+                            href: https://github.com/lachmanfrantisek/hello-world/pull/1
+                          issue:
+                            href: https://api.github.com/repos/lachmanfrantisek/hello-world/issues/1
+                          review_comment:
+                            href: https://api.github.com/repos/lachmanfrantisek/hello-world/pulls/comments{/number}
+                          review_comments:
+                            href: https://api.github.com/repos/lachmanfrantisek/hello-world/pulls/1/comments
+                          self:
+                            href: https://api.github.com/repos/lachmanfrantisek/hello-world/pulls/1
+                          statuses:
+                            href: https://api.github.com/repos/lachmanfrantisek/hello-world/statuses/cecb73fad313fd3f23b5a0da718937c358d6e952
+                        additions: 0
+                        assignee: null
+                        assignees: []
+                        author_association: NONE
+                        base:
+                          label: lachmanfrantisek:master
+                          ref: master
+                          repo:
+                            archive_url: https://api.github.com/repos/lachmanfrantisek/hello-world/{archive_format}{/ref}
+                            archived: false
+                            assignees_url: https://api.github.com/repos/lachmanfrantisek/hello-world/assignees{/user}
+                            blobs_url: https://api.github.com/repos/lachmanfrantisek/hello-world/git/blobs{/sha}
+                            branches_url: https://api.github.com/repos/lachmanfrantisek/hello-world/branches{/branch}
+                            clone_url: https://github.com/lachmanfrantisek/hello-world.git
+                            collaborators_url: https://api.github.com/repos/lachmanfrantisek/hello-world/collaborators{/collaborator}
+                            comments_url: https://api.github.com/repos/lachmanfrantisek/hello-world/comments{/number}
+                            commits_url: https://api.github.com/repos/lachmanfrantisek/hello-world/commits{/sha}
+                            compare_url: https://api.github.com/repos/lachmanfrantisek/hello-world/compare/{base}...{head}
+                            contents_url: https://api.github.com/repos/lachmanfrantisek/hello-world/contents/{+path}
+                            contributors_url: https://api.github.com/repos/lachmanfrantisek/hello-world/contributors
+                            created_at: '2019-12-06T11:37:26Z'
+                            default_branch: master
+                            deployments_url: https://api.github.com/repos/lachmanfrantisek/hello-world/deployments
+                            description: The most progresive command-line tool in
+                              the world.
+                            disabled: false
+                            downloads_url: https://api.github.com/repos/lachmanfrantisek/hello-world/downloads
+                            events_url: https://api.github.com/repos/lachmanfrantisek/hello-world/events
+                            fork: true
+                            forks: 0
+                            forks_count: 0
+                            forks_url: https://api.github.com/repos/lachmanfrantisek/hello-world/forks
+                            full_name: lachmanfrantisek/hello-world
+                            git_commits_url: https://api.github.com/repos/lachmanfrantisek/hello-world/git/commits{/sha}
+                            git_refs_url: https://api.github.com/repos/lachmanfrantisek/hello-world/git/refs{/sha}
+                            git_tags_url: https://api.github.com/repos/lachmanfrantisek/hello-world/git/tags{/sha}
+                            git_url: git://github.com/lachmanfrantisek/hello-world.git
+                            has_downloads: true
+                            has_issues: false
+                            has_pages: false
+                            has_projects: true
+                            has_wiki: true
+                            homepage: null
+                            hooks_url: https://api.github.com/repos/lachmanfrantisek/hello-world/hooks
+                            html_url: https://github.com/lachmanfrantisek/hello-world
+                            id: 226316621
+                            issue_comment_url: https://api.github.com/repos/lachmanfrantisek/hello-world/issues/comments{/number}
+                            issue_events_url: https://api.github.com/repos/lachmanfrantisek/hello-world/issues/events{/number}
+                            issues_url: https://api.github.com/repos/lachmanfrantisek/hello-world/issues{/number}
+                            keys_url: https://api.github.com/repos/lachmanfrantisek/hello-world/keys{/key_id}
+                            labels_url: https://api.github.com/repos/lachmanfrantisek/hello-world/labels{/name}
+                            language: null
+                            languages_url: https://api.github.com/repos/lachmanfrantisek/hello-world/languages
+                            license:
+                              key: mit
+                              name: MIT License
+                              node_id: MDc6TGljZW5zZTEz
+                              spdx_id: MIT
+                              url: https://api.github.com/licenses/mit
+                            merges_url: https://api.github.com/repos/lachmanfrantisek/hello-world/merges
+                            milestones_url: https://api.github.com/repos/lachmanfrantisek/hello-world/milestones{/number}
+                            mirror_url: null
+                            name: hello-world
+                            node_id: MDEwOlJlcG9zaXRvcnkyMjYzMTY2MjE=
+                            notifications_url: https://api.github.com/repos/lachmanfrantisek/hello-world/notifications{?since,all,participating}
+                            open_issues: 1
+                            open_issues_count: 1
+                            owner:
+                              avatar_url: https://avatars1.githubusercontent.com/u/20214043?v=4
+                              events_url: https://api.github.com/users/lachmanfrantisek/events{/privacy}
+                              followers_url: https://api.github.com/users/lachmanfrantisek/followers
+                              following_url: https://api.github.com/users/lachmanfrantisek/following{/other_user}
+                              gists_url: https://api.github.com/users/lachmanfrantisek/gists{/gist_id}
+                              gravatar_id: ''
+                              html_url: https://github.com/lachmanfrantisek
+                              id: 20214043
+                              login: lachmanfrantisek
+                              node_id: MDQ6VXNlcjIwMjE0MDQz
+                              organizations_url: https://api.github.com/users/lachmanfrantisek/orgs
+                              received_events_url: https://api.github.com/users/lachmanfrantisek/received_events
+                              repos_url: https://api.github.com/users/lachmanfrantisek/repos
+                              site_admin: false
+                              starred_url: https://api.github.com/users/lachmanfrantisek/starred{/owner}{/repo}
+                              subscriptions_url: https://api.github.com/users/lachmanfrantisek/subscriptions
+                              type: User
+                              url: https://api.github.com/users/lachmanfrantisek
+                            private: false
+                            pulls_url: https://api.github.com/repos/lachmanfrantisek/hello-world/pulls{/number}
+                            pushed_at: '2020-04-28T18:56:25Z'
+                            releases_url: https://api.github.com/repos/lachmanfrantisek/hello-world/releases{/id}
+                            size: 23
+                            ssh_url: git@github.com:lachmanfrantisek/hello-world.git
+                            stargazers_count: 0
+                            stargazers_url: https://api.github.com/repos/lachmanfrantisek/hello-world/stargazers
+                            statuses_url: https://api.github.com/repos/lachmanfrantisek/hello-world/statuses/{sha}
+                            subscribers_url: https://api.github.com/repos/lachmanfrantisek/hello-world/subscribers
+                            subscription_url: https://api.github.com/repos/lachmanfrantisek/hello-world/subscription
+                            svn_url: https://github.com/lachmanfrantisek/hello-world
+                            tags_url: https://api.github.com/repos/lachmanfrantisek/hello-world/tags
+                            teams_url: https://api.github.com/repos/lachmanfrantisek/hello-world/teams
+                            trees_url: https://api.github.com/repos/lachmanfrantisek/hello-world/git/trees{/sha}
+                            updated_at: '2019-12-06T11:37:29Z'
+                            url: https://api.github.com/repos/lachmanfrantisek/hello-world
+                            watchers: 0
+                            watchers_count: 0
+                          sha: 1b39c59761eb96e0a12870e0906551e74a34378c
+                          user:
+                            avatar_url: https://avatars1.githubusercontent.com/u/20214043?v=4
+                            events_url: https://api.github.com/users/lachmanfrantisek/events{/privacy}
+                            followers_url: https://api.github.com/users/lachmanfrantisek/followers
+                            following_url: https://api.github.com/users/lachmanfrantisek/following{/other_user}
+                            gists_url: https://api.github.com/users/lachmanfrantisek/gists{/gist_id}
+                            gravatar_id: ''
+                            html_url: https://github.com/lachmanfrantisek
+                            id: 20214043
+                            login: lachmanfrantisek
+                            node_id: MDQ6VXNlcjIwMjE0MDQz
+                            organizations_url: https://api.github.com/users/lachmanfrantisek/orgs
+                            received_events_url: https://api.github.com/users/lachmanfrantisek/received_events
+                            repos_url: https://api.github.com/users/lachmanfrantisek/repos
+                            site_admin: false
+                            starred_url: https://api.github.com/users/lachmanfrantisek/starred{/owner}{/repo}
+                            subscriptions_url: https://api.github.com/users/lachmanfrantisek/subscriptions
+                            type: User
+                            url: https://api.github.com/users/lachmanfrantisek
+                        body: ''
+                        changed_files: 0
+                        closed_at: null
+                        comments: 0
+                        comments_url: https://api.github.com/repos/lachmanfrantisek/hello-world/issues/1/comments
+                        commits: 1
+                        commits_url: https://api.github.com/repos/lachmanfrantisek/hello-world/pulls/1/commits
+                        created_at: '2020-04-28T18:56:25Z'
+                        deletions: 0
+                        diff_url: https://github.com/lachmanfrantisek/hello-world/pull/1.diff
+                        draft: false
+                        head:
+                          label: mfocko:rfe-new
+                          ref: rfe-new
+                          repo:
+                            archive_url: https://api.github.com/repos/mfocko/hello-world/{archive_format}{/ref}
+                            archived: false
+                            assignees_url: https://api.github.com/repos/mfocko/hello-world/assignees{/user}
+                            blobs_url: https://api.github.com/repos/mfocko/hello-world/git/blobs{/sha}
+                            branches_url: https://api.github.com/repos/mfocko/hello-world/branches{/branch}
+                            clone_url: https://github.com/mfocko/hello-world.git
+                            collaborators_url: https://api.github.com/repos/mfocko/hello-world/collaborators{/collaborator}
+                            comments_url: https://api.github.com/repos/mfocko/hello-world/comments{/number}
+                            commits_url: https://api.github.com/repos/mfocko/hello-world/commits{/sha}
+                            compare_url: https://api.github.com/repos/mfocko/hello-world/compare/{base}...{head}
+                            contents_url: https://api.github.com/repos/mfocko/hello-world/contents/{+path}
+                            contributors_url: https://api.github.com/repos/mfocko/hello-world/contributors
+                            created_at: '2019-11-26T18:49:42Z'
+                            default_branch: master
+                            deployments_url: https://api.github.com/repos/mfocko/hello-world/deployments
+                            description: The most progresive command-line tool in
+                              the world.
+                            disabled: false
+                            downloads_url: https://api.github.com/repos/mfocko/hello-world/downloads
+                            events_url: https://api.github.com/repos/mfocko/hello-world/events
+                            fork: true
+                            forks: 0
+                            forks_count: 0
+                            forks_url: https://api.github.com/repos/mfocko/hello-world/forks
+                            full_name: mfocko/hello-world
+                            git_commits_url: https://api.github.com/repos/mfocko/hello-world/git/commits{/sha}
+                            git_refs_url: https://api.github.com/repos/mfocko/hello-world/git/refs{/sha}
+                            git_tags_url: https://api.github.com/repos/mfocko/hello-world/git/tags{/sha}
+                            git_url: git://github.com/mfocko/hello-world.git
+                            has_downloads: true
+                            has_issues: false
+                            has_pages: false
+                            has_projects: true
+                            has_wiki: true
+                            homepage: null
+                            hooks_url: https://api.github.com/repos/mfocko/hello-world/hooks
+                            html_url: https://github.com/mfocko/hello-world
+                            id: 224263392
+                            issue_comment_url: https://api.github.com/repos/mfocko/hello-world/issues/comments{/number}
+                            issue_events_url: https://api.github.com/repos/mfocko/hello-world/issues/events{/number}
+                            issues_url: https://api.github.com/repos/mfocko/hello-world/issues{/number}
+                            keys_url: https://api.github.com/repos/mfocko/hello-world/keys{/key_id}
+                            labels_url: https://api.github.com/repos/mfocko/hello-world/labels{/name}
+                            language: null
+                            languages_url: https://api.github.com/repos/mfocko/hello-world/languages
+                            license:
+                              key: mit
+                              name: MIT License
+                              node_id: MDc6TGljZW5zZTEz
+                              spdx_id: MIT
+                              url: https://api.github.com/licenses/mit
+                            merges_url: https://api.github.com/repos/mfocko/hello-world/merges
+                            milestones_url: https://api.github.com/repos/mfocko/hello-world/milestones{/number}
+                            mirror_url: null
+                            name: hello-world
+                            node_id: MDEwOlJlcG9zaXRvcnkyMjQyNjMzOTI=
+                            notifications_url: https://api.github.com/repos/mfocko/hello-world/notifications{?since,all,participating}
+                            open_issues: 1
+                            open_issues_count: 1
+                            owner:
+                              avatar_url: https://avatars0.githubusercontent.com/u/8149784?v=4
+                              events_url: https://api.github.com/users/mfocko/events{/privacy}
+                              followers_url: https://api.github.com/users/mfocko/followers
+                              following_url: https://api.github.com/users/mfocko/following{/other_user}
+                              gists_url: https://api.github.com/users/mfocko/gists{/gist_id}
+                              gravatar_id: ''
+                              html_url: https://github.com/mfocko
+                              id: 8149784
+                              login: mfocko
+                              node_id: MDQ6VXNlcjgxNDk3ODQ=
+                              organizations_url: https://api.github.com/users/mfocko/orgs
+                              received_events_url: https://api.github.com/users/mfocko/received_events
+                              repos_url: https://api.github.com/users/mfocko/repos
+                              site_admin: false
+                              starred_url: https://api.github.com/users/mfocko/starred{/owner}{/repo}
+                              subscriptions_url: https://api.github.com/users/mfocko/subscriptions
+                              type: User
+                              url: https://api.github.com/users/mfocko
+                            private: false
+                            pulls_url: https://api.github.com/repos/mfocko/hello-world/pulls{/number}
+                            pushed_at: '2020-04-28T18:55:31Z'
+                            releases_url: https://api.github.com/repos/mfocko/hello-world/releases{/id}
+                            size: 16
+                            ssh_url: git@github.com:mfocko/hello-world.git
+                            stargazers_count: 0
+                            stargazers_url: https://api.github.com/repos/mfocko/hello-world/stargazers
+                            statuses_url: https://api.github.com/repos/mfocko/hello-world/statuses/{sha}
+                            subscribers_url: https://api.github.com/repos/mfocko/hello-world/subscribers
+                            subscription_url: https://api.github.com/repos/mfocko/hello-world/subscription
+                            svn_url: https://github.com/mfocko/hello-world
+                            tags_url: https://api.github.com/repos/mfocko/hello-world/tags
+                            teams_url: https://api.github.com/repos/mfocko/hello-world/teams
+                            trees_url: https://api.github.com/repos/mfocko/hello-world/git/trees{/sha}
+                            updated_at: '2019-11-26T18:49:44Z'
+                            url: https://api.github.com/repos/mfocko/hello-world
+                            watchers: 0
+                            watchers_count: 0
+                          sha: cecb73fad313fd3f23b5a0da718937c358d6e952
+                          user:
+                            avatar_url: https://avatars0.githubusercontent.com/u/8149784?v=4
+                            events_url: https://api.github.com/users/mfocko/events{/privacy}
+                            followers_url: https://api.github.com/users/mfocko/followers
+                            following_url: https://api.github.com/users/mfocko/following{/other_user}
+                            gists_url: https://api.github.com/users/mfocko/gists{/gist_id}
+                            gravatar_id: ''
+                            html_url: https://github.com/mfocko
+                            id: 8149784
+                            login: mfocko
+                            node_id: MDQ6VXNlcjgxNDk3ODQ=
+                            organizations_url: https://api.github.com/users/mfocko/orgs
+                            received_events_url: https://api.github.com/users/mfocko/received_events
+                            repos_url: https://api.github.com/users/mfocko/repos
+                            site_admin: false
+                            starred_url: https://api.github.com/users/mfocko/starred{/owner}{/repo}
+                            subscriptions_url: https://api.github.com/users/mfocko/subscriptions
+                            type: User
+                            url: https://api.github.com/users/mfocko
+                        html_url: https://github.com/lachmanfrantisek/hello-world/pull/1
+                        id: 410299454
+                        issue_url: https://api.github.com/repos/lachmanfrantisek/hello-world/issues/1
+                        labels: []
+                        locked: false
+                        maintainer_can_modify: true
+                        merge_commit_sha: 9d2a206e65d2287b5e4699f886229c7ceb8cbd11
+                        mergeable: true
+                        mergeable_state: clean
+                        merged: false
+                        merged_at: null
+                        merged_by: null
+                        milestone: null
+                        node_id: MDExOlB1bGxSZXF1ZXN0NDEwMjk5NDU0
+                        number: 1
+                        patch_url: https://github.com/lachmanfrantisek/hello-world/pull/1.patch
+                        rebaseable: true
+                        requested_reviewers: []
+                        requested_teams: []
+                        review_comment_url: https://api.github.com/repos/lachmanfrantisek/hello-world/pulls/comments{/number}
+                        review_comments: 0
+                        review_comments_url: https://api.github.com/repos/lachmanfrantisek/hello-world/pulls/1/comments
+                        state: open
+                        statuses_url: https://api.github.com/repos/lachmanfrantisek/hello-world/statuses/cecb73fad313fd3f23b5a0da718937c358d6e952
+                        title: test_source_project demo for passed results
+                        updated_at: '2020-04-28T18:56:25Z'
+                        url: https://api.github.com/repos/lachmanfrantisek/hello-world/pulls/1
+                        user:
+                          avatar_url: https://avatars0.githubusercontent.com/u/8149784?v=4
+                          events_url: https://api.github.com/users/mfocko/events{/privacy}
+                          followers_url: https://api.github.com/users/mfocko/followers
+                          following_url: https://api.github.com/users/mfocko/following{/other_user}
+                          gists_url: https://api.github.com/users/mfocko/gists{/gist_id}
+                          gravatar_id: ''
+                          html_url: https://github.com/mfocko
+                          id: 8149784
+                          login: mfocko
+                          node_id: MDQ6VXNlcjgxNDk3ODQ=
+                          organizations_url: https://api.github.com/users/mfocko/orgs
+                          received_events_url: https://api.github.com/users/mfocko/received_events
+                          repos_url: https://api.github.com/users/mfocko/repos
+                          site_admin: false
+                          starred_url: https://api.github.com/users/mfocko/starred{/owner}{/repo}
+                          subscriptions_url: https://api.github.com/users/mfocko/subscriptions
+                          type: User
+                          url: https://api.github.com/users/mfocko
+                      _next: null
+                      elapsed: 0.2
+                      encoding: utf-8
+                      headers:
+                        Access-Control-Allow-Origin: '*'
+                        Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                          X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+                          X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+                          X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
+                        Cache-Control: private, max-age=60, s-maxage=60
+                        Content-Encoding: gzip
+                        Content-Security-Policy: default-src 'none'
+                        Content-Type: application/json; charset=utf-8
+                        Date: Fri, 01 Nov 2019 13-36-03 GMT
+                        ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                        Last-Modified: Tue, 28 Apr 2020 18:56:25 GMT
+                        Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                        Server: GitHub.com
+                        Status: 200 OK
+                        Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                          preload
+                        Transfer-Encoding: chunked
+                        Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                          Accept, X-Requested-With
+                        X-Accepted-OAuth-Scopes: ''
+                        X-Content-Type-Options: nosniff
+                        X-Frame-Options: deny
+                        X-GitHub-Media-Type: github.v3; format=json
+                        X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                        X-OAuth-Scopes: admin:enterprise, admin:gpg_key, admin:org,
+                          admin:org_hook, admin:public_key, admin:repo_hook, delete:packages,
+                          delete_repo, gist, notifications, read:packages, repo, user,
+                          workflow, write:discussion, write:packages
+                        X-RateLimit-Limit: '5000'
+                        X-RateLimit-Remaining: '4972'
+                        X-RateLimit-Reset: '1572953901'
+                        X-XSS-Protection: 1; mode=block
+                      raw: !!binary ""
+                      reason: OK
+                      status_code: 200
+        ogr.services.github.project:
+          github.MainClass:
+            github.Requester:
+              requests.sessions:
+                requre.objects:
+                  requests.sessions:
+                    send:
+                    - metadata:
+                        latency: 0.3848443031311035
+                        module_call_list:
+                        - unittest.case
+                        - tests.integration.test_github
+                        - ogr.services.github.project
+                        - ogr.services.github.pull_request
+                        - ogr.services.github.project
+                        - github.MainClass
+                        - github.Requester
+                        - requests.sessions
+                        - requre.objects
+                        - requests.sessions
+                        - send
+                      output:
+                        __store_indicator: 2
+                        _content:
+                          archive_url: https://api.github.com/repos/lachmanfrantisek/hello-world/{archive_format}{/ref}
+                          archived: false
+                          assignees_url: https://api.github.com/repos/lachmanfrantisek/hello-world/assignees{/user}
+                          blobs_url: https://api.github.com/repos/lachmanfrantisek/hello-world/git/blobs{/sha}
+                          branches_url: https://api.github.com/repos/lachmanfrantisek/hello-world/branches{/branch}
+                          clone_url: https://github.com/lachmanfrantisek/hello-world.git
+                          collaborators_url: https://api.github.com/repos/lachmanfrantisek/hello-world/collaborators{/collaborator}
+                          comments_url: https://api.github.com/repos/lachmanfrantisek/hello-world/comments{/number}
+                          commits_url: https://api.github.com/repos/lachmanfrantisek/hello-world/commits{/sha}
+                          compare_url: https://api.github.com/repos/lachmanfrantisek/hello-world/compare/{base}...{head}
+                          contents_url: https://api.github.com/repos/lachmanfrantisek/hello-world/contents/{+path}
+                          contributors_url: https://api.github.com/repos/lachmanfrantisek/hello-world/contributors
+                          created_at: '2019-12-06T11:37:26Z'
+                          default_branch: master
+                          deployments_url: https://api.github.com/repos/lachmanfrantisek/hello-world/deployments
+                          description: The most progresive command-line tool in the
+                            world.
+                          disabled: false
+                          downloads_url: https://api.github.com/repos/lachmanfrantisek/hello-world/downloads
+                          events_url: https://api.github.com/repos/lachmanfrantisek/hello-world/events
+                          fork: true
+                          forks: 0
+                          forks_count: 0
+                          forks_url: https://api.github.com/repos/lachmanfrantisek/hello-world/forks
+                          full_name: lachmanfrantisek/hello-world
+                          git_commits_url: https://api.github.com/repos/lachmanfrantisek/hello-world/git/commits{/sha}
+                          git_refs_url: https://api.github.com/repos/lachmanfrantisek/hello-world/git/refs{/sha}
+                          git_tags_url: https://api.github.com/repos/lachmanfrantisek/hello-world/git/tags{/sha}
+                          git_url: git://github.com/lachmanfrantisek/hello-world.git
+                          has_downloads: true
+                          has_issues: false
+                          has_pages: false
+                          has_projects: true
+                          has_wiki: true
+                          homepage: null
+                          hooks_url: https://api.github.com/repos/lachmanfrantisek/hello-world/hooks
+                          html_url: https://github.com/lachmanfrantisek/hello-world
+                          id: 226316621
+                          issue_comment_url: https://api.github.com/repos/lachmanfrantisek/hello-world/issues/comments{/number}
+                          issue_events_url: https://api.github.com/repos/lachmanfrantisek/hello-world/issues/events{/number}
+                          issues_url: https://api.github.com/repos/lachmanfrantisek/hello-world/issues{/number}
+                          keys_url: https://api.github.com/repos/lachmanfrantisek/hello-world/keys{/key_id}
+                          labels_url: https://api.github.com/repos/lachmanfrantisek/hello-world/labels{/name}
+                          language: null
+                          languages_url: https://api.github.com/repos/lachmanfrantisek/hello-world/languages
+                          license:
+                            key: mit
+                            name: MIT License
+                            node_id: MDc6TGljZW5zZTEz
+                            spdx_id: MIT
+                            url: https://api.github.com/licenses/mit
+                          merges_url: https://api.github.com/repos/lachmanfrantisek/hello-world/merges
+                          milestones_url: https://api.github.com/repos/lachmanfrantisek/hello-world/milestones{/number}
+                          mirror_url: null
+                          name: hello-world
+                          network_count: 17
+                          node_id: MDEwOlJlcG9zaXRvcnkyMjYzMTY2MjE=
+                          notifications_url: https://api.github.com/repos/lachmanfrantisek/hello-world/notifications{?since,all,participating}
+                          open_issues: 1
+                          open_issues_count: 1
+                          owner:
+                            avatar_url: https://avatars1.githubusercontent.com/u/20214043?v=4
+                            events_url: https://api.github.com/users/lachmanfrantisek/events{/privacy}
+                            followers_url: https://api.github.com/users/lachmanfrantisek/followers
+                            following_url: https://api.github.com/users/lachmanfrantisek/following{/other_user}
+                            gists_url: https://api.github.com/users/lachmanfrantisek/gists{/gist_id}
+                            gravatar_id: ''
+                            html_url: https://github.com/lachmanfrantisek
+                            id: 20214043
+                            login: lachmanfrantisek
+                            node_id: MDQ6VXNlcjIwMjE0MDQz
+                            organizations_url: https://api.github.com/users/lachmanfrantisek/orgs
+                            received_events_url: https://api.github.com/users/lachmanfrantisek/received_events
+                            repos_url: https://api.github.com/users/lachmanfrantisek/repos
+                            site_admin: false
+                            starred_url: https://api.github.com/users/lachmanfrantisek/starred{/owner}{/repo}
+                            subscriptions_url: https://api.github.com/users/lachmanfrantisek/subscriptions
+                            type: User
+                            url: https://api.github.com/users/lachmanfrantisek
+                          parent:
+                            archive_url: https://api.github.com/repos/packit-service/hello-world/{archive_format}{/ref}
+                            archived: false
+                            assignees_url: https://api.github.com/repos/packit-service/hello-world/assignees{/user}
+                            blobs_url: https://api.github.com/repos/packit-service/hello-world/git/blobs{/sha}
+                            branches_url: https://api.github.com/repos/packit-service/hello-world/branches{/branch}
+                            clone_url: https://github.com/packit-service/hello-world.git
+                            collaborators_url: https://api.github.com/repos/packit-service/hello-world/collaborators{/collaborator}
+                            comments_url: https://api.github.com/repos/packit-service/hello-world/comments{/number}
+                            commits_url: https://api.github.com/repos/packit-service/hello-world/commits{/sha}
+                            compare_url: https://api.github.com/repos/packit-service/hello-world/compare/{base}...{head}
+                            contents_url: https://api.github.com/repos/packit-service/hello-world/contents/{+path}
+                            contributors_url: https://api.github.com/repos/packit-service/hello-world/contributors
+                            created_at: '2019-05-02T18:54:46Z'
+                            default_branch: master
+                            deployments_url: https://api.github.com/repos/packit-service/hello-world/deployments
+                            description: The most progresive command-line tool in
+                              the world.
+                            disabled: false
+                            downloads_url: https://api.github.com/repos/packit-service/hello-world/downloads
+                            events_url: https://api.github.com/repos/packit-service/hello-world/events
+                            fork: false
+                            forks: 17
+                            forks_count: 17
+                            forks_url: https://api.github.com/repos/packit-service/hello-world/forks
+                            full_name: packit-service/hello-world
+                            git_commits_url: https://api.github.com/repos/packit-service/hello-world/git/commits{/sha}
+                            git_refs_url: https://api.github.com/repos/packit-service/hello-world/git/refs{/sha}
+                            git_tags_url: https://api.github.com/repos/packit-service/hello-world/git/tags{/sha}
+                            git_url: git://github.com/packit-service/hello-world.git
+                            has_downloads: true
+                            has_issues: true
+                            has_pages: false
+                            has_projects: true
+                            has_wiki: true
+                            homepage: null
+                            hooks_url: https://api.github.com/repos/packit-service/hello-world/hooks
+                            html_url: https://github.com/packit-service/hello-world
+                            id: 184635124
+                            issue_comment_url: https://api.github.com/repos/packit-service/hello-world/issues/comments{/number}
+                            issue_events_url: https://api.github.com/repos/packit-service/hello-world/issues/events{/number}
+                            issues_url: https://api.github.com/repos/packit-service/hello-world/issues{/number}
+                            keys_url: https://api.github.com/repos/packit-service/hello-world/keys{/key_id}
+                            labels_url: https://api.github.com/repos/packit-service/hello-world/labels{/name}
+                            language: Python
+                            languages_url: https://api.github.com/repos/packit-service/hello-world/languages
+                            license:
+                              key: mit
+                              name: MIT License
+                              node_id: MDc6TGljZW5zZTEz
+                              spdx_id: MIT
+                              url: https://api.github.com/licenses/mit
+                            merges_url: https://api.github.com/repos/packit-service/hello-world/merges
+                            milestones_url: https://api.github.com/repos/packit-service/hello-world/milestones{/number}
+                            mirror_url: null
+                            name: hello-world
+                            node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+                            notifications_url: https://api.github.com/repos/packit-service/hello-world/notifications{?since,all,participating}
+                            open_issues: 22
+                            open_issues_count: 22
+                            owner:
+                              avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
+                              events_url: https://api.github.com/users/packit-service/events{/privacy}
+                              followers_url: https://api.github.com/users/packit-service/followers
+                              following_url: https://api.github.com/users/packit-service/following{/other_user}
+                              gists_url: https://api.github.com/users/packit-service/gists{/gist_id}
+                              gravatar_id: ''
+                              html_url: https://github.com/packit-service
+                              id: 46870917
+                              login: packit-service
+                              node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                              organizations_url: https://api.github.com/users/packit-service/orgs
+                              received_events_url: https://api.github.com/users/packit-service/received_events
+                              repos_url: https://api.github.com/users/packit-service/repos
+                              site_admin: false
+                              starred_url: https://api.github.com/users/packit-service/starred{/owner}{/repo}
+                              subscriptions_url: https://api.github.com/users/packit-service/subscriptions
+                              type: Organization
+                              url: https://api.github.com/users/packit-service
+                            private: false
+                            pulls_url: https://api.github.com/repos/packit-service/hello-world/pulls{/number}
+                            pushed_at: '2020-04-23T07:49:42Z'
+                            releases_url: https://api.github.com/repos/packit-service/hello-world/releases{/id}
+                            size: 22
+                            ssh_url: git@github.com:packit-service/hello-world.git
+                            stargazers_count: 0
+                            stargazers_url: https://api.github.com/repos/packit-service/hello-world/stargazers
+                            statuses_url: https://api.github.com/repos/packit-service/hello-world/statuses/{sha}
+                            subscribers_url: https://api.github.com/repos/packit-service/hello-world/subscribers
+                            subscription_url: https://api.github.com/repos/packit-service/hello-world/subscription
+                            svn_url: https://github.com/packit-service/hello-world
+                            tags_url: https://api.github.com/repos/packit-service/hello-world/tags
+                            teams_url: https://api.github.com/repos/packit-service/hello-world/teams
+                            trees_url: https://api.github.com/repos/packit-service/hello-world/git/trees{/sha}
+                            updated_at: '2020-04-03T14:38:55Z'
+                            url: https://api.github.com/repos/packit-service/hello-world
+                            watchers: 0
+                            watchers_count: 0
+                          permissions:
+                            admin: false
+                            pull: true
+                            push: false
+                          private: false
+                          pulls_url: https://api.github.com/repos/lachmanfrantisek/hello-world/pulls{/number}
+                          pushed_at: '2020-04-28T18:56:25Z'
+                          releases_url: https://api.github.com/repos/lachmanfrantisek/hello-world/releases{/id}
+                          size: 23
+                          source:
+                            archive_url: https://api.github.com/repos/packit-service/hello-world/{archive_format}{/ref}
+                            archived: false
+                            assignees_url: https://api.github.com/repos/packit-service/hello-world/assignees{/user}
+                            blobs_url: https://api.github.com/repos/packit-service/hello-world/git/blobs{/sha}
+                            branches_url: https://api.github.com/repos/packit-service/hello-world/branches{/branch}
+                            clone_url: https://github.com/packit-service/hello-world.git
+                            collaborators_url: https://api.github.com/repos/packit-service/hello-world/collaborators{/collaborator}
+                            comments_url: https://api.github.com/repos/packit-service/hello-world/comments{/number}
+                            commits_url: https://api.github.com/repos/packit-service/hello-world/commits{/sha}
+                            compare_url: https://api.github.com/repos/packit-service/hello-world/compare/{base}...{head}
+                            contents_url: https://api.github.com/repos/packit-service/hello-world/contents/{+path}
+                            contributors_url: https://api.github.com/repos/packit-service/hello-world/contributors
+                            created_at: '2019-05-02T18:54:46Z'
+                            default_branch: master
+                            deployments_url: https://api.github.com/repos/packit-service/hello-world/deployments
+                            description: The most progresive command-line tool in
+                              the world.
+                            disabled: false
+                            downloads_url: https://api.github.com/repos/packit-service/hello-world/downloads
+                            events_url: https://api.github.com/repos/packit-service/hello-world/events
+                            fork: false
+                            forks: 17
+                            forks_count: 17
+                            forks_url: https://api.github.com/repos/packit-service/hello-world/forks
+                            full_name: packit-service/hello-world
+                            git_commits_url: https://api.github.com/repos/packit-service/hello-world/git/commits{/sha}
+                            git_refs_url: https://api.github.com/repos/packit-service/hello-world/git/refs{/sha}
+                            git_tags_url: https://api.github.com/repos/packit-service/hello-world/git/tags{/sha}
+                            git_url: git://github.com/packit-service/hello-world.git
+                            has_downloads: true
+                            has_issues: true
+                            has_pages: false
+                            has_projects: true
+                            has_wiki: true
+                            homepage: null
+                            hooks_url: https://api.github.com/repos/packit-service/hello-world/hooks
+                            html_url: https://github.com/packit-service/hello-world
+                            id: 184635124
+                            issue_comment_url: https://api.github.com/repos/packit-service/hello-world/issues/comments{/number}
+                            issue_events_url: https://api.github.com/repos/packit-service/hello-world/issues/events{/number}
+                            issues_url: https://api.github.com/repos/packit-service/hello-world/issues{/number}
+                            keys_url: https://api.github.com/repos/packit-service/hello-world/keys{/key_id}
+                            labels_url: https://api.github.com/repos/packit-service/hello-world/labels{/name}
+                            language: Python
+                            languages_url: https://api.github.com/repos/packit-service/hello-world/languages
+                            license:
+                              key: mit
+                              name: MIT License
+                              node_id: MDc6TGljZW5zZTEz
+                              spdx_id: MIT
+                              url: https://api.github.com/licenses/mit
+                            merges_url: https://api.github.com/repos/packit-service/hello-world/merges
+                            milestones_url: https://api.github.com/repos/packit-service/hello-world/milestones{/number}
+                            mirror_url: null
+                            name: hello-world
+                            node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+                            notifications_url: https://api.github.com/repos/packit-service/hello-world/notifications{?since,all,participating}
+                            open_issues: 22
+                            open_issues_count: 22
+                            owner:
+                              avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
+                              events_url: https://api.github.com/users/packit-service/events{/privacy}
+                              followers_url: https://api.github.com/users/packit-service/followers
+                              following_url: https://api.github.com/users/packit-service/following{/other_user}
+                              gists_url: https://api.github.com/users/packit-service/gists{/gist_id}
+                              gravatar_id: ''
+                              html_url: https://github.com/packit-service
+                              id: 46870917
+                              login: packit-service
+                              node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                              organizations_url: https://api.github.com/users/packit-service/orgs
+                              received_events_url: https://api.github.com/users/packit-service/received_events
+                              repos_url: https://api.github.com/users/packit-service/repos
+                              site_admin: false
+                              starred_url: https://api.github.com/users/packit-service/starred{/owner}{/repo}
+                              subscriptions_url: https://api.github.com/users/packit-service/subscriptions
+                              type: Organization
+                              url: https://api.github.com/users/packit-service
+                            private: false
+                            pulls_url: https://api.github.com/repos/packit-service/hello-world/pulls{/number}
+                            pushed_at: '2020-04-23T07:49:42Z'
+                            releases_url: https://api.github.com/repos/packit-service/hello-world/releases{/id}
+                            size: 22
+                            ssh_url: git@github.com:packit-service/hello-world.git
+                            stargazers_count: 0
+                            stargazers_url: https://api.github.com/repos/packit-service/hello-world/stargazers
+                            statuses_url: https://api.github.com/repos/packit-service/hello-world/statuses/{sha}
+                            subscribers_url: https://api.github.com/repos/packit-service/hello-world/subscribers
+                            subscription_url: https://api.github.com/repos/packit-service/hello-world/subscription
+                            svn_url: https://github.com/packit-service/hello-world
+                            tags_url: https://api.github.com/repos/packit-service/hello-world/tags
+                            teams_url: https://api.github.com/repos/packit-service/hello-world/teams
+                            trees_url: https://api.github.com/repos/packit-service/hello-world/git/trees{/sha}
+                            updated_at: '2020-04-03T14:38:55Z'
+                            url: https://api.github.com/repos/packit-service/hello-world
+                            watchers: 0
+                            watchers_count: 0
+                          ssh_url: git@github.com:lachmanfrantisek/hello-world.git
+                          stargazers_count: 0
+                          stargazers_url: https://api.github.com/repos/lachmanfrantisek/hello-world/stargazers
+                          statuses_url: https://api.github.com/repos/lachmanfrantisek/hello-world/statuses/{sha}
+                          subscribers_count: 0
+                          subscribers_url: https://api.github.com/repos/lachmanfrantisek/hello-world/subscribers
+                          subscription_url: https://api.github.com/repos/lachmanfrantisek/hello-world/subscription
+                          svn_url: https://github.com/lachmanfrantisek/hello-world
+                          tags_url: https://api.github.com/repos/lachmanfrantisek/hello-world/tags
+                          teams_url: https://api.github.com/repos/lachmanfrantisek/hello-world/teams
+                          temp_clone_token: ''
+                          trees_url: https://api.github.com/repos/lachmanfrantisek/hello-world/git/trees{/sha}
+                          updated_at: '2019-12-06T11:37:29Z'
+                          url: https://api.github.com/repos/lachmanfrantisek/hello-world
+                          watchers: 0
+                          watchers_count: 0
+                        _next: null
+                        elapsed: 0.2
+                        encoding: utf-8
+                        headers:
+                          Access-Control-Allow-Origin: '*'
+                          Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                            X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+                            X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+                            X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
+                          Cache-Control: private, max-age=60, s-maxage=60
+                          Content-Encoding: gzip
+                          Content-Security-Policy: default-src 'none'
+                          Content-Type: application/json; charset=utf-8
+                          Date: Fri, 01 Nov 2019 13-36-03 GMT
+                          ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                          Last-Modified: Fri, 06 Dec 2019 11:37:29 GMT
+                          Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                          Server: GitHub.com
+                          Status: 200 OK
+                          Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                            preload
+                          Transfer-Encoding: chunked
+                          Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                            Accept, X-Requested-With
+                          X-Accepted-OAuth-Scopes: repo
+                          X-Content-Type-Options: nosniff
+                          X-Frame-Options: deny
+                          X-GitHub-Media-Type: github.v3; format=json
+                          X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                          X-OAuth-Scopes: admin:enterprise, admin:gpg_key, admin:org,
+                            admin:org_hook, admin:public_key, admin:repo_hook, delete:packages,
+                            delete_repo, gist, notifications, read:packages, repo,
+                            user, workflow, write:discussion, write:packages
+                          X-RateLimit-Limit: '5000'
+                          X-RateLimit-Remaining: '4972'
+                          X-RateLimit-Reset: '1572953901'
+                          X-XSS-Protection: 1; mode=block
+                        raw: !!binary ""
+                        reason: OK
+                        status_code: 200

--- a/tests/integration/test_data/test_github/tests.integration.test_github.PullRequests.test_source_project_renamed_fork.yaml
+++ b/tests/integration/test_data/test_github/tests.integration.test_github.PullRequests.test_source_project_renamed_fork.yaml
@@ -1,0 +1,581 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectFull
+  version_storage_file: 2
+unittest.case:
+  tests.integration.test_github:
+    ogr.services.github.project:
+      ogr.services.github.pull_request:
+        github.Repository:
+          github.Requester:
+            requests.sessions:
+              requre.objects:
+                requests.sessions:
+                  send:
+                  - metadata:
+                      latency: 0.3817145824432373
+                      module_call_list:
+                      - unittest.case
+                      - tests.integration.test_github
+                      - ogr.services.github.project
+                      - ogr.services.github.pull_request
+                      - github.Repository
+                      - github.Requester
+                      - requests.sessions
+                      - requre.objects
+                      - requests.sessions
+                      - send
+                    output:
+                      __store_indicator: 2
+                      _content:
+                        _links:
+                          comments:
+                            href: https://api.github.com/repos/packit-service/hello-world/issues/113/comments
+                          commits:
+                            href: https://api.github.com/repos/packit-service/hello-world/pulls/113/commits
+                          html:
+                            href: https://github.com/packit-service/hello-world/pull/113
+                          issue:
+                            href: https://api.github.com/repos/packit-service/hello-world/issues/113
+                          review_comment:
+                            href: https://api.github.com/repos/packit-service/hello-world/pulls/comments{/number}
+                          review_comments:
+                            href: https://api.github.com/repos/packit-service/hello-world/pulls/113/comments
+                          self:
+                            href: https://api.github.com/repos/packit-service/hello-world/pulls/113
+                          statuses:
+                            href: https://api.github.com/repos/packit-service/hello-world/statuses/7cf6d0cbeca285ecbeb19a0067cb243783b3c768
+                        additions: 0
+                        assignee: null
+                        assignees: []
+                        author_association: MEMBER
+                        base:
+                          label: packit-service:master
+                          ref: master
+                          repo:
+                            archive_url: https://api.github.com/repos/packit-service/hello-world/{archive_format}{/ref}
+                            archived: false
+                            assignees_url: https://api.github.com/repos/packit-service/hello-world/assignees{/user}
+                            blobs_url: https://api.github.com/repos/packit-service/hello-world/git/blobs{/sha}
+                            branches_url: https://api.github.com/repos/packit-service/hello-world/branches{/branch}
+                            clone_url: https://github.com/packit-service/hello-world.git
+                            collaborators_url: https://api.github.com/repos/packit-service/hello-world/collaborators{/collaborator}
+                            comments_url: https://api.github.com/repos/packit-service/hello-world/comments{/number}
+                            commits_url: https://api.github.com/repos/packit-service/hello-world/commits{/sha}
+                            compare_url: https://api.github.com/repos/packit-service/hello-world/compare/{base}...{head}
+                            contents_url: https://api.github.com/repos/packit-service/hello-world/contents/{+path}
+                            contributors_url: https://api.github.com/repos/packit-service/hello-world/contributors
+                            created_at: '2019-05-02T18:54:46Z'
+                            default_branch: master
+                            deployments_url: https://api.github.com/repos/packit-service/hello-world/deployments
+                            description: The most progresive command-line tool in
+                              the world.
+                            disabled: false
+                            downloads_url: https://api.github.com/repos/packit-service/hello-world/downloads
+                            events_url: https://api.github.com/repos/packit-service/hello-world/events
+                            fork: false
+                            forks: 17
+                            forks_count: 17
+                            forks_url: https://api.github.com/repos/packit-service/hello-world/forks
+                            full_name: packit-service/hello-world
+                            git_commits_url: https://api.github.com/repos/packit-service/hello-world/git/commits{/sha}
+                            git_refs_url: https://api.github.com/repos/packit-service/hello-world/git/refs{/sha}
+                            git_tags_url: https://api.github.com/repos/packit-service/hello-world/git/tags{/sha}
+                            git_url: git://github.com/packit-service/hello-world.git
+                            has_downloads: true
+                            has_issues: true
+                            has_pages: false
+                            has_projects: true
+                            has_wiki: true
+                            homepage: null
+                            hooks_url: https://api.github.com/repos/packit-service/hello-world/hooks
+                            html_url: https://github.com/packit-service/hello-world
+                            id: 184635124
+                            issue_comment_url: https://api.github.com/repos/packit-service/hello-world/issues/comments{/number}
+                            issue_events_url: https://api.github.com/repos/packit-service/hello-world/issues/events{/number}
+                            issues_url: https://api.github.com/repos/packit-service/hello-world/issues{/number}
+                            keys_url: https://api.github.com/repos/packit-service/hello-world/keys{/key_id}
+                            labels_url: https://api.github.com/repos/packit-service/hello-world/labels{/name}
+                            language: Python
+                            languages_url: https://api.github.com/repos/packit-service/hello-world/languages
+                            license:
+                              key: mit
+                              name: MIT License
+                              node_id: MDc6TGljZW5zZTEz
+                              spdx_id: MIT
+                              url: https://api.github.com/licenses/mit
+                            merges_url: https://api.github.com/repos/packit-service/hello-world/merges
+                            milestones_url: https://api.github.com/repos/packit-service/hello-world/milestones{/number}
+                            mirror_url: null
+                            name: hello-world
+                            node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+                            notifications_url: https://api.github.com/repos/packit-service/hello-world/notifications{?since,all,participating}
+                            open_issues: 23
+                            open_issues_count: 23
+                            owner:
+                              avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
+                              events_url: https://api.github.com/users/packit-service/events{/privacy}
+                              followers_url: https://api.github.com/users/packit-service/followers
+                              following_url: https://api.github.com/users/packit-service/following{/other_user}
+                              gists_url: https://api.github.com/users/packit-service/gists{/gist_id}
+                              gravatar_id: ''
+                              html_url: https://github.com/packit-service
+                              id: 46870917
+                              login: packit-service
+                              node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                              organizations_url: https://api.github.com/users/packit-service/orgs
+                              received_events_url: https://api.github.com/users/packit-service/received_events
+                              repos_url: https://api.github.com/users/packit-service/repos
+                              site_admin: false
+                              starred_url: https://api.github.com/users/packit-service/starred{/owner}{/repo}
+                              subscriptions_url: https://api.github.com/users/packit-service/subscriptions
+                              type: Organization
+                              url: https://api.github.com/users/packit-service
+                            private: false
+                            pulls_url: https://api.github.com/repos/packit-service/hello-world/pulls{/number}
+                            pushed_at: '2020-04-28T19:10:14Z'
+                            releases_url: https://api.github.com/repos/packit-service/hello-world/releases{/id}
+                            size: 22
+                            ssh_url: git@github.com:packit-service/hello-world.git
+                            stargazers_count: 0
+                            stargazers_url: https://api.github.com/repos/packit-service/hello-world/stargazers
+                            statuses_url: https://api.github.com/repos/packit-service/hello-world/statuses/{sha}
+                            subscribers_url: https://api.github.com/repos/packit-service/hello-world/subscribers
+                            subscription_url: https://api.github.com/repos/packit-service/hello-world/subscription
+                            svn_url: https://github.com/packit-service/hello-world
+                            tags_url: https://api.github.com/repos/packit-service/hello-world/tags
+                            teams_url: https://api.github.com/repos/packit-service/hello-world/teams
+                            trees_url: https://api.github.com/repos/packit-service/hello-world/git/trees{/sha}
+                            updated_at: '2020-04-03T14:38:55Z'
+                            url: https://api.github.com/repos/packit-service/hello-world
+                            watchers: 0
+                            watchers_count: 0
+                          sha: c0f5d6ee6e4a482877aa9d92066918fa1eb15423
+                          user:
+                            avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
+                            events_url: https://api.github.com/users/packit-service/events{/privacy}
+                            followers_url: https://api.github.com/users/packit-service/followers
+                            following_url: https://api.github.com/users/packit-service/following{/other_user}
+                            gists_url: https://api.github.com/users/packit-service/gists{/gist_id}
+                            gravatar_id: ''
+                            html_url: https://github.com/packit-service
+                            id: 46870917
+                            login: packit-service
+                            node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                            organizations_url: https://api.github.com/users/packit-service/orgs
+                            received_events_url: https://api.github.com/users/packit-service/received_events
+                            repos_url: https://api.github.com/users/packit-service/repos
+                            site_admin: false
+                            starred_url: https://api.github.com/users/packit-service/starred{/owner}{/repo}
+                            subscriptions_url: https://api.github.com/users/packit-service/subscriptions
+                            type: Organization
+                            url: https://api.github.com/users/packit-service
+                        body: ''
+                        changed_files: 1
+                        closed_at: null
+                        comments: 0
+                        comments_url: https://api.github.com/repos/packit-service/hello-world/issues/113/comments
+                        commits: 3
+                        commits_url: https://api.github.com/repos/packit-service/hello-world/pulls/113/commits
+                        created_at: '2020-04-28T19:10:13Z'
+                        deletions: 26
+                        diff_url: https://github.com/packit-service/hello-world/pull/113.diff
+                        draft: false
+                        head:
+                          label: mfocko:test_source
+                          ref: test_source
+                          repo:
+                            archive_url: https://api.github.com/repos/mfocko/bye-world/{archive_format}{/ref}
+                            archived: false
+                            assignees_url: https://api.github.com/repos/mfocko/bye-world/assignees{/user}
+                            blobs_url: https://api.github.com/repos/mfocko/bye-world/git/blobs{/sha}
+                            branches_url: https://api.github.com/repos/mfocko/bye-world/branches{/branch}
+                            clone_url: https://github.com/mfocko/bye-world.git
+                            collaborators_url: https://api.github.com/repos/mfocko/bye-world/collaborators{/collaborator}
+                            comments_url: https://api.github.com/repos/mfocko/bye-world/comments{/number}
+                            commits_url: https://api.github.com/repos/mfocko/bye-world/commits{/sha}
+                            compare_url: https://api.github.com/repos/mfocko/bye-world/compare/{base}...{head}
+                            contents_url: https://api.github.com/repos/mfocko/bye-world/contents/{+path}
+                            contributors_url: https://api.github.com/repos/mfocko/bye-world/contributors
+                            created_at: '2019-11-26T18:49:42Z'
+                            default_branch: master
+                            deployments_url: https://api.github.com/repos/mfocko/bye-world/deployments
+                            description: The most progresive command-line tool in
+                              the world.
+                            disabled: false
+                            downloads_url: https://api.github.com/repos/mfocko/bye-world/downloads
+                            events_url: https://api.github.com/repos/mfocko/bye-world/events
+                            fork: true
+                            forks: 0
+                            forks_count: 0
+                            forks_url: https://api.github.com/repos/mfocko/bye-world/forks
+                            full_name: mfocko/bye-world
+                            git_commits_url: https://api.github.com/repos/mfocko/bye-world/git/commits{/sha}
+                            git_refs_url: https://api.github.com/repos/mfocko/bye-world/git/refs{/sha}
+                            git_tags_url: https://api.github.com/repos/mfocko/bye-world/git/tags{/sha}
+                            git_url: git://github.com/mfocko/bye-world.git
+                            has_downloads: true
+                            has_issues: false
+                            has_pages: false
+                            has_projects: true
+                            has_wiki: true
+                            homepage: null
+                            hooks_url: https://api.github.com/repos/mfocko/bye-world/hooks
+                            html_url: https://github.com/mfocko/bye-world
+                            id: 224263392
+                            issue_comment_url: https://api.github.com/repos/mfocko/bye-world/issues/comments{/number}
+                            issue_events_url: https://api.github.com/repos/mfocko/bye-world/issues/events{/number}
+                            issues_url: https://api.github.com/repos/mfocko/bye-world/issues{/number}
+                            keys_url: https://api.github.com/repos/mfocko/bye-world/keys{/key_id}
+                            labels_url: https://api.github.com/repos/mfocko/bye-world/labels{/name}
+                            language: null
+                            languages_url: https://api.github.com/repos/mfocko/bye-world/languages
+                            license:
+                              key: mit
+                              name: MIT License
+                              node_id: MDc6TGljZW5zZTEz
+                              spdx_id: MIT
+                              url: https://api.github.com/licenses/mit
+                            merges_url: https://api.github.com/repos/mfocko/bye-world/merges
+                            milestones_url: https://api.github.com/repos/mfocko/bye-world/milestones{/number}
+                            mirror_url: null
+                            name: bye-world
+                            node_id: MDEwOlJlcG9zaXRvcnkyMjQyNjMzOTI=
+                            notifications_url: https://api.github.com/repos/mfocko/bye-world/notifications{?since,all,participating}
+                            open_issues: 1
+                            open_issues_count: 1
+                            owner:
+                              avatar_url: https://avatars0.githubusercontent.com/u/8149784?v=4
+                              events_url: https://api.github.com/users/mfocko/events{/privacy}
+                              followers_url: https://api.github.com/users/mfocko/followers
+                              following_url: https://api.github.com/users/mfocko/following{/other_user}
+                              gists_url: https://api.github.com/users/mfocko/gists{/gist_id}
+                              gravatar_id: ''
+                              html_url: https://github.com/mfocko
+                              id: 8149784
+                              login: mfocko
+                              node_id: MDQ6VXNlcjgxNDk3ODQ=
+                              organizations_url: https://api.github.com/users/mfocko/orgs
+                              received_events_url: https://api.github.com/users/mfocko/received_events
+                              repos_url: https://api.github.com/users/mfocko/repos
+                              site_admin: false
+                              starred_url: https://api.github.com/users/mfocko/starred{/owner}{/repo}
+                              subscriptions_url: https://api.github.com/users/mfocko/subscriptions
+                              type: User
+                              url: https://api.github.com/users/mfocko
+                            private: false
+                            pulls_url: https://api.github.com/repos/mfocko/bye-world/pulls{/number}
+                            pushed_at: '2020-04-28T18:55:31Z'
+                            releases_url: https://api.github.com/repos/mfocko/bye-world/releases{/id}
+                            size: 16
+                            ssh_url: git@github.com:mfocko/bye-world.git
+                            stargazers_count: 0
+                            stargazers_url: https://api.github.com/repos/mfocko/bye-world/stargazers
+                            statuses_url: https://api.github.com/repos/mfocko/bye-world/statuses/{sha}
+                            subscribers_url: https://api.github.com/repos/mfocko/bye-world/subscribers
+                            subscription_url: https://api.github.com/repos/mfocko/bye-world/subscription
+                            svn_url: https://github.com/mfocko/bye-world
+                            tags_url: https://api.github.com/repos/mfocko/bye-world/tags
+                            teams_url: https://api.github.com/repos/mfocko/bye-world/teams
+                            trees_url: https://api.github.com/repos/mfocko/bye-world/git/trees{/sha}
+                            updated_at: '2020-04-28T19:08:53Z'
+                            url: https://api.github.com/repos/mfocko/bye-world
+                            watchers: 0
+                            watchers_count: 0
+                          sha: 7cf6d0cbeca285ecbeb19a0067cb243783b3c768
+                          user:
+                            avatar_url: https://avatars0.githubusercontent.com/u/8149784?v=4
+                            events_url: https://api.github.com/users/mfocko/events{/privacy}
+                            followers_url: https://api.github.com/users/mfocko/followers
+                            following_url: https://api.github.com/users/mfocko/following{/other_user}
+                            gists_url: https://api.github.com/users/mfocko/gists{/gist_id}
+                            gravatar_id: ''
+                            html_url: https://github.com/mfocko
+                            id: 8149784
+                            login: mfocko
+                            node_id: MDQ6VXNlcjgxNDk3ODQ=
+                            organizations_url: https://api.github.com/users/mfocko/orgs
+                            received_events_url: https://api.github.com/users/mfocko/received_events
+                            repos_url: https://api.github.com/users/mfocko/repos
+                            site_admin: false
+                            starred_url: https://api.github.com/users/mfocko/starred{/owner}{/repo}
+                            subscriptions_url: https://api.github.com/users/mfocko/subscriptions
+                            type: User
+                            url: https://api.github.com/users/mfocko
+                        html_url: https://github.com/packit-service/hello-world/pull/113
+                        id: 410305713
+                        issue_url: https://api.github.com/repos/packit-service/hello-world/issues/113
+                        labels: []
+                        locked: false
+                        maintainer_can_modify: true
+                        merge_commit_sha: null
+                        mergeable: false
+                        mergeable_state: dirty
+                        merged: false
+                        merged_at: null
+                        merged_by: null
+                        milestone: null
+                        node_id: MDExOlB1bGxSZXF1ZXN0NDEwMzA1NzEz
+                        number: 113
+                        patch_url: https://github.com/packit-service/hello-world/pull/113.patch
+                        rebaseable: false
+                        requested_reviewers: []
+                        requested_teams: []
+                        review_comment_url: https://api.github.com/repos/packit-service/hello-world/pulls/comments{/number}
+                        review_comments: 0
+                        review_comments_url: https://api.github.com/repos/packit-service/hello-world/pulls/113/comments
+                        state: open
+                        statuses_url: https://api.github.com/repos/packit-service/hello-world/statuses/7cf6d0cbeca285ecbeb19a0067cb243783b3c768
+                        title: '[ogr] Test source_project on PR'
+                        updated_at: '2020-04-28T19:10:13Z'
+                        url: https://api.github.com/repos/packit-service/hello-world/pulls/113
+                        user:
+                          avatar_url: https://avatars0.githubusercontent.com/u/8149784?v=4
+                          events_url: https://api.github.com/users/mfocko/events{/privacy}
+                          followers_url: https://api.github.com/users/mfocko/followers
+                          following_url: https://api.github.com/users/mfocko/following{/other_user}
+                          gists_url: https://api.github.com/users/mfocko/gists{/gist_id}
+                          gravatar_id: ''
+                          html_url: https://github.com/mfocko
+                          id: 8149784
+                          login: mfocko
+                          node_id: MDQ6VXNlcjgxNDk3ODQ=
+                          organizations_url: https://api.github.com/users/mfocko/orgs
+                          received_events_url: https://api.github.com/users/mfocko/received_events
+                          repos_url: https://api.github.com/users/mfocko/repos
+                          site_admin: false
+                          starred_url: https://api.github.com/users/mfocko/starred{/owner}{/repo}
+                          subscriptions_url: https://api.github.com/users/mfocko/subscriptions
+                          type: User
+                          url: https://api.github.com/users/mfocko
+                      _next: null
+                      elapsed: 0.2
+                      encoding: utf-8
+                      headers:
+                        Access-Control-Allow-Origin: '*'
+                        Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                          X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+                          X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+                          X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
+                        Cache-Control: private, max-age=60, s-maxage=60
+                        Content-Encoding: gzip
+                        Content-Security-Policy: default-src 'none'
+                        Content-Type: application/json; charset=utf-8
+                        Date: Fri, 01 Nov 2019 13-36-03 GMT
+                        ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                        Last-Modified: Tue, 28 Apr 2020 19:10:13 GMT
+                        Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                        Server: GitHub.com
+                        Status: 200 OK
+                        Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                          preload
+                        Transfer-Encoding: chunked
+                        Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                          Accept, X-Requested-With
+                        X-Accepted-OAuth-Scopes: ''
+                        X-Content-Type-Options: nosniff
+                        X-Frame-Options: deny
+                        X-GitHub-Media-Type: github.v3; format=json
+                        X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                        X-OAuth-Scopes: admin:enterprise, admin:gpg_key, admin:org,
+                          admin:org_hook, admin:public_key, admin:repo_hook, delete:packages,
+                          delete_repo, gist, notifications, read:packages, repo, user,
+                          workflow, write:discussion, write:packages
+                        X-RateLimit-Limit: '5000'
+                        X-RateLimit-Remaining: '4972'
+                        X-RateLimit-Reset: '1572953901'
+                        X-XSS-Protection: 1; mode=block
+                      raw: !!binary ""
+                      reason: OK
+                      status_code: 200
+        ogr.services.github.project:
+          github.MainClass:
+            github.Requester:
+              requests.sessions:
+                requre.objects:
+                  requests.sessions:
+                    send:
+                    - metadata:
+                        latency: 0.44859766960144043
+                        module_call_list:
+                        - unittest.case
+                        - tests.integration.test_github
+                        - ogr.services.github.project
+                        - ogr.services.github.pull_request
+                        - ogr.services.github.project
+                        - github.MainClass
+                        - github.Requester
+                        - requests.sessions
+                        - requre.objects
+                        - requests.sessions
+                        - send
+                      output:
+                        __store_indicator: 2
+                        _content:
+                          allow_merge_commit: true
+                          allow_rebase_merge: true
+                          allow_squash_merge: true
+                          archive_url: https://api.github.com/repos/packit-service/hello-world/{archive_format}{/ref}
+                          archived: false
+                          assignees_url: https://api.github.com/repos/packit-service/hello-world/assignees{/user}
+                          blobs_url: https://api.github.com/repos/packit-service/hello-world/git/blobs{/sha}
+                          branches_url: https://api.github.com/repos/packit-service/hello-world/branches{/branch}
+                          clone_url: https://github.com/packit-service/hello-world.git
+                          collaborators_url: https://api.github.com/repos/packit-service/hello-world/collaborators{/collaborator}
+                          comments_url: https://api.github.com/repos/packit-service/hello-world/comments{/number}
+                          commits_url: https://api.github.com/repos/packit-service/hello-world/commits{/sha}
+                          compare_url: https://api.github.com/repos/packit-service/hello-world/compare/{base}...{head}
+                          contents_url: https://api.github.com/repos/packit-service/hello-world/contents/{+path}
+                          contributors_url: https://api.github.com/repos/packit-service/hello-world/contributors
+                          created_at: '2019-05-02T18:54:46Z'
+                          default_branch: master
+                          delete_branch_on_merge: false
+                          deployments_url: https://api.github.com/repos/packit-service/hello-world/deployments
+                          description: The most progresive command-line tool in the
+                            world.
+                          disabled: false
+                          downloads_url: https://api.github.com/repos/packit-service/hello-world/downloads
+                          events_url: https://api.github.com/repos/packit-service/hello-world/events
+                          fork: false
+                          forks: 17
+                          forks_count: 17
+                          forks_url: https://api.github.com/repos/packit-service/hello-world/forks
+                          full_name: packit-service/hello-world
+                          git_commits_url: https://api.github.com/repos/packit-service/hello-world/git/commits{/sha}
+                          git_refs_url: https://api.github.com/repos/packit-service/hello-world/git/refs{/sha}
+                          git_tags_url: https://api.github.com/repos/packit-service/hello-world/git/tags{/sha}
+                          git_url: git://github.com/packit-service/hello-world.git
+                          has_downloads: true
+                          has_issues: true
+                          has_pages: false
+                          has_projects: true
+                          has_wiki: true
+                          homepage: null
+                          hooks_url: https://api.github.com/repos/packit-service/hello-world/hooks
+                          html_url: https://github.com/packit-service/hello-world
+                          id: 184635124
+                          issue_comment_url: https://api.github.com/repos/packit-service/hello-world/issues/comments{/number}
+                          issue_events_url: https://api.github.com/repos/packit-service/hello-world/issues/events{/number}
+                          issues_url: https://api.github.com/repos/packit-service/hello-world/issues{/number}
+                          keys_url: https://api.github.com/repos/packit-service/hello-world/keys{/key_id}
+                          labels_url: https://api.github.com/repos/packit-service/hello-world/labels{/name}
+                          language: Python
+                          languages_url: https://api.github.com/repos/packit-service/hello-world/languages
+                          license:
+                            key: mit
+                            name: MIT License
+                            node_id: MDc6TGljZW5zZTEz
+                            spdx_id: MIT
+                            url: https://api.github.com/licenses/mit
+                          merges_url: https://api.github.com/repos/packit-service/hello-world/merges
+                          milestones_url: https://api.github.com/repos/packit-service/hello-world/milestones{/number}
+                          mirror_url: null
+                          name: hello-world
+                          network_count: 17
+                          node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+                          notifications_url: https://api.github.com/repos/packit-service/hello-world/notifications{?since,all,participating}
+                          open_issues: 23
+                          open_issues_count: 23
+                          organization:
+                            avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
+                            events_url: https://api.github.com/users/packit-service/events{/privacy}
+                            followers_url: https://api.github.com/users/packit-service/followers
+                            following_url: https://api.github.com/users/packit-service/following{/other_user}
+                            gists_url: https://api.github.com/users/packit-service/gists{/gist_id}
+                            gravatar_id: ''
+                            html_url: https://github.com/packit-service
+                            id: 46870917
+                            login: packit-service
+                            node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                            organizations_url: https://api.github.com/users/packit-service/orgs
+                            received_events_url: https://api.github.com/users/packit-service/received_events
+                            repos_url: https://api.github.com/users/packit-service/repos
+                            site_admin: false
+                            starred_url: https://api.github.com/users/packit-service/starred{/owner}{/repo}
+                            subscriptions_url: https://api.github.com/users/packit-service/subscriptions
+                            type: Organization
+                            url: https://api.github.com/users/packit-service
+                          owner:
+                            avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
+                            events_url: https://api.github.com/users/packit-service/events{/privacy}
+                            followers_url: https://api.github.com/users/packit-service/followers
+                            following_url: https://api.github.com/users/packit-service/following{/other_user}
+                            gists_url: https://api.github.com/users/packit-service/gists{/gist_id}
+                            gravatar_id: ''
+                            html_url: https://github.com/packit-service
+                            id: 46870917
+                            login: packit-service
+                            node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                            organizations_url: https://api.github.com/users/packit-service/orgs
+                            received_events_url: https://api.github.com/users/packit-service/received_events
+                            repos_url: https://api.github.com/users/packit-service/repos
+                            site_admin: false
+                            starred_url: https://api.github.com/users/packit-service/starred{/owner}{/repo}
+                            subscriptions_url: https://api.github.com/users/packit-service/subscriptions
+                            type: Organization
+                            url: https://api.github.com/users/packit-service
+                          permissions:
+                            admin: true
+                            pull: true
+                            push: true
+                          private: false
+                          pulls_url: https://api.github.com/repos/packit-service/hello-world/pulls{/number}
+                          pushed_at: '2020-04-28T19:10:14Z'
+                          releases_url: https://api.github.com/repos/packit-service/hello-world/releases{/id}
+                          size: 22
+                          ssh_url: git@github.com:packit-service/hello-world.git
+                          stargazers_count: 0
+                          stargazers_url: https://api.github.com/repos/packit-service/hello-world/stargazers
+                          statuses_url: https://api.github.com/repos/packit-service/hello-world/statuses/{sha}
+                          subscribers_count: 8
+                          subscribers_url: https://api.github.com/repos/packit-service/hello-world/subscribers
+                          subscription_url: https://api.github.com/repos/packit-service/hello-world/subscription
+                          svn_url: https://github.com/packit-service/hello-world
+                          tags_url: https://api.github.com/repos/packit-service/hello-world/tags
+                          teams_url: https://api.github.com/repos/packit-service/hello-world/teams
+                          temp_clone_token: ''
+                          trees_url: https://api.github.com/repos/packit-service/hello-world/git/trees{/sha}
+                          updated_at: '2020-04-03T14:38:55Z'
+                          url: https://api.github.com/repos/packit-service/hello-world
+                          watchers: 0
+                          watchers_count: 0
+                        _next: null
+                        elapsed: 0.2
+                        encoding: utf-8
+                        headers:
+                          Access-Control-Allow-Origin: '*'
+                          Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                            X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+                            X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+                            X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
+                          Cache-Control: private, max-age=60, s-maxage=60
+                          Content-Encoding: gzip
+                          Content-Security-Policy: default-src 'none'
+                          Content-Type: application/json; charset=utf-8
+                          Date: Fri, 01 Nov 2019 13-36-03 GMT
+                          ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                          Last-Modified: Fri, 03 Apr 2020 14:38:55 GMT
+                          Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                          Server: GitHub.com
+                          Status: 200 OK
+                          Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                            preload
+                          Transfer-Encoding: chunked
+                          Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                            Accept, X-Requested-With
+                          X-Accepted-OAuth-Scopes: repo
+                          X-Content-Type-Options: nosniff
+                          X-Frame-Options: deny
+                          X-GitHub-Media-Type: github.v3; format=json
+                          X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                          X-OAuth-Scopes: admin:enterprise, admin:gpg_key, admin:org,
+                            admin:org_hook, admin:public_key, admin:repo_hook, delete:packages,
+                            delete_repo, gist, notifications, read:packages, repo,
+                            user, workflow, write:discussion, write:packages
+                          X-RateLimit-Limit: '5000'
+                          X-RateLimit-Remaining: '4972'
+                          X-RateLimit-Reset: '1572953901'
+                          X-XSS-Protection: 1; mode=block
+                        raw: !!binary ""
+                        reason: OK
+                        status_code: 200

--- a/tests/integration/test_data/test_github/tests.integration.test_github.PullRequests.test_source_project_renamed_upstream.yaml
+++ b/tests/integration/test_data/test_github/tests.integration.test_github.PullRequests.test_source_project_renamed_upstream.yaml
@@ -1,0 +1,563 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectFull
+  version_storage_file: 2
+unittest.case:
+  tests.integration.test_github:
+    ogr.services.github.project:
+      ogr.services.github.pull_request:
+        github.Repository:
+          github.Requester:
+            requests.sessions:
+              requre.objects:
+                requests.sessions:
+                  send:
+                  - metadata:
+                      latency: 0.7097175121307373
+                      module_call_list:
+                      - unittest.case
+                      - tests.integration.test_github
+                      - ogr.services.github.project
+                      - ogr.services.github.pull_request
+                      - github.Repository
+                      - github.Requester
+                      - requests.sessions
+                      - requre.objects
+                      - requests.sessions
+                      - send
+                    output:
+                      __store_indicator: 2
+                      _content:
+                        _links:
+                          comments:
+                            href: https://api.github.com/repos/packit-service/not-potential-spoon/issues/1/comments
+                          commits:
+                            href: https://api.github.com/repos/packit-service/not-potential-spoon/pulls/1/commits
+                          html:
+                            href: https://github.com/packit-service/not-potential-spoon/pull/1
+                          issue:
+                            href: https://api.github.com/repos/packit-service/not-potential-spoon/issues/1
+                          review_comment:
+                            href: https://api.github.com/repos/packit-service/not-potential-spoon/pulls/comments{/number}
+                          review_comments:
+                            href: https://api.github.com/repos/packit-service/not-potential-spoon/pulls/1/comments
+                          self:
+                            href: https://api.github.com/repos/packit-service/not-potential-spoon/pulls/1
+                          statuses:
+                            href: https://api.github.com/repos/packit-service/not-potential-spoon/statuses/3cb9b4f2f656e458b0c10220548a4cbbdcb79a2b
+                        additions: 3
+                        assignee: null
+                        assignees: []
+                        author_association: MEMBER
+                        base:
+                          label: packit-service:master
+                          ref: master
+                          repo:
+                            archive_url: https://api.github.com/repos/packit-service/not-potential-spoon/{archive_format}{/ref}
+                            archived: false
+                            assignees_url: https://api.github.com/repos/packit-service/not-potential-spoon/assignees{/user}
+                            blobs_url: https://api.github.com/repos/packit-service/not-potential-spoon/git/blobs{/sha}
+                            branches_url: https://api.github.com/repos/packit-service/not-potential-spoon/branches{/branch}
+                            clone_url: https://github.com/packit-service/not-potential-spoon.git
+                            collaborators_url: https://api.github.com/repos/packit-service/not-potential-spoon/collaborators{/collaborator}
+                            comments_url: https://api.github.com/repos/packit-service/not-potential-spoon/comments{/number}
+                            commits_url: https://api.github.com/repos/packit-service/not-potential-spoon/commits{/sha}
+                            compare_url: https://api.github.com/repos/packit-service/not-potential-spoon/compare/{base}...{head}
+                            contents_url: https://api.github.com/repos/packit-service/not-potential-spoon/contents/{+path}
+                            contributors_url: https://api.github.com/repos/packit-service/not-potential-spoon/contributors
+                            created_at: '2020-04-29T13:08:07Z'
+                            default_branch: master
+                            deployments_url: https://api.github.com/repos/packit-service/not-potential-spoon/deployments
+                            description: 'Test renaming upstream '
+                            disabled: false
+                            downloads_url: https://api.github.com/repos/packit-service/not-potential-spoon/downloads
+                            events_url: https://api.github.com/repos/packit-service/not-potential-spoon/events
+                            fork: false
+                            forks: 1
+                            forks_count: 1
+                            forks_url: https://api.github.com/repos/packit-service/not-potential-spoon/forks
+                            full_name: packit-service/not-potential-spoon
+                            git_commits_url: https://api.github.com/repos/packit-service/not-potential-spoon/git/commits{/sha}
+                            git_refs_url: https://api.github.com/repos/packit-service/not-potential-spoon/git/refs{/sha}
+                            git_tags_url: https://api.github.com/repos/packit-service/not-potential-spoon/git/tags{/sha}
+                            git_url: git://github.com/packit-service/not-potential-spoon.git
+                            has_downloads: true
+                            has_issues: true
+                            has_pages: false
+                            has_projects: true
+                            has_wiki: true
+                            homepage: null
+                            hooks_url: https://api.github.com/repos/packit-service/not-potential-spoon/hooks
+                            html_url: https://github.com/packit-service/not-potential-spoon
+                            id: 259927958
+                            issue_comment_url: https://api.github.com/repos/packit-service/not-potential-spoon/issues/comments{/number}
+                            issue_events_url: https://api.github.com/repos/packit-service/not-potential-spoon/issues/events{/number}
+                            issues_url: https://api.github.com/repos/packit-service/not-potential-spoon/issues{/number}
+                            keys_url: https://api.github.com/repos/packit-service/not-potential-spoon/keys{/key_id}
+                            labels_url: https://api.github.com/repos/packit-service/not-potential-spoon/labels{/name}
+                            language: null
+                            languages_url: https://api.github.com/repos/packit-service/not-potential-spoon/languages
+                            license: null
+                            merges_url: https://api.github.com/repos/packit-service/not-potential-spoon/merges
+                            milestones_url: https://api.github.com/repos/packit-service/not-potential-spoon/milestones{/number}
+                            mirror_url: null
+                            name: not-potential-spoon
+                            node_id: MDEwOlJlcG9zaXRvcnkyNTk5Mjc5NTg=
+                            notifications_url: https://api.github.com/repos/packit-service/not-potential-spoon/notifications{?since,all,participating}
+                            open_issues: 1
+                            open_issues_count: 1
+                            owner:
+                              avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
+                              events_url: https://api.github.com/users/packit-service/events{/privacy}
+                              followers_url: https://api.github.com/users/packit-service/followers
+                              following_url: https://api.github.com/users/packit-service/following{/other_user}
+                              gists_url: https://api.github.com/users/packit-service/gists{/gist_id}
+                              gravatar_id: ''
+                              html_url: https://github.com/packit-service
+                              id: 46870917
+                              login: packit-service
+                              node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                              organizations_url: https://api.github.com/users/packit-service/orgs
+                              received_events_url: https://api.github.com/users/packit-service/received_events
+                              repos_url: https://api.github.com/users/packit-service/repos
+                              site_admin: false
+                              starred_url: https://api.github.com/users/packit-service/starred{/owner}{/repo}
+                              subscriptions_url: https://api.github.com/users/packit-service/subscriptions
+                              type: Organization
+                              url: https://api.github.com/users/packit-service
+                            private: false
+                            pulls_url: https://api.github.com/repos/packit-service/not-potential-spoon/pulls{/number}
+                            pushed_at: '2020-04-29T13:11:24Z'
+                            releases_url: https://api.github.com/repos/packit-service/not-potential-spoon/releases{/id}
+                            size: 0
+                            ssh_url: git@github.com:packit-service/not-potential-spoon.git
+                            stargazers_count: 0
+                            stargazers_url: https://api.github.com/repos/packit-service/not-potential-spoon/stargazers
+                            statuses_url: https://api.github.com/repos/packit-service/not-potential-spoon/statuses/{sha}
+                            subscribers_url: https://api.github.com/repos/packit-service/not-potential-spoon/subscribers
+                            subscription_url: https://api.github.com/repos/packit-service/not-potential-spoon/subscription
+                            svn_url: https://github.com/packit-service/not-potential-spoon
+                            tags_url: https://api.github.com/repos/packit-service/not-potential-spoon/tags
+                            teams_url: https://api.github.com/repos/packit-service/not-potential-spoon/teams
+                            trees_url: https://api.github.com/repos/packit-service/not-potential-spoon/git/trees{/sha}
+                            updated_at: '2020-04-29T13:11:50Z'
+                            url: https://api.github.com/repos/packit-service/not-potential-spoon
+                            watchers: 0
+                            watchers_count: 0
+                          sha: 37bf49cc6dee3a37e885381d66a435df520e7c65
+                          user:
+                            avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
+                            events_url: https://api.github.com/users/packit-service/events{/privacy}
+                            followers_url: https://api.github.com/users/packit-service/followers
+                            following_url: https://api.github.com/users/packit-service/following{/other_user}
+                            gists_url: https://api.github.com/users/packit-service/gists{/gist_id}
+                            gravatar_id: ''
+                            html_url: https://github.com/packit-service
+                            id: 46870917
+                            login: packit-service
+                            node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                            organizations_url: https://api.github.com/users/packit-service/orgs
+                            received_events_url: https://api.github.com/users/packit-service/received_events
+                            repos_url: https://api.github.com/users/packit-service/repos
+                            site_admin: false
+                            starred_url: https://api.github.com/users/packit-service/starred{/owner}{/repo}
+                            subscriptions_url: https://api.github.com/users/packit-service/subscriptions
+                            type: Organization
+                            url: https://api.github.com/users/packit-service
+                        body: ''
+                        changed_files: 1
+                        closed_at: null
+                        comments: 0
+                        comments_url: https://api.github.com/repos/packit-service/not-potential-spoon/issues/1/comments
+                        commits: 1
+                        commits_url: https://api.github.com/repos/packit-service/not-potential-spoon/pulls/1/commits
+                        created_at: '2020-04-29T13:11:23Z'
+                        deletions: 0
+                        diff_url: https://github.com/packit-service/not-potential-spoon/pull/1.diff
+                        draft: false
+                        head:
+                          label: mfocko:test-pr
+                          ref: test-pr
+                          repo:
+                            archive_url: https://api.github.com/repos/mfocko/potential-spoon/{archive_format}{/ref}
+                            archived: false
+                            assignees_url: https://api.github.com/repos/mfocko/potential-spoon/assignees{/user}
+                            blobs_url: https://api.github.com/repos/mfocko/potential-spoon/git/blobs{/sha}
+                            branches_url: https://api.github.com/repos/mfocko/potential-spoon/branches{/branch}
+                            clone_url: https://github.com/mfocko/potential-spoon.git
+                            collaborators_url: https://api.github.com/repos/mfocko/potential-spoon/collaborators{/collaborator}
+                            comments_url: https://api.github.com/repos/mfocko/potential-spoon/comments{/number}
+                            commits_url: https://api.github.com/repos/mfocko/potential-spoon/commits{/sha}
+                            compare_url: https://api.github.com/repos/mfocko/potential-spoon/compare/{base}...{head}
+                            contents_url: https://api.github.com/repos/mfocko/potential-spoon/contents/{+path}
+                            contributors_url: https://api.github.com/repos/mfocko/potential-spoon/contributors
+                            created_at: '2020-04-29T13:09:54Z'
+                            default_branch: master
+                            deployments_url: https://api.github.com/repos/mfocko/potential-spoon/deployments
+                            description: 'Test renaming upstream '
+                            disabled: false
+                            downloads_url: https://api.github.com/repos/mfocko/potential-spoon/downloads
+                            events_url: https://api.github.com/repos/mfocko/potential-spoon/events
+                            fork: true
+                            forks: 0
+                            forks_count: 0
+                            forks_url: https://api.github.com/repos/mfocko/potential-spoon/forks
+                            full_name: mfocko/potential-spoon
+                            git_commits_url: https://api.github.com/repos/mfocko/potential-spoon/git/commits{/sha}
+                            git_refs_url: https://api.github.com/repos/mfocko/potential-spoon/git/refs{/sha}
+                            git_tags_url: https://api.github.com/repos/mfocko/potential-spoon/git/tags{/sha}
+                            git_url: git://github.com/mfocko/potential-spoon.git
+                            has_downloads: true
+                            has_issues: false
+                            has_pages: false
+                            has_projects: true
+                            has_wiki: true
+                            homepage: null
+                            hooks_url: https://api.github.com/repos/mfocko/potential-spoon/hooks
+                            html_url: https://github.com/mfocko/potential-spoon
+                            id: 259928367
+                            issue_comment_url: https://api.github.com/repos/mfocko/potential-spoon/issues/comments{/number}
+                            issue_events_url: https://api.github.com/repos/mfocko/potential-spoon/issues/events{/number}
+                            issues_url: https://api.github.com/repos/mfocko/potential-spoon/issues{/number}
+                            keys_url: https://api.github.com/repos/mfocko/potential-spoon/keys{/key_id}
+                            labels_url: https://api.github.com/repos/mfocko/potential-spoon/labels{/name}
+                            language: null
+                            languages_url: https://api.github.com/repos/mfocko/potential-spoon/languages
+                            license: null
+                            merges_url: https://api.github.com/repos/mfocko/potential-spoon/merges
+                            milestones_url: https://api.github.com/repos/mfocko/potential-spoon/milestones{/number}
+                            mirror_url: null
+                            name: potential-spoon
+                            node_id: MDEwOlJlcG9zaXRvcnkyNTk5MjgzNjc=
+                            notifications_url: https://api.github.com/repos/mfocko/potential-spoon/notifications{?since,all,participating}
+                            open_issues: 0
+                            open_issues_count: 0
+                            owner:
+                              avatar_url: https://avatars0.githubusercontent.com/u/8149784?v=4
+                              events_url: https://api.github.com/users/mfocko/events{/privacy}
+                              followers_url: https://api.github.com/users/mfocko/followers
+                              following_url: https://api.github.com/users/mfocko/following{/other_user}
+                              gists_url: https://api.github.com/users/mfocko/gists{/gist_id}
+                              gravatar_id: ''
+                              html_url: https://github.com/mfocko
+                              id: 8149784
+                              login: mfocko
+                              node_id: MDQ6VXNlcjgxNDk3ODQ=
+                              organizations_url: https://api.github.com/users/mfocko/orgs
+                              received_events_url: https://api.github.com/users/mfocko/received_events
+                              repos_url: https://api.github.com/users/mfocko/repos
+                              site_admin: false
+                              starred_url: https://api.github.com/users/mfocko/starred{/owner}{/repo}
+                              subscriptions_url: https://api.github.com/users/mfocko/subscriptions
+                              type: User
+                              url: https://api.github.com/users/mfocko
+                            private: false
+                            pulls_url: https://api.github.com/repos/mfocko/potential-spoon/pulls{/number}
+                            pushed_at: '2020-04-29T13:11:11Z'
+                            releases_url: https://api.github.com/repos/mfocko/potential-spoon/releases{/id}
+                            size: 0
+                            ssh_url: git@github.com:mfocko/potential-spoon.git
+                            stargazers_count: 0
+                            stargazers_url: https://api.github.com/repos/mfocko/potential-spoon/stargazers
+                            statuses_url: https://api.github.com/repos/mfocko/potential-spoon/statuses/{sha}
+                            subscribers_url: https://api.github.com/repos/mfocko/potential-spoon/subscribers
+                            subscription_url: https://api.github.com/repos/mfocko/potential-spoon/subscription
+                            svn_url: https://github.com/mfocko/potential-spoon
+                            tags_url: https://api.github.com/repos/mfocko/potential-spoon/tags
+                            teams_url: https://api.github.com/repos/mfocko/potential-spoon/teams
+                            trees_url: https://api.github.com/repos/mfocko/potential-spoon/git/trees{/sha}
+                            updated_at: '2020-04-29T13:09:56Z'
+                            url: https://api.github.com/repos/mfocko/potential-spoon
+                            watchers: 0
+                            watchers_count: 0
+                          sha: 3cb9b4f2f656e458b0c10220548a4cbbdcb79a2b
+                          user:
+                            avatar_url: https://avatars0.githubusercontent.com/u/8149784?v=4
+                            events_url: https://api.github.com/users/mfocko/events{/privacy}
+                            followers_url: https://api.github.com/users/mfocko/followers
+                            following_url: https://api.github.com/users/mfocko/following{/other_user}
+                            gists_url: https://api.github.com/users/mfocko/gists{/gist_id}
+                            gravatar_id: ''
+                            html_url: https://github.com/mfocko
+                            id: 8149784
+                            login: mfocko
+                            node_id: MDQ6VXNlcjgxNDk3ODQ=
+                            organizations_url: https://api.github.com/users/mfocko/orgs
+                            received_events_url: https://api.github.com/users/mfocko/received_events
+                            repos_url: https://api.github.com/users/mfocko/repos
+                            site_admin: false
+                            starred_url: https://api.github.com/users/mfocko/starred{/owner}{/repo}
+                            subscriptions_url: https://api.github.com/users/mfocko/subscriptions
+                            type: User
+                            url: https://api.github.com/users/mfocko
+                        html_url: https://github.com/packit-service/not-potential-spoon/pull/1
+                        id: 410703971
+                        issue_url: https://api.github.com/repos/packit-service/not-potential-spoon/issues/1
+                        labels: []
+                        locked: false
+                        maintainer_can_modify: true
+                        merge_commit_sha: a432b35bdd165690c4e11008f87c68ab23dc77c0
+                        mergeable: true
+                        mergeable_state: clean
+                        merged: false
+                        merged_at: null
+                        merged_by: null
+                        milestone: null
+                        node_id: MDExOlB1bGxSZXF1ZXN0NDEwNzAzOTcx
+                        number: 1
+                        patch_url: https://github.com/packit-service/not-potential-spoon/pull/1.patch
+                        rebaseable: true
+                        requested_reviewers: []
+                        requested_teams: []
+                        review_comment_url: https://api.github.com/repos/packit-service/not-potential-spoon/pulls/comments{/number}
+                        review_comments: 0
+                        review_comments_url: https://api.github.com/repos/packit-service/not-potential-spoon/pulls/1/comments
+                        state: open
+                        statuses_url: https://api.github.com/repos/packit-service/not-potential-spoon/statuses/3cb9b4f2f656e458b0c10220548a4cbbdcb79a2b
+                        title: test PR
+                        updated_at: '2020-04-29T13:11:23Z'
+                        url: https://api.github.com/repos/packit-service/not-potential-spoon/pulls/1
+                        user:
+                          avatar_url: https://avatars0.githubusercontent.com/u/8149784?v=4
+                          events_url: https://api.github.com/users/mfocko/events{/privacy}
+                          followers_url: https://api.github.com/users/mfocko/followers
+                          following_url: https://api.github.com/users/mfocko/following{/other_user}
+                          gists_url: https://api.github.com/users/mfocko/gists{/gist_id}
+                          gravatar_id: ''
+                          html_url: https://github.com/mfocko
+                          id: 8149784
+                          login: mfocko
+                          node_id: MDQ6VXNlcjgxNDk3ODQ=
+                          organizations_url: https://api.github.com/users/mfocko/orgs
+                          received_events_url: https://api.github.com/users/mfocko/received_events
+                          repos_url: https://api.github.com/users/mfocko/repos
+                          site_admin: false
+                          starred_url: https://api.github.com/users/mfocko/starred{/owner}{/repo}
+                          subscriptions_url: https://api.github.com/users/mfocko/subscriptions
+                          type: User
+                          url: https://api.github.com/users/mfocko
+                      _next: null
+                      elapsed: 0.2
+                      encoding: utf-8
+                      headers:
+                        Access-Control-Allow-Origin: '*'
+                        Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                          X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+                          X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+                          X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
+                        Cache-Control: private, max-age=60, s-maxage=60
+                        Content-Encoding: gzip
+                        Content-Security-Policy: default-src 'none'
+                        Content-Type: application/json; charset=utf-8
+                        Date: Fri, 01 Nov 2019 13-36-03 GMT
+                        ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                        Last-Modified: Wed, 29 Apr 2020 13:11:23 GMT
+                        Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                        Server: GitHub.com
+                        Status: 200 OK
+                        Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                          preload
+                        Transfer-Encoding: chunked
+                        Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                          Accept, X-Requested-With
+                        X-Accepted-OAuth-Scopes: ''
+                        X-Content-Type-Options: nosniff
+                        X-Frame-Options: deny
+                        X-GitHub-Media-Type: github.v3; format=json
+                        X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                        X-OAuth-Scopes: admin:enterprise, admin:gpg_key, admin:org,
+                          admin:org_hook, admin:public_key, admin:repo_hook, delete:packages,
+                          delete_repo, gist, notifications, read:packages, repo, user,
+                          workflow, write:discussion, write:packages
+                        X-RateLimit-Limit: '5000'
+                        X-RateLimit-Remaining: '4972'
+                        X-RateLimit-Reset: '1572953901'
+                        X-XSS-Protection: 1; mode=block
+                      raw: !!binary ""
+                      reason: OK
+                      status_code: 200
+        ogr.services.github.project:
+          github.MainClass:
+            github.Requester:
+              requests.sessions:
+                requre.objects:
+                  requests.sessions:
+                    send:
+                    - metadata:
+                        latency: 0.7818787097930908
+                        module_call_list:
+                        - unittest.case
+                        - tests.integration.test_github
+                        - ogr.services.github.project
+                        - ogr.services.github.pull_request
+                        - ogr.services.github.project
+                        - github.MainClass
+                        - github.Requester
+                        - requests.sessions
+                        - requre.objects
+                        - requests.sessions
+                        - send
+                      output:
+                        __store_indicator: 2
+                        _content:
+                          allow_merge_commit: true
+                          allow_rebase_merge: true
+                          allow_squash_merge: true
+                          archive_url: https://api.github.com/repos/packit-service/not-potential-spoon/{archive_format}{/ref}
+                          archived: false
+                          assignees_url: https://api.github.com/repos/packit-service/not-potential-spoon/assignees{/user}
+                          blobs_url: https://api.github.com/repos/packit-service/not-potential-spoon/git/blobs{/sha}
+                          branches_url: https://api.github.com/repos/packit-service/not-potential-spoon/branches{/branch}
+                          clone_url: https://github.com/packit-service/not-potential-spoon.git
+                          collaborators_url: https://api.github.com/repos/packit-service/not-potential-spoon/collaborators{/collaborator}
+                          comments_url: https://api.github.com/repos/packit-service/not-potential-spoon/comments{/number}
+                          commits_url: https://api.github.com/repos/packit-service/not-potential-spoon/commits{/sha}
+                          compare_url: https://api.github.com/repos/packit-service/not-potential-spoon/compare/{base}...{head}
+                          contents_url: https://api.github.com/repos/packit-service/not-potential-spoon/contents/{+path}
+                          contributors_url: https://api.github.com/repos/packit-service/not-potential-spoon/contributors
+                          created_at: '2020-04-29T13:08:07Z'
+                          default_branch: master
+                          delete_branch_on_merge: false
+                          deployments_url: https://api.github.com/repos/packit-service/not-potential-spoon/deployments
+                          description: 'Test renaming upstream '
+                          disabled: false
+                          downloads_url: https://api.github.com/repos/packit-service/not-potential-spoon/downloads
+                          events_url: https://api.github.com/repos/packit-service/not-potential-spoon/events
+                          fork: false
+                          forks: 1
+                          forks_count: 1
+                          forks_url: https://api.github.com/repos/packit-service/not-potential-spoon/forks
+                          full_name: packit-service/not-potential-spoon
+                          git_commits_url: https://api.github.com/repos/packit-service/not-potential-spoon/git/commits{/sha}
+                          git_refs_url: https://api.github.com/repos/packit-service/not-potential-spoon/git/refs{/sha}
+                          git_tags_url: https://api.github.com/repos/packit-service/not-potential-spoon/git/tags{/sha}
+                          git_url: git://github.com/packit-service/not-potential-spoon.git
+                          has_downloads: true
+                          has_issues: true
+                          has_pages: false
+                          has_projects: true
+                          has_wiki: true
+                          homepage: null
+                          hooks_url: https://api.github.com/repos/packit-service/not-potential-spoon/hooks
+                          html_url: https://github.com/packit-service/not-potential-spoon
+                          id: 259927958
+                          issue_comment_url: https://api.github.com/repos/packit-service/not-potential-spoon/issues/comments{/number}
+                          issue_events_url: https://api.github.com/repos/packit-service/not-potential-spoon/issues/events{/number}
+                          issues_url: https://api.github.com/repos/packit-service/not-potential-spoon/issues{/number}
+                          keys_url: https://api.github.com/repos/packit-service/not-potential-spoon/keys{/key_id}
+                          labels_url: https://api.github.com/repos/packit-service/not-potential-spoon/labels{/name}
+                          language: null
+                          languages_url: https://api.github.com/repos/packit-service/not-potential-spoon/languages
+                          license: null
+                          merges_url: https://api.github.com/repos/packit-service/not-potential-spoon/merges
+                          milestones_url: https://api.github.com/repos/packit-service/not-potential-spoon/milestones{/number}
+                          mirror_url: null
+                          name: not-potential-spoon
+                          network_count: 1
+                          node_id: MDEwOlJlcG9zaXRvcnkyNTk5Mjc5NTg=
+                          notifications_url: https://api.github.com/repos/packit-service/not-potential-spoon/notifications{?since,all,participating}
+                          open_issues: 1
+                          open_issues_count: 1
+                          organization:
+                            avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
+                            events_url: https://api.github.com/users/packit-service/events{/privacy}
+                            followers_url: https://api.github.com/users/packit-service/followers
+                            following_url: https://api.github.com/users/packit-service/following{/other_user}
+                            gists_url: https://api.github.com/users/packit-service/gists{/gist_id}
+                            gravatar_id: ''
+                            html_url: https://github.com/packit-service
+                            id: 46870917
+                            login: packit-service
+                            node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                            organizations_url: https://api.github.com/users/packit-service/orgs
+                            received_events_url: https://api.github.com/users/packit-service/received_events
+                            repos_url: https://api.github.com/users/packit-service/repos
+                            site_admin: false
+                            starred_url: https://api.github.com/users/packit-service/starred{/owner}{/repo}
+                            subscriptions_url: https://api.github.com/users/packit-service/subscriptions
+                            type: Organization
+                            url: https://api.github.com/users/packit-service
+                          owner:
+                            avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
+                            events_url: https://api.github.com/users/packit-service/events{/privacy}
+                            followers_url: https://api.github.com/users/packit-service/followers
+                            following_url: https://api.github.com/users/packit-service/following{/other_user}
+                            gists_url: https://api.github.com/users/packit-service/gists{/gist_id}
+                            gravatar_id: ''
+                            html_url: https://github.com/packit-service
+                            id: 46870917
+                            login: packit-service
+                            node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                            organizations_url: https://api.github.com/users/packit-service/orgs
+                            received_events_url: https://api.github.com/users/packit-service/received_events
+                            repos_url: https://api.github.com/users/packit-service/repos
+                            site_admin: false
+                            starred_url: https://api.github.com/users/packit-service/starred{/owner}{/repo}
+                            subscriptions_url: https://api.github.com/users/packit-service/subscriptions
+                            type: Organization
+                            url: https://api.github.com/users/packit-service
+                          permissions:
+                            admin: true
+                            pull: true
+                            push: true
+                          private: false
+                          pulls_url: https://api.github.com/repos/packit-service/not-potential-spoon/pulls{/number}
+                          pushed_at: '2020-04-29T13:11:24Z'
+                          releases_url: https://api.github.com/repos/packit-service/not-potential-spoon/releases{/id}
+                          size: 0
+                          ssh_url: git@github.com:packit-service/not-potential-spoon.git
+                          stargazers_count: 0
+                          stargazers_url: https://api.github.com/repos/packit-service/not-potential-spoon/stargazers
+                          statuses_url: https://api.github.com/repos/packit-service/not-potential-spoon/statuses/{sha}
+                          subscribers_count: 8
+                          subscribers_url: https://api.github.com/repos/packit-service/not-potential-spoon/subscribers
+                          subscription_url: https://api.github.com/repos/packit-service/not-potential-spoon/subscription
+                          svn_url: https://github.com/packit-service/not-potential-spoon
+                          tags_url: https://api.github.com/repos/packit-service/not-potential-spoon/tags
+                          teams_url: https://api.github.com/repos/packit-service/not-potential-spoon/teams
+                          temp_clone_token: ''
+                          trees_url: https://api.github.com/repos/packit-service/not-potential-spoon/git/trees{/sha}
+                          updated_at: '2020-04-29T13:11:50Z'
+                          url: https://api.github.com/repos/packit-service/not-potential-spoon
+                          watchers: 0
+                          watchers_count: 0
+                        _next: null
+                        elapsed: 0.2
+                        encoding: utf-8
+                        headers:
+                          Access-Control-Allow-Origin: '*'
+                          Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                            X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+                            X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+                            X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
+                          Cache-Control: private, max-age=60, s-maxage=60
+                          Content-Encoding: gzip
+                          Content-Security-Policy: default-src 'none'
+                          Content-Type: application/json; charset=utf-8
+                          Date: Fri, 01 Nov 2019 13-36-03 GMT
+                          ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                          Last-Modified: Wed, 29 Apr 2020 13:11:50 GMT
+                          Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                          Server: GitHub.com
+                          Status: 200 OK
+                          Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                            preload
+                          Transfer-Encoding: chunked
+                          Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                            Accept, X-Requested-With
+                          X-Accepted-OAuth-Scopes: repo
+                          X-Content-Type-Options: nosniff
+                          X-Frame-Options: deny
+                          X-GitHub-Media-Type: github.v3; format=json
+                          X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                          X-OAuth-Scopes: admin:enterprise, admin:gpg_key, admin:org,
+                            admin:org_hook, admin:public_key, admin:repo_hook, delete:packages,
+                            delete_repo, gist, notifications, read:packages, repo,
+                            user, workflow, write:discussion, write:packages
+                          X-RateLimit-Limit: '5000'
+                          X-RateLimit-Remaining: '4972'
+                          X-RateLimit-Reset: '1572953901'
+                          X-XSS-Protection: 1; mode=block
+                        raw: !!binary ""
+                        reason: OK
+                        status_code: 200

--- a/tests/integration/test_data/test_github/tests.integration.test_github.PullRequests.test_source_project_upstream_branch.yaml
+++ b/tests/integration/test_data/test_github/tests.integration.test_github.PullRequests.test_source_project_upstream_branch.yaml
@@ -1,0 +1,582 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectFull
+  version_storage_file: 2
+unittest.case:
+  tests.integration.test_github:
+    ogr.services.github.project:
+      ogr.services.github.pull_request:
+        github.Repository:
+          github.Requester:
+            requests.sessions:
+              requre.objects:
+                requests.sessions:
+                  send:
+                  - metadata:
+                      latency: 0.3980522155761719
+                      module_call_list:
+                      - unittest.case
+                      - tests.integration.test_github
+                      - ogr.services.github.project
+                      - ogr.services.github.pull_request
+                      - github.Repository
+                      - github.Requester
+                      - requests.sessions
+                      - requre.objects
+                      - requests.sessions
+                      - send
+                    output:
+                      __store_indicator: 2
+                      _content:
+                        _links:
+                          comments:
+                            href: https://api.github.com/repos/packit-service/hello-world/issues/72/comments
+                          commits:
+                            href: https://api.github.com/repos/packit-service/hello-world/pulls/72/commits
+                          html:
+                            href: https://github.com/packit-service/hello-world/pull/72
+                          issue:
+                            href: https://api.github.com/repos/packit-service/hello-world/issues/72
+                          review_comment:
+                            href: https://api.github.com/repos/packit-service/hello-world/pulls/comments{/number}
+                          review_comments:
+                            href: https://api.github.com/repos/packit-service/hello-world/pulls/72/comments
+                          self:
+                            href: https://api.github.com/repos/packit-service/hello-world/pulls/72
+                          statuses:
+                            href: https://api.github.com/repos/packit-service/hello-world/statuses/7cf6d0cbeca285ecbeb19a0067cb243783b3c768
+                        additions: 0
+                        assignee: null
+                        assignees: []
+                        author_association: MEMBER
+                        base:
+                          label: packit-service:master
+                          ref: master
+                          repo:
+                            archive_url: https://api.github.com/repos/packit-service/hello-world/{archive_format}{/ref}
+                            archived: false
+                            assignees_url: https://api.github.com/repos/packit-service/hello-world/assignees{/user}
+                            blobs_url: https://api.github.com/repos/packit-service/hello-world/git/blobs{/sha}
+                            branches_url: https://api.github.com/repos/packit-service/hello-world/branches{/branch}
+                            clone_url: https://github.com/packit-service/hello-world.git
+                            collaborators_url: https://api.github.com/repos/packit-service/hello-world/collaborators{/collaborator}
+                            comments_url: https://api.github.com/repos/packit-service/hello-world/comments{/number}
+                            commits_url: https://api.github.com/repos/packit-service/hello-world/commits{/sha}
+                            compare_url: https://api.github.com/repos/packit-service/hello-world/compare/{base}...{head}
+                            contents_url: https://api.github.com/repos/packit-service/hello-world/contents/{+path}
+                            contributors_url: https://api.github.com/repos/packit-service/hello-world/contributors
+                            created_at: '2019-05-02T18:54:46Z'
+                            default_branch: master
+                            deployments_url: https://api.github.com/repos/packit-service/hello-world/deployments
+                            description: The most progresive command-line tool in
+                              the world.
+                            disabled: false
+                            downloads_url: https://api.github.com/repos/packit-service/hello-world/downloads
+                            events_url: https://api.github.com/repos/packit-service/hello-world/events
+                            fork: false
+                            forks: 17
+                            forks_count: 17
+                            forks_url: https://api.github.com/repos/packit-service/hello-world/forks
+                            full_name: packit-service/hello-world
+                            git_commits_url: https://api.github.com/repos/packit-service/hello-world/git/commits{/sha}
+                            git_refs_url: https://api.github.com/repos/packit-service/hello-world/git/refs{/sha}
+                            git_tags_url: https://api.github.com/repos/packit-service/hello-world/git/tags{/sha}
+                            git_url: git://github.com/packit-service/hello-world.git
+                            has_downloads: true
+                            has_issues: true
+                            has_pages: false
+                            has_projects: true
+                            has_wiki: true
+                            homepage: null
+                            hooks_url: https://api.github.com/repos/packit-service/hello-world/hooks
+                            html_url: https://github.com/packit-service/hello-world
+                            id: 184635124
+                            issue_comment_url: https://api.github.com/repos/packit-service/hello-world/issues/comments{/number}
+                            issue_events_url: https://api.github.com/repos/packit-service/hello-world/issues/events{/number}
+                            issues_url: https://api.github.com/repos/packit-service/hello-world/issues{/number}
+                            keys_url: https://api.github.com/repos/packit-service/hello-world/keys{/key_id}
+                            labels_url: https://api.github.com/repos/packit-service/hello-world/labels{/name}
+                            language: Python
+                            languages_url: https://api.github.com/repos/packit-service/hello-world/languages
+                            license:
+                              key: mit
+                              name: MIT License
+                              node_id: MDc6TGljZW5zZTEz
+                              spdx_id: MIT
+                              url: https://api.github.com/licenses/mit
+                            merges_url: https://api.github.com/repos/packit-service/hello-world/merges
+                            milestones_url: https://api.github.com/repos/packit-service/hello-world/milestones{/number}
+                            mirror_url: null
+                            name: hello-world
+                            node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+                            notifications_url: https://api.github.com/repos/packit-service/hello-world/notifications{?since,all,participating}
+                            open_issues: 22
+                            open_issues_count: 22
+                            owner:
+                              avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
+                              events_url: https://api.github.com/users/packit-service/events{/privacy}
+                              followers_url: https://api.github.com/users/packit-service/followers
+                              following_url: https://api.github.com/users/packit-service/following{/other_user}
+                              gists_url: https://api.github.com/users/packit-service/gists{/gist_id}
+                              gravatar_id: ''
+                              html_url: https://github.com/packit-service
+                              id: 46870917
+                              login: packit-service
+                              node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                              organizations_url: https://api.github.com/users/packit-service/orgs
+                              received_events_url: https://api.github.com/users/packit-service/received_events
+                              repos_url: https://api.github.com/users/packit-service/repos
+                              site_admin: false
+                              starred_url: https://api.github.com/users/packit-service/starred{/owner}{/repo}
+                              subscriptions_url: https://api.github.com/users/packit-service/subscriptions
+                              type: Organization
+                              url: https://api.github.com/users/packit-service
+                            private: false
+                            pulls_url: https://api.github.com/repos/packit-service/hello-world/pulls{/number}
+                            pushed_at: '2020-04-23T07:49:42Z'
+                            releases_url: https://api.github.com/repos/packit-service/hello-world/releases{/id}
+                            size: 22
+                            ssh_url: git@github.com:packit-service/hello-world.git
+                            stargazers_count: 0
+                            stargazers_url: https://api.github.com/repos/packit-service/hello-world/stargazers
+                            statuses_url: https://api.github.com/repos/packit-service/hello-world/statuses/{sha}
+                            subscribers_url: https://api.github.com/repos/packit-service/hello-world/subscribers
+                            subscription_url: https://api.github.com/repos/packit-service/hello-world/subscription
+                            svn_url: https://github.com/packit-service/hello-world
+                            tags_url: https://api.github.com/repos/packit-service/hello-world/tags
+                            teams_url: https://api.github.com/repos/packit-service/hello-world/teams
+                            trees_url: https://api.github.com/repos/packit-service/hello-world/git/trees{/sha}
+                            updated_at: '2020-04-03T14:38:55Z'
+                            url: https://api.github.com/repos/packit-service/hello-world
+                            watchers: 0
+                            watchers_count: 0
+                          sha: 28d30dd1178b9983a0b717c809895500b2a3583b
+                          user:
+                            avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
+                            events_url: https://api.github.com/users/packit-service/events{/privacy}
+                            followers_url: https://api.github.com/users/packit-service/followers
+                            following_url: https://api.github.com/users/packit-service/following{/other_user}
+                            gists_url: https://api.github.com/users/packit-service/gists{/gist_id}
+                            gravatar_id: ''
+                            html_url: https://github.com/packit-service
+                            id: 46870917
+                            login: packit-service
+                            node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                            organizations_url: https://api.github.com/users/packit-service/orgs
+                            received_events_url: https://api.github.com/users/packit-service/received_events
+                            repos_url: https://api.github.com/users/packit-service/repos
+                            site_admin: false
+                            starred_url: https://api.github.com/users/packit-service/starred{/owner}{/repo}
+                            subscriptions_url: https://api.github.com/users/packit-service/subscriptions
+                            type: Organization
+                            url: https://api.github.com/users/packit-service
+                        body: This test case is used for testing OGR project - updating
+                          the pr info
+                        changed_files: 1
+                        closed_at: null
+                        comments: 1
+                        comments_url: https://api.github.com/repos/packit-service/hello-world/issues/72/comments
+                        commits: 3
+                        commits_url: https://api.github.com/repos/packit-service/hello-world/pulls/72/commits
+                        created_at: '2019-11-27T11:19:20Z'
+                        deletions: 26
+                        diff_url: https://github.com/packit-service/hello-world/pull/72.diff
+                        draft: false
+                        head:
+                          label: packit-service:test_source
+                          ref: test_source
+                          repo:
+                            archive_url: https://api.github.com/repos/packit-service/hello-world/{archive_format}{/ref}
+                            archived: false
+                            assignees_url: https://api.github.com/repos/packit-service/hello-world/assignees{/user}
+                            blobs_url: https://api.github.com/repos/packit-service/hello-world/git/blobs{/sha}
+                            branches_url: https://api.github.com/repos/packit-service/hello-world/branches{/branch}
+                            clone_url: https://github.com/packit-service/hello-world.git
+                            collaborators_url: https://api.github.com/repos/packit-service/hello-world/collaborators{/collaborator}
+                            comments_url: https://api.github.com/repos/packit-service/hello-world/comments{/number}
+                            commits_url: https://api.github.com/repos/packit-service/hello-world/commits{/sha}
+                            compare_url: https://api.github.com/repos/packit-service/hello-world/compare/{base}...{head}
+                            contents_url: https://api.github.com/repos/packit-service/hello-world/contents/{+path}
+                            contributors_url: https://api.github.com/repos/packit-service/hello-world/contributors
+                            created_at: '2019-05-02T18:54:46Z'
+                            default_branch: master
+                            deployments_url: https://api.github.com/repos/packit-service/hello-world/deployments
+                            description: The most progresive command-line tool in
+                              the world.
+                            disabled: false
+                            downloads_url: https://api.github.com/repos/packit-service/hello-world/downloads
+                            events_url: https://api.github.com/repos/packit-service/hello-world/events
+                            fork: false
+                            forks: 17
+                            forks_count: 17
+                            forks_url: https://api.github.com/repos/packit-service/hello-world/forks
+                            full_name: packit-service/hello-world
+                            git_commits_url: https://api.github.com/repos/packit-service/hello-world/git/commits{/sha}
+                            git_refs_url: https://api.github.com/repos/packit-service/hello-world/git/refs{/sha}
+                            git_tags_url: https://api.github.com/repos/packit-service/hello-world/git/tags{/sha}
+                            git_url: git://github.com/packit-service/hello-world.git
+                            has_downloads: true
+                            has_issues: true
+                            has_pages: false
+                            has_projects: true
+                            has_wiki: true
+                            homepage: null
+                            hooks_url: https://api.github.com/repos/packit-service/hello-world/hooks
+                            html_url: https://github.com/packit-service/hello-world
+                            id: 184635124
+                            issue_comment_url: https://api.github.com/repos/packit-service/hello-world/issues/comments{/number}
+                            issue_events_url: https://api.github.com/repos/packit-service/hello-world/issues/events{/number}
+                            issues_url: https://api.github.com/repos/packit-service/hello-world/issues{/number}
+                            keys_url: https://api.github.com/repos/packit-service/hello-world/keys{/key_id}
+                            labels_url: https://api.github.com/repos/packit-service/hello-world/labels{/name}
+                            language: Python
+                            languages_url: https://api.github.com/repos/packit-service/hello-world/languages
+                            license:
+                              key: mit
+                              name: MIT License
+                              node_id: MDc6TGljZW5zZTEz
+                              spdx_id: MIT
+                              url: https://api.github.com/licenses/mit
+                            merges_url: https://api.github.com/repos/packit-service/hello-world/merges
+                            milestones_url: https://api.github.com/repos/packit-service/hello-world/milestones{/number}
+                            mirror_url: null
+                            name: hello-world
+                            node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+                            notifications_url: https://api.github.com/repos/packit-service/hello-world/notifications{?since,all,participating}
+                            open_issues: 22
+                            open_issues_count: 22
+                            owner:
+                              avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
+                              events_url: https://api.github.com/users/packit-service/events{/privacy}
+                              followers_url: https://api.github.com/users/packit-service/followers
+                              following_url: https://api.github.com/users/packit-service/following{/other_user}
+                              gists_url: https://api.github.com/users/packit-service/gists{/gist_id}
+                              gravatar_id: ''
+                              html_url: https://github.com/packit-service
+                              id: 46870917
+                              login: packit-service
+                              node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                              organizations_url: https://api.github.com/users/packit-service/orgs
+                              received_events_url: https://api.github.com/users/packit-service/received_events
+                              repos_url: https://api.github.com/users/packit-service/repos
+                              site_admin: false
+                              starred_url: https://api.github.com/users/packit-service/starred{/owner}{/repo}
+                              subscriptions_url: https://api.github.com/users/packit-service/subscriptions
+                              type: Organization
+                              url: https://api.github.com/users/packit-service
+                            private: false
+                            pulls_url: https://api.github.com/repos/packit-service/hello-world/pulls{/number}
+                            pushed_at: '2020-04-23T07:49:42Z'
+                            releases_url: https://api.github.com/repos/packit-service/hello-world/releases{/id}
+                            size: 22
+                            ssh_url: git@github.com:packit-service/hello-world.git
+                            stargazers_count: 0
+                            stargazers_url: https://api.github.com/repos/packit-service/hello-world/stargazers
+                            statuses_url: https://api.github.com/repos/packit-service/hello-world/statuses/{sha}
+                            subscribers_url: https://api.github.com/repos/packit-service/hello-world/subscribers
+                            subscription_url: https://api.github.com/repos/packit-service/hello-world/subscription
+                            svn_url: https://github.com/packit-service/hello-world
+                            tags_url: https://api.github.com/repos/packit-service/hello-world/tags
+                            teams_url: https://api.github.com/repos/packit-service/hello-world/teams
+                            trees_url: https://api.github.com/repos/packit-service/hello-world/git/trees{/sha}
+                            updated_at: '2020-04-03T14:38:55Z'
+                            url: https://api.github.com/repos/packit-service/hello-world
+                            watchers: 0
+                            watchers_count: 0
+                          sha: 7cf6d0cbeca285ecbeb19a0067cb243783b3c768
+                          user:
+                            avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
+                            events_url: https://api.github.com/users/packit-service/events{/privacy}
+                            followers_url: https://api.github.com/users/packit-service/followers
+                            following_url: https://api.github.com/users/packit-service/following{/other_user}
+                            gists_url: https://api.github.com/users/packit-service/gists{/gist_id}
+                            gravatar_id: ''
+                            html_url: https://github.com/packit-service
+                            id: 46870917
+                            login: packit-service
+                            node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                            organizations_url: https://api.github.com/users/packit-service/orgs
+                            received_events_url: https://api.github.com/users/packit-service/received_events
+                            repos_url: https://api.github.com/users/packit-service/repos
+                            site_admin: false
+                            starred_url: https://api.github.com/users/packit-service/starred{/owner}{/repo}
+                            subscriptions_url: https://api.github.com/users/packit-service/subscriptions
+                            type: Organization
+                            url: https://api.github.com/users/packit-service
+                        html_url: https://github.com/packit-service/hello-world/pull/72
+                        id: 346187823
+                        issue_url: https://api.github.com/repos/packit-service/hello-world/issues/72
+                        labels: []
+                        locked: false
+                        maintainer_can_modify: false
+                        merge_commit_sha: 919658de01745f4dcdfac66d247cd37a91988fb1
+                        mergeable: false
+                        mergeable_state: dirty
+                        merged: false
+                        merged_at: null
+                        merged_by: null
+                        milestone: null
+                        node_id: MDExOlB1bGxSZXF1ZXN0MzQ2MTg3ODIz
+                        number: 72
+                        patch_url: https://github.com/packit-service/hello-world/pull/72.patch
+                        rebaseable: false
+                        requested_reviewers: []
+                        requested_teams: []
+                        review_comment_url: https://api.github.com/repos/packit-service/hello-world/pulls/comments{/number}
+                        review_comments: 0
+                        review_comments_url: https://api.github.com/repos/packit-service/hello-world/pulls/72/comments
+                        state: open
+                        statuses_url: https://api.github.com/repos/packit-service/hello-world/statuses/7cf6d0cbeca285ecbeb19a0067cb243783b3c768
+                        title: 'Ogr test case: Test pull request for updating PR info'
+                        updated_at: '2020-04-21T08:38:04Z'
+                        url: https://api.github.com/repos/packit-service/hello-world/pulls/72
+                        user:
+                          avatar_url: https://avatars0.githubusercontent.com/u/8149784?v=4
+                          events_url: https://api.github.com/users/mfocko/events{/privacy}
+                          followers_url: https://api.github.com/users/mfocko/followers
+                          following_url: https://api.github.com/users/mfocko/following{/other_user}
+                          gists_url: https://api.github.com/users/mfocko/gists{/gist_id}
+                          gravatar_id: ''
+                          html_url: https://github.com/mfocko
+                          id: 8149784
+                          login: mfocko
+                          node_id: MDQ6VXNlcjgxNDk3ODQ=
+                          organizations_url: https://api.github.com/users/mfocko/orgs
+                          received_events_url: https://api.github.com/users/mfocko/received_events
+                          repos_url: https://api.github.com/users/mfocko/repos
+                          site_admin: false
+                          starred_url: https://api.github.com/users/mfocko/starred{/owner}{/repo}
+                          subscriptions_url: https://api.github.com/users/mfocko/subscriptions
+                          type: User
+                          url: https://api.github.com/users/mfocko
+                      _next: null
+                      elapsed: 0.2
+                      encoding: utf-8
+                      headers:
+                        Access-Control-Allow-Origin: '*'
+                        Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                          X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+                          X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+                          X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
+                        Cache-Control: private, max-age=60, s-maxage=60
+                        Content-Encoding: gzip
+                        Content-Security-Policy: default-src 'none'
+                        Content-Type: application/json; charset=utf-8
+                        Date: Fri, 01 Nov 2019 13-36-03 GMT
+                        ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                        Last-Modified: Fri, 24 Apr 2020 11:08:43 GMT
+                        Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                        Server: GitHub.com
+                        Status: 200 OK
+                        Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                          preload
+                        Transfer-Encoding: chunked
+                        Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                          Accept, X-Requested-With
+                        X-Accepted-OAuth-Scopes: ''
+                        X-Content-Type-Options: nosniff
+                        X-Frame-Options: deny
+                        X-GitHub-Media-Type: github.v3; format=json
+                        X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                        X-OAuth-Scopes: admin:enterprise, admin:gpg_key, admin:org,
+                          admin:org_hook, admin:public_key, admin:repo_hook, delete:packages,
+                          delete_repo, gist, notifications, read:packages, repo, user,
+                          workflow, write:discussion, write:packages
+                        X-RateLimit-Limit: '5000'
+                        X-RateLimit-Remaining: '4972'
+                        X-RateLimit-Reset: '1572953901'
+                        X-XSS-Protection: 1; mode=block
+                      raw: !!binary ""
+                      reason: OK
+                      status_code: 200
+        ogr.services.github.project:
+          github.MainClass:
+            github.Requester:
+              requests.sessions:
+                requre.objects:
+                  requests.sessions:
+                    send:
+                    - metadata:
+                        latency: 0.5266990661621094
+                        module_call_list:
+                        - unittest.case
+                        - tests.integration.test_github
+                        - ogr.services.github.project
+                        - ogr.services.github.pull_request
+                        - ogr.services.github.project
+                        - github.MainClass
+                        - github.Requester
+                        - requests.sessions
+                        - requre.objects
+                        - requests.sessions
+                        - send
+                      output:
+                        __store_indicator: 2
+                        _content:
+                          allow_merge_commit: true
+                          allow_rebase_merge: true
+                          allow_squash_merge: true
+                          archive_url: https://api.github.com/repos/packit-service/hello-world/{archive_format}{/ref}
+                          archived: false
+                          assignees_url: https://api.github.com/repos/packit-service/hello-world/assignees{/user}
+                          blobs_url: https://api.github.com/repos/packit-service/hello-world/git/blobs{/sha}
+                          branches_url: https://api.github.com/repos/packit-service/hello-world/branches{/branch}
+                          clone_url: https://github.com/packit-service/hello-world.git
+                          collaborators_url: https://api.github.com/repos/packit-service/hello-world/collaborators{/collaborator}
+                          comments_url: https://api.github.com/repos/packit-service/hello-world/comments{/number}
+                          commits_url: https://api.github.com/repos/packit-service/hello-world/commits{/sha}
+                          compare_url: https://api.github.com/repos/packit-service/hello-world/compare/{base}...{head}
+                          contents_url: https://api.github.com/repos/packit-service/hello-world/contents/{+path}
+                          contributors_url: https://api.github.com/repos/packit-service/hello-world/contributors
+                          created_at: '2019-05-02T18:54:46Z'
+                          default_branch: master
+                          delete_branch_on_merge: false
+                          deployments_url: https://api.github.com/repos/packit-service/hello-world/deployments
+                          description: The most progresive command-line tool in the
+                            world.
+                          disabled: false
+                          downloads_url: https://api.github.com/repos/packit-service/hello-world/downloads
+                          events_url: https://api.github.com/repos/packit-service/hello-world/events
+                          fork: false
+                          forks: 17
+                          forks_count: 17
+                          forks_url: https://api.github.com/repos/packit-service/hello-world/forks
+                          full_name: packit-service/hello-world
+                          git_commits_url: https://api.github.com/repos/packit-service/hello-world/git/commits{/sha}
+                          git_refs_url: https://api.github.com/repos/packit-service/hello-world/git/refs{/sha}
+                          git_tags_url: https://api.github.com/repos/packit-service/hello-world/git/tags{/sha}
+                          git_url: git://github.com/packit-service/hello-world.git
+                          has_downloads: true
+                          has_issues: true
+                          has_pages: false
+                          has_projects: true
+                          has_wiki: true
+                          homepage: null
+                          hooks_url: https://api.github.com/repos/packit-service/hello-world/hooks
+                          html_url: https://github.com/packit-service/hello-world
+                          id: 184635124
+                          issue_comment_url: https://api.github.com/repos/packit-service/hello-world/issues/comments{/number}
+                          issue_events_url: https://api.github.com/repos/packit-service/hello-world/issues/events{/number}
+                          issues_url: https://api.github.com/repos/packit-service/hello-world/issues{/number}
+                          keys_url: https://api.github.com/repos/packit-service/hello-world/keys{/key_id}
+                          labels_url: https://api.github.com/repos/packit-service/hello-world/labels{/name}
+                          language: Python
+                          languages_url: https://api.github.com/repos/packit-service/hello-world/languages
+                          license:
+                            key: mit
+                            name: MIT License
+                            node_id: MDc6TGljZW5zZTEz
+                            spdx_id: MIT
+                            url: https://api.github.com/licenses/mit
+                          merges_url: https://api.github.com/repos/packit-service/hello-world/merges
+                          milestones_url: https://api.github.com/repos/packit-service/hello-world/milestones{/number}
+                          mirror_url: null
+                          name: hello-world
+                          network_count: 17
+                          node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+                          notifications_url: https://api.github.com/repos/packit-service/hello-world/notifications{?since,all,participating}
+                          open_issues: 22
+                          open_issues_count: 22
+                          organization:
+                            avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
+                            events_url: https://api.github.com/users/packit-service/events{/privacy}
+                            followers_url: https://api.github.com/users/packit-service/followers
+                            following_url: https://api.github.com/users/packit-service/following{/other_user}
+                            gists_url: https://api.github.com/users/packit-service/gists{/gist_id}
+                            gravatar_id: ''
+                            html_url: https://github.com/packit-service
+                            id: 46870917
+                            login: packit-service
+                            node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                            organizations_url: https://api.github.com/users/packit-service/orgs
+                            received_events_url: https://api.github.com/users/packit-service/received_events
+                            repos_url: https://api.github.com/users/packit-service/repos
+                            site_admin: false
+                            starred_url: https://api.github.com/users/packit-service/starred{/owner}{/repo}
+                            subscriptions_url: https://api.github.com/users/packit-service/subscriptions
+                            type: Organization
+                            url: https://api.github.com/users/packit-service
+                          owner:
+                            avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
+                            events_url: https://api.github.com/users/packit-service/events{/privacy}
+                            followers_url: https://api.github.com/users/packit-service/followers
+                            following_url: https://api.github.com/users/packit-service/following{/other_user}
+                            gists_url: https://api.github.com/users/packit-service/gists{/gist_id}
+                            gravatar_id: ''
+                            html_url: https://github.com/packit-service
+                            id: 46870917
+                            login: packit-service
+                            node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                            organizations_url: https://api.github.com/users/packit-service/orgs
+                            received_events_url: https://api.github.com/users/packit-service/received_events
+                            repos_url: https://api.github.com/users/packit-service/repos
+                            site_admin: false
+                            starred_url: https://api.github.com/users/packit-service/starred{/owner}{/repo}
+                            subscriptions_url: https://api.github.com/users/packit-service/subscriptions
+                            type: Organization
+                            url: https://api.github.com/users/packit-service
+                          permissions:
+                            admin: true
+                            pull: true
+                            push: true
+                          private: false
+                          pulls_url: https://api.github.com/repos/packit-service/hello-world/pulls{/number}
+                          pushed_at: '2020-04-23T07:49:42Z'
+                          releases_url: https://api.github.com/repos/packit-service/hello-world/releases{/id}
+                          size: 22
+                          ssh_url: git@github.com:packit-service/hello-world.git
+                          stargazers_count: 0
+                          stargazers_url: https://api.github.com/repos/packit-service/hello-world/stargazers
+                          statuses_url: https://api.github.com/repos/packit-service/hello-world/statuses/{sha}
+                          subscribers_count: 8
+                          subscribers_url: https://api.github.com/repos/packit-service/hello-world/subscribers
+                          subscription_url: https://api.github.com/repos/packit-service/hello-world/subscription
+                          svn_url: https://github.com/packit-service/hello-world
+                          tags_url: https://api.github.com/repos/packit-service/hello-world/tags
+                          teams_url: https://api.github.com/repos/packit-service/hello-world/teams
+                          temp_clone_token: ''
+                          trees_url: https://api.github.com/repos/packit-service/hello-world/git/trees{/sha}
+                          updated_at: '2020-04-03T14:38:55Z'
+                          url: https://api.github.com/repos/packit-service/hello-world
+                          watchers: 0
+                          watchers_count: 0
+                        _next: null
+                        elapsed: 0.2
+                        encoding: utf-8
+                        headers:
+                          Access-Control-Allow-Origin: '*'
+                          Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                            X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+                            X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+                            X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
+                          Cache-Control: private, max-age=60, s-maxage=60
+                          Content-Encoding: gzip
+                          Content-Security-Policy: default-src 'none'
+                          Content-Type: application/json; charset=utf-8
+                          Date: Fri, 01 Nov 2019 13-36-03 GMT
+                          ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                          Last-Modified: Fri, 03 Apr 2020 14:38:55 GMT
+                          Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                          Server: GitHub.com
+                          Status: 200 OK
+                          Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                            preload
+                          Transfer-Encoding: chunked
+                          Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                            Accept, X-Requested-With
+                          X-Accepted-OAuth-Scopes: repo
+                          X-Content-Type-Options: nosniff
+                          X-Frame-Options: deny
+                          X-GitHub-Media-Type: github.v3; format=json
+                          X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                          X-OAuth-Scopes: admin:enterprise, admin:gpg_key, admin:org,
+                            admin:org_hook, admin:public_key, admin:repo_hook, delete:packages,
+                            delete_repo, gist, notifications, read:packages, repo,
+                            user, workflow, write:discussion, write:packages
+                          X-RateLimit-Limit: '5000'
+                          X-RateLimit-Remaining: '4972'
+                          X-RateLimit-Reset: '1572953901'
+                          X-XSS-Protection: 1; mode=block
+                        raw: !!binary ""
+                        reason: OK
+                        status_code: 200

--- a/tests/integration/test_data/test_github/tests.integration.test_github.PullRequests.test_source_project_upstream_fork.yaml
+++ b/tests/integration/test_data/test_github/tests.integration.test_github.PullRequests.test_source_project_upstream_fork.yaml
@@ -1,0 +1,581 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectFull
+  version_storage_file: 2
+unittest.case:
+  tests.integration.test_github:
+    ogr.services.github.project:
+      ogr.services.github.pull_request:
+        github.Repository:
+          github.Requester:
+            requests.sessions:
+              requre.objects:
+                requests.sessions:
+                  send:
+                  - metadata:
+                      latency: 0.5031528472900391
+                      module_call_list:
+                      - unittest.case
+                      - tests.integration.test_github
+                      - ogr.services.github.project
+                      - ogr.services.github.pull_request
+                      - github.Repository
+                      - github.Requester
+                      - requests.sessions
+                      - requre.objects
+                      - requests.sessions
+                      - send
+                    output:
+                      __store_indicator: 2
+                      _content:
+                        _links:
+                          comments:
+                            href: https://api.github.com/repos/packit-service/hello-world/issues/111/comments
+                          commits:
+                            href: https://api.github.com/repos/packit-service/hello-world/pulls/111/commits
+                          html:
+                            href: https://github.com/packit-service/hello-world/pull/111
+                          issue:
+                            href: https://api.github.com/repos/packit-service/hello-world/issues/111
+                          review_comment:
+                            href: https://api.github.com/repos/packit-service/hello-world/pulls/comments{/number}
+                          review_comments:
+                            href: https://api.github.com/repos/packit-service/hello-world/pulls/111/comments
+                          self:
+                            href: https://api.github.com/repos/packit-service/hello-world/pulls/111
+                          statuses:
+                            href: https://api.github.com/repos/packit-service/hello-world/statuses/1abb19255a7c1bec7ffcae2487f022b23175af2b
+                        additions: 0
+                        assignee: null
+                        assignees: []
+                        author_association: MEMBER
+                        base:
+                          label: packit-service:master
+                          ref: master
+                          repo:
+                            archive_url: https://api.github.com/repos/packit-service/hello-world/{archive_format}{/ref}
+                            archived: false
+                            assignees_url: https://api.github.com/repos/packit-service/hello-world/assignees{/user}
+                            blobs_url: https://api.github.com/repos/packit-service/hello-world/git/blobs{/sha}
+                            branches_url: https://api.github.com/repos/packit-service/hello-world/branches{/branch}
+                            clone_url: https://github.com/packit-service/hello-world.git
+                            collaborators_url: https://api.github.com/repos/packit-service/hello-world/collaborators{/collaborator}
+                            comments_url: https://api.github.com/repos/packit-service/hello-world/comments{/number}
+                            commits_url: https://api.github.com/repos/packit-service/hello-world/commits{/sha}
+                            compare_url: https://api.github.com/repos/packit-service/hello-world/compare/{base}...{head}
+                            contents_url: https://api.github.com/repos/packit-service/hello-world/contents/{+path}
+                            contributors_url: https://api.github.com/repos/packit-service/hello-world/contributors
+                            created_at: '2019-05-02T18:54:46Z'
+                            default_branch: master
+                            deployments_url: https://api.github.com/repos/packit-service/hello-world/deployments
+                            description: The most progresive command-line tool in
+                              the world.
+                            disabled: false
+                            downloads_url: https://api.github.com/repos/packit-service/hello-world/downloads
+                            events_url: https://api.github.com/repos/packit-service/hello-world/events
+                            fork: false
+                            forks: 17
+                            forks_count: 17
+                            forks_url: https://api.github.com/repos/packit-service/hello-world/forks
+                            full_name: packit-service/hello-world
+                            git_commits_url: https://api.github.com/repos/packit-service/hello-world/git/commits{/sha}
+                            git_refs_url: https://api.github.com/repos/packit-service/hello-world/git/refs{/sha}
+                            git_tags_url: https://api.github.com/repos/packit-service/hello-world/git/tags{/sha}
+                            git_url: git://github.com/packit-service/hello-world.git
+                            has_downloads: true
+                            has_issues: true
+                            has_pages: false
+                            has_projects: true
+                            has_wiki: true
+                            homepage: null
+                            hooks_url: https://api.github.com/repos/packit-service/hello-world/hooks
+                            html_url: https://github.com/packit-service/hello-world
+                            id: 184635124
+                            issue_comment_url: https://api.github.com/repos/packit-service/hello-world/issues/comments{/number}
+                            issue_events_url: https://api.github.com/repos/packit-service/hello-world/issues/events{/number}
+                            issues_url: https://api.github.com/repos/packit-service/hello-world/issues{/number}
+                            keys_url: https://api.github.com/repos/packit-service/hello-world/keys{/key_id}
+                            labels_url: https://api.github.com/repos/packit-service/hello-world/labels{/name}
+                            language: Python
+                            languages_url: https://api.github.com/repos/packit-service/hello-world/languages
+                            license:
+                              key: mit
+                              name: MIT License
+                              node_id: MDc6TGljZW5zZTEz
+                              spdx_id: MIT
+                              url: https://api.github.com/licenses/mit
+                            merges_url: https://api.github.com/repos/packit-service/hello-world/merges
+                            milestones_url: https://api.github.com/repos/packit-service/hello-world/milestones{/number}
+                            mirror_url: null
+                            name: hello-world
+                            node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+                            notifications_url: https://api.github.com/repos/packit-service/hello-world/notifications{?since,all,participating}
+                            open_issues: 22
+                            open_issues_count: 22
+                            owner:
+                              avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
+                              events_url: https://api.github.com/users/packit-service/events{/privacy}
+                              followers_url: https://api.github.com/users/packit-service/followers
+                              following_url: https://api.github.com/users/packit-service/following{/other_user}
+                              gists_url: https://api.github.com/users/packit-service/gists{/gist_id}
+                              gravatar_id: ''
+                              html_url: https://github.com/packit-service
+                              id: 46870917
+                              login: packit-service
+                              node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                              organizations_url: https://api.github.com/users/packit-service/orgs
+                              received_events_url: https://api.github.com/users/packit-service/received_events
+                              repos_url: https://api.github.com/users/packit-service/repos
+                              site_admin: false
+                              starred_url: https://api.github.com/users/packit-service/starred{/owner}{/repo}
+                              subscriptions_url: https://api.github.com/users/packit-service/subscriptions
+                              type: Organization
+                              url: https://api.github.com/users/packit-service
+                            private: false
+                            pulls_url: https://api.github.com/repos/packit-service/hello-world/pulls{/number}
+                            pushed_at: '2020-04-23T07:49:42Z'
+                            releases_url: https://api.github.com/repos/packit-service/hello-world/releases{/id}
+                            size: 22
+                            ssh_url: git@github.com:packit-service/hello-world.git
+                            stargazers_count: 0
+                            stargazers_url: https://api.github.com/repos/packit-service/hello-world/stargazers
+                            statuses_url: https://api.github.com/repos/packit-service/hello-world/statuses/{sha}
+                            subscribers_url: https://api.github.com/repos/packit-service/hello-world/subscribers
+                            subscription_url: https://api.github.com/repos/packit-service/hello-world/subscription
+                            svn_url: https://github.com/packit-service/hello-world
+                            tags_url: https://api.github.com/repos/packit-service/hello-world/tags
+                            teams_url: https://api.github.com/repos/packit-service/hello-world/teams
+                            trees_url: https://api.github.com/repos/packit-service/hello-world/git/trees{/sha}
+                            updated_at: '2020-04-03T14:38:55Z'
+                            url: https://api.github.com/repos/packit-service/hello-world
+                            watchers: 0
+                            watchers_count: 0
+                          sha: c0f5d6ee6e4a482877aa9d92066918fa1eb15423
+                          user:
+                            avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
+                            events_url: https://api.github.com/users/packit-service/events{/privacy}
+                            followers_url: https://api.github.com/users/packit-service/followers
+                            following_url: https://api.github.com/users/packit-service/following{/other_user}
+                            gists_url: https://api.github.com/users/packit-service/gists{/gist_id}
+                            gravatar_id: ''
+                            html_url: https://github.com/packit-service
+                            id: 46870917
+                            login: packit-service
+                            node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                            organizations_url: https://api.github.com/users/packit-service/orgs
+                            received_events_url: https://api.github.com/users/packit-service/received_events
+                            repos_url: https://api.github.com/users/packit-service/repos
+                            site_admin: false
+                            starred_url: https://api.github.com/users/packit-service/starred{/owner}{/repo}
+                            subscriptions_url: https://api.github.com/users/packit-service/subscriptions
+                            type: Organization
+                            url: https://api.github.com/users/packit-service
+                        body: ''
+                        changed_files: 3
+                        closed_at: null
+                        comments: 0
+                        comments_url: https://api.github.com/repos/packit-service/hello-world/issues/111/comments
+                        commits: 1
+                        commits_url: https://api.github.com/repos/packit-service/hello-world/pulls/111/commits
+                        created_at: '2020-04-21T09:28:40Z'
+                        deletions: 18
+                        diff_url: https://github.com/packit-service/hello-world/pull/111.diff
+                        draft: false
+                        head:
+                          label: lbarcziova:test_case_no_fmf
+                          ref: test_case_no_fmf
+                          repo:
+                            archive_url: https://api.github.com/repos/lbarcziova/hello-world/{archive_format}{/ref}
+                            archived: false
+                            assignees_url: https://api.github.com/repos/lbarcziova/hello-world/assignees{/user}
+                            blobs_url: https://api.github.com/repos/lbarcziova/hello-world/git/blobs{/sha}
+                            branches_url: https://api.github.com/repos/lbarcziova/hello-world/branches{/branch}
+                            clone_url: https://github.com/lbarcziova/hello-world.git
+                            collaborators_url: https://api.github.com/repos/lbarcziova/hello-world/collaborators{/collaborator}
+                            comments_url: https://api.github.com/repos/lbarcziova/hello-world/comments{/number}
+                            commits_url: https://api.github.com/repos/lbarcziova/hello-world/commits{/sha}
+                            compare_url: https://api.github.com/repos/lbarcziova/hello-world/compare/{base}...{head}
+                            contents_url: https://api.github.com/repos/lbarcziova/hello-world/contents/{+path}
+                            contributors_url: https://api.github.com/repos/lbarcziova/hello-world/contributors
+                            created_at: '2019-07-11T13:14:42Z'
+                            default_branch: master
+                            deployments_url: https://api.github.com/repos/lbarcziova/hello-world/deployments
+                            description: The most progresive command-line tool in
+                              the world.
+                            disabled: false
+                            downloads_url: https://api.github.com/repos/lbarcziova/hello-world/downloads
+                            events_url: https://api.github.com/repos/lbarcziova/hello-world/events
+                            fork: true
+                            forks: 0
+                            forks_count: 0
+                            forks_url: https://api.github.com/repos/lbarcziova/hello-world/forks
+                            full_name: lbarcziova/hello-world
+                            git_commits_url: https://api.github.com/repos/lbarcziova/hello-world/git/commits{/sha}
+                            git_refs_url: https://api.github.com/repos/lbarcziova/hello-world/git/refs{/sha}
+                            git_tags_url: https://api.github.com/repos/lbarcziova/hello-world/git/tags{/sha}
+                            git_url: git://github.com/lbarcziova/hello-world.git
+                            has_downloads: true
+                            has_issues: false
+                            has_pages: false
+                            has_projects: true
+                            has_wiki: true
+                            homepage: null
+                            hooks_url: https://api.github.com/repos/lbarcziova/hello-world/hooks
+                            html_url: https://github.com/lbarcziova/hello-world
+                            id: 196397797
+                            issue_comment_url: https://api.github.com/repos/lbarcziova/hello-world/issues/comments{/number}
+                            issue_events_url: https://api.github.com/repos/lbarcziova/hello-world/issues/events{/number}
+                            issues_url: https://api.github.com/repos/lbarcziova/hello-world/issues{/number}
+                            keys_url: https://api.github.com/repos/lbarcziova/hello-world/keys{/key_id}
+                            labels_url: https://api.github.com/repos/lbarcziova/hello-world/labels{/name}
+                            language: Python
+                            languages_url: https://api.github.com/repos/lbarcziova/hello-world/languages
+                            license:
+                              key: mit
+                              name: MIT License
+                              node_id: MDc6TGljZW5zZTEz
+                              spdx_id: MIT
+                              url: https://api.github.com/licenses/mit
+                            merges_url: https://api.github.com/repos/lbarcziova/hello-world/merges
+                            milestones_url: https://api.github.com/repos/lbarcziova/hello-world/milestones{/number}
+                            mirror_url: null
+                            name: hello-world
+                            node_id: MDEwOlJlcG9zaXRvcnkxOTYzOTc3OTc=
+                            notifications_url: https://api.github.com/repos/lbarcziova/hello-world/notifications{?since,all,participating}
+                            open_issues: 0
+                            open_issues_count: 0
+                            owner:
+                              avatar_url: https://avatars3.githubusercontent.com/u/49026743?v=4
+                              events_url: https://api.github.com/users/lbarcziova/events{/privacy}
+                              followers_url: https://api.github.com/users/lbarcziova/followers
+                              following_url: https://api.github.com/users/lbarcziova/following{/other_user}
+                              gists_url: https://api.github.com/users/lbarcziova/gists{/gist_id}
+                              gravatar_id: ''
+                              html_url: https://github.com/lbarcziova
+                              id: 49026743
+                              login: lbarcziova
+                              node_id: MDQ6VXNlcjQ5MDI2NzQz
+                              organizations_url: https://api.github.com/users/lbarcziova/orgs
+                              received_events_url: https://api.github.com/users/lbarcziova/received_events
+                              repos_url: https://api.github.com/users/lbarcziova/repos
+                              site_admin: false
+                              starred_url: https://api.github.com/users/lbarcziova/starred{/owner}{/repo}
+                              subscriptions_url: https://api.github.com/users/lbarcziova/subscriptions
+                              type: User
+                              url: https://api.github.com/users/lbarcziova
+                            private: false
+                            pulls_url: https://api.github.com/repos/lbarcziova/hello-world/pulls{/number}
+                            pushed_at: '2020-04-23T07:49:24Z'
+                            releases_url: https://api.github.com/repos/lbarcziova/hello-world/releases{/id}
+                            size: 21
+                            ssh_url: git@github.com:lbarcziova/hello-world.git
+                            stargazers_count: 0
+                            stargazers_url: https://api.github.com/repos/lbarcziova/hello-world/stargazers
+                            statuses_url: https://api.github.com/repos/lbarcziova/hello-world/statuses/{sha}
+                            subscribers_url: https://api.github.com/repos/lbarcziova/hello-world/subscribers
+                            subscription_url: https://api.github.com/repos/lbarcziova/hello-world/subscription
+                            svn_url: https://github.com/lbarcziova/hello-world
+                            tags_url: https://api.github.com/repos/lbarcziova/hello-world/tags
+                            teams_url: https://api.github.com/repos/lbarcziova/hello-world/teams
+                            trees_url: https://api.github.com/repos/lbarcziova/hello-world/git/trees{/sha}
+                            updated_at: '2019-07-11T13:14:45Z'
+                            url: https://api.github.com/repos/lbarcziova/hello-world
+                            watchers: 0
+                            watchers_count: 0
+                          sha: 1abb19255a7c1bec7ffcae2487f022b23175af2b
+                          user:
+                            avatar_url: https://avatars3.githubusercontent.com/u/49026743?v=4
+                            events_url: https://api.github.com/users/lbarcziova/events{/privacy}
+                            followers_url: https://api.github.com/users/lbarcziova/followers
+                            following_url: https://api.github.com/users/lbarcziova/following{/other_user}
+                            gists_url: https://api.github.com/users/lbarcziova/gists{/gist_id}
+                            gravatar_id: ''
+                            html_url: https://github.com/lbarcziova
+                            id: 49026743
+                            login: lbarcziova
+                            node_id: MDQ6VXNlcjQ5MDI2NzQz
+                            organizations_url: https://api.github.com/users/lbarcziova/orgs
+                            received_events_url: https://api.github.com/users/lbarcziova/received_events
+                            repos_url: https://api.github.com/users/lbarcziova/repos
+                            site_admin: false
+                            starred_url: https://api.github.com/users/lbarcziova/starred{/owner}{/repo}
+                            subscriptions_url: https://api.github.com/users/lbarcziova/subscriptions
+                            type: User
+                            url: https://api.github.com/users/lbarcziova
+                        html_url: https://github.com/packit-service/hello-world/pull/111
+                        id: 406553376
+                        issue_url: https://api.github.com/repos/packit-service/hello-world/issues/111
+                        labels: []
+                        locked: false
+                        maintainer_can_modify: true
+                        merge_commit_sha: 8512ef316918edc39c4a6eee13e6cc45344d03ac
+                        mergeable: true
+                        mergeable_state: clean
+                        merged: false
+                        merged_at: null
+                        merged_by: null
+                        milestone: null
+                        node_id: MDExOlB1bGxSZXF1ZXN0NDA2NTUzMzc2
+                        number: 111
+                        patch_url: https://github.com/packit-service/hello-world/pull/111.patch
+                        rebaseable: true
+                        requested_reviewers: []
+                        requested_teams: []
+                        review_comment_url: https://api.github.com/repos/packit-service/hello-world/pulls/comments{/number}
+                        review_comments: 0
+                        review_comments_url: https://api.github.com/repos/packit-service/hello-world/pulls/111/comments
+                        state: open
+                        statuses_url: https://api.github.com/repos/packit-service/hello-world/statuses/1abb19255a7c1bec7ffcae2487f022b23175af2b
+                        title: 'Test case: no fmf file'
+                        updated_at: '2020-04-21T09:28:40Z'
+                        url: https://api.github.com/repos/packit-service/hello-world/pulls/111
+                        user:
+                          avatar_url: https://avatars3.githubusercontent.com/u/49026743?v=4
+                          events_url: https://api.github.com/users/lbarcziova/events{/privacy}
+                          followers_url: https://api.github.com/users/lbarcziova/followers
+                          following_url: https://api.github.com/users/lbarcziova/following{/other_user}
+                          gists_url: https://api.github.com/users/lbarcziova/gists{/gist_id}
+                          gravatar_id: ''
+                          html_url: https://github.com/lbarcziova
+                          id: 49026743
+                          login: lbarcziova
+                          node_id: MDQ6VXNlcjQ5MDI2NzQz
+                          organizations_url: https://api.github.com/users/lbarcziova/orgs
+                          received_events_url: https://api.github.com/users/lbarcziova/received_events
+                          repos_url: https://api.github.com/users/lbarcziova/repos
+                          site_admin: false
+                          starred_url: https://api.github.com/users/lbarcziova/starred{/owner}{/repo}
+                          subscriptions_url: https://api.github.com/users/lbarcziova/subscriptions
+                          type: User
+                          url: https://api.github.com/users/lbarcziova
+                      _next: null
+                      elapsed: 0.2
+                      encoding: utf-8
+                      headers:
+                        Access-Control-Allow-Origin: '*'
+                        Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                          X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+                          X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+                          X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
+                        Cache-Control: private, max-age=60, s-maxage=60
+                        Content-Encoding: gzip
+                        Content-Security-Policy: default-src 'none'
+                        Content-Type: application/json; charset=utf-8
+                        Date: Fri, 01 Nov 2019 13-36-03 GMT
+                        ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                        Last-Modified: Tue, 28 Apr 2020 06:53:21 GMT
+                        Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                        Server: GitHub.com
+                        Status: 200 OK
+                        Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                          preload
+                        Transfer-Encoding: chunked
+                        Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                          Accept, X-Requested-With
+                        X-Accepted-OAuth-Scopes: ''
+                        X-Content-Type-Options: nosniff
+                        X-Frame-Options: deny
+                        X-GitHub-Media-Type: github.v3; format=json
+                        X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                        X-OAuth-Scopes: admin:enterprise, admin:gpg_key, admin:org,
+                          admin:org_hook, admin:public_key, admin:repo_hook, delete:packages,
+                          delete_repo, gist, notifications, read:packages, repo, user,
+                          workflow, write:discussion, write:packages
+                        X-RateLimit-Limit: '5000'
+                        X-RateLimit-Remaining: '4972'
+                        X-RateLimit-Reset: '1572953901'
+                        X-XSS-Protection: 1; mode=block
+                      raw: !!binary ""
+                      reason: OK
+                      status_code: 200
+        ogr.services.github.project:
+          github.MainClass:
+            github.Requester:
+              requests.sessions:
+                requre.objects:
+                  requests.sessions:
+                    send:
+                    - metadata:
+                        latency: 0.4608423709869385
+                        module_call_list:
+                        - unittest.case
+                        - tests.integration.test_github
+                        - ogr.services.github.project
+                        - ogr.services.github.pull_request
+                        - ogr.services.github.project
+                        - github.MainClass
+                        - github.Requester
+                        - requests.sessions
+                        - requre.objects
+                        - requests.sessions
+                        - send
+                      output:
+                        __store_indicator: 2
+                        _content:
+                          allow_merge_commit: true
+                          allow_rebase_merge: true
+                          allow_squash_merge: true
+                          archive_url: https://api.github.com/repos/packit-service/hello-world/{archive_format}{/ref}
+                          archived: false
+                          assignees_url: https://api.github.com/repos/packit-service/hello-world/assignees{/user}
+                          blobs_url: https://api.github.com/repos/packit-service/hello-world/git/blobs{/sha}
+                          branches_url: https://api.github.com/repos/packit-service/hello-world/branches{/branch}
+                          clone_url: https://github.com/packit-service/hello-world.git
+                          collaborators_url: https://api.github.com/repos/packit-service/hello-world/collaborators{/collaborator}
+                          comments_url: https://api.github.com/repos/packit-service/hello-world/comments{/number}
+                          commits_url: https://api.github.com/repos/packit-service/hello-world/commits{/sha}
+                          compare_url: https://api.github.com/repos/packit-service/hello-world/compare/{base}...{head}
+                          contents_url: https://api.github.com/repos/packit-service/hello-world/contents/{+path}
+                          contributors_url: https://api.github.com/repos/packit-service/hello-world/contributors
+                          created_at: '2019-05-02T18:54:46Z'
+                          default_branch: master
+                          delete_branch_on_merge: false
+                          deployments_url: https://api.github.com/repos/packit-service/hello-world/deployments
+                          description: The most progresive command-line tool in the
+                            world.
+                          disabled: false
+                          downloads_url: https://api.github.com/repos/packit-service/hello-world/downloads
+                          events_url: https://api.github.com/repos/packit-service/hello-world/events
+                          fork: false
+                          forks: 17
+                          forks_count: 17
+                          forks_url: https://api.github.com/repos/packit-service/hello-world/forks
+                          full_name: packit-service/hello-world
+                          git_commits_url: https://api.github.com/repos/packit-service/hello-world/git/commits{/sha}
+                          git_refs_url: https://api.github.com/repos/packit-service/hello-world/git/refs{/sha}
+                          git_tags_url: https://api.github.com/repos/packit-service/hello-world/git/tags{/sha}
+                          git_url: git://github.com/packit-service/hello-world.git
+                          has_downloads: true
+                          has_issues: true
+                          has_pages: false
+                          has_projects: true
+                          has_wiki: true
+                          homepage: null
+                          hooks_url: https://api.github.com/repos/packit-service/hello-world/hooks
+                          html_url: https://github.com/packit-service/hello-world
+                          id: 184635124
+                          issue_comment_url: https://api.github.com/repos/packit-service/hello-world/issues/comments{/number}
+                          issue_events_url: https://api.github.com/repos/packit-service/hello-world/issues/events{/number}
+                          issues_url: https://api.github.com/repos/packit-service/hello-world/issues{/number}
+                          keys_url: https://api.github.com/repos/packit-service/hello-world/keys{/key_id}
+                          labels_url: https://api.github.com/repos/packit-service/hello-world/labels{/name}
+                          language: Python
+                          languages_url: https://api.github.com/repos/packit-service/hello-world/languages
+                          license:
+                            key: mit
+                            name: MIT License
+                            node_id: MDc6TGljZW5zZTEz
+                            spdx_id: MIT
+                            url: https://api.github.com/licenses/mit
+                          merges_url: https://api.github.com/repos/packit-service/hello-world/merges
+                          milestones_url: https://api.github.com/repos/packit-service/hello-world/milestones{/number}
+                          mirror_url: null
+                          name: hello-world
+                          network_count: 17
+                          node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+                          notifications_url: https://api.github.com/repos/packit-service/hello-world/notifications{?since,all,participating}
+                          open_issues: 22
+                          open_issues_count: 22
+                          organization:
+                            avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
+                            events_url: https://api.github.com/users/packit-service/events{/privacy}
+                            followers_url: https://api.github.com/users/packit-service/followers
+                            following_url: https://api.github.com/users/packit-service/following{/other_user}
+                            gists_url: https://api.github.com/users/packit-service/gists{/gist_id}
+                            gravatar_id: ''
+                            html_url: https://github.com/packit-service
+                            id: 46870917
+                            login: packit-service
+                            node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                            organizations_url: https://api.github.com/users/packit-service/orgs
+                            received_events_url: https://api.github.com/users/packit-service/received_events
+                            repos_url: https://api.github.com/users/packit-service/repos
+                            site_admin: false
+                            starred_url: https://api.github.com/users/packit-service/starred{/owner}{/repo}
+                            subscriptions_url: https://api.github.com/users/packit-service/subscriptions
+                            type: Organization
+                            url: https://api.github.com/users/packit-service
+                          owner:
+                            avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
+                            events_url: https://api.github.com/users/packit-service/events{/privacy}
+                            followers_url: https://api.github.com/users/packit-service/followers
+                            following_url: https://api.github.com/users/packit-service/following{/other_user}
+                            gists_url: https://api.github.com/users/packit-service/gists{/gist_id}
+                            gravatar_id: ''
+                            html_url: https://github.com/packit-service
+                            id: 46870917
+                            login: packit-service
+                            node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                            organizations_url: https://api.github.com/users/packit-service/orgs
+                            received_events_url: https://api.github.com/users/packit-service/received_events
+                            repos_url: https://api.github.com/users/packit-service/repos
+                            site_admin: false
+                            starred_url: https://api.github.com/users/packit-service/starred{/owner}{/repo}
+                            subscriptions_url: https://api.github.com/users/packit-service/subscriptions
+                            type: Organization
+                            url: https://api.github.com/users/packit-service
+                          permissions:
+                            admin: true
+                            pull: true
+                            push: true
+                          private: false
+                          pulls_url: https://api.github.com/repos/packit-service/hello-world/pulls{/number}
+                          pushed_at: '2020-04-23T07:49:42Z'
+                          releases_url: https://api.github.com/repos/packit-service/hello-world/releases{/id}
+                          size: 22
+                          ssh_url: git@github.com:packit-service/hello-world.git
+                          stargazers_count: 0
+                          stargazers_url: https://api.github.com/repos/packit-service/hello-world/stargazers
+                          statuses_url: https://api.github.com/repos/packit-service/hello-world/statuses/{sha}
+                          subscribers_count: 8
+                          subscribers_url: https://api.github.com/repos/packit-service/hello-world/subscribers
+                          subscription_url: https://api.github.com/repos/packit-service/hello-world/subscription
+                          svn_url: https://github.com/packit-service/hello-world
+                          tags_url: https://api.github.com/repos/packit-service/hello-world/tags
+                          teams_url: https://api.github.com/repos/packit-service/hello-world/teams
+                          temp_clone_token: ''
+                          trees_url: https://api.github.com/repos/packit-service/hello-world/git/trees{/sha}
+                          updated_at: '2020-04-03T14:38:55Z'
+                          url: https://api.github.com/repos/packit-service/hello-world
+                          watchers: 0
+                          watchers_count: 0
+                        _next: null
+                        elapsed: 0.2
+                        encoding: utf-8
+                        headers:
+                          Access-Control-Allow-Origin: '*'
+                          Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                            X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+                            X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+                            X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
+                          Cache-Control: private, max-age=60, s-maxage=60
+                          Content-Encoding: gzip
+                          Content-Security-Policy: default-src 'none'
+                          Content-Type: application/json; charset=utf-8
+                          Date: Fri, 01 Nov 2019 13-36-03 GMT
+                          ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                          Last-Modified: Fri, 03 Apr 2020 14:38:55 GMT
+                          Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                          Server: GitHub.com
+                          Status: 200 OK
+                          Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                            preload
+                          Transfer-Encoding: chunked
+                          Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                            Accept, X-Requested-With
+                          X-Accepted-OAuth-Scopes: repo
+                          X-Content-Type-Options: nosniff
+                          X-Frame-Options: deny
+                          X-GitHub-Media-Type: github.v3; format=json
+                          X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                          X-OAuth-Scopes: admin:enterprise, admin:gpg_key, admin:org,
+                            admin:org_hook, admin:public_key, admin:repo_hook, delete:packages,
+                            delete_repo, gist, notifications, read:packages, repo,
+                            user, workflow, write:discussion, write:packages
+                          X-RateLimit-Limit: '5000'
+                          X-RateLimit-Remaining: '4972'
+                          X-RateLimit-Reset: '1572953901'
+                          X-XSS-Protection: 1; mode=block
+                        raw: !!binary ""
+                        reason: OK
+                        status_code: 200

--- a/tests/integration/test_data/test_gitlab/tests.integration.test_gitlab.PullRequests.test_source_project_fork_fork.yaml
+++ b/tests/integration/test_data/test_gitlab/tests.integration.test_gitlab.PullRequests.test_source_project_fork_fork.yaml
@@ -1,0 +1,597 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectFull
+  version_storage_file: 2
+unittest.case:
+  tests.integration.test_gitlab:
+    ogr.services.gitlab.project:
+      ogr.services.gitlab.pull_request:
+        gitlab.exceptions:
+          gitlab.mixins:
+            gitlab:
+              requre.objects:
+                requests.sessions:
+                  send:
+                  - metadata:
+                      latency: 0.38888978958129883
+                      module_call_list:
+                      - unittest.case
+                      - tests.integration.test_gitlab
+                      - ogr.services.gitlab.project
+                      - ogr.services.gitlab.pull_request
+                      - gitlab.exceptions
+                      - gitlab.mixins
+                      - gitlab
+                      - requre.objects
+                      - requests.sessions
+                      - send
+                    output:
+                      __store_indicator: 2
+                      _content:
+                        approvals_before_merge: null
+                        assignee: null
+                        assignees: []
+                        author:
+                          avatar_url: https://assets.gitlab-static.net/uploads/-/system/user/avatar/375555/avatar.png
+                          id: 375555
+                          name: Matej Focko
+                          state: active
+                          username: mfocko
+                          web_url: https://gitlab.com/mfocko
+                        blocking_discussions_resolved: true
+                        changes_count: null
+                        closed_at: null
+                        closed_by: null
+                        created_at: '2020-04-28T19:16:38.822Z'
+                        description: ''
+                        diff_refs:
+                          base_sha: 257ce9fd8c5421d2e116337847710ba70d215aa6
+                          head_sha: 257ce9fd8c5421d2e116337847710ba70d215aa6
+                          start_sha: b8e18207cfdad954f1b3a96db34d0706b272e6cf
+                        discussion_locked: null
+                        downvotes: 0
+                        first_contribution: false
+                        first_deployed_to_production_at: null
+                        force_remove_source_branch: true
+                        has_conflicts: true
+                        head_pipeline: null
+                        id: 57207293
+                        iid: 1
+                        labels: []
+                        latest_build_finished_at: null
+                        latest_build_started_at: null
+                        merge_commit_sha: null
+                        merge_error: null
+                        merge_status: cannot_be_merged
+                        merge_when_pipeline_succeeds: false
+                        merged_at: null
+                        merged_by: null
+                        milestone: null
+                        pipeline: null
+                        project_id: 15896155
+                        reference: '!1'
+                        references:
+                          full: mfocko/ogr-tests!1
+                          relative: '!1'
+                          short: '!1'
+                        sha: 257ce9fd8c5421d2e116337847710ba70d215aa6
+                        should_remove_source_branch: null
+                        source_branch: pr-test1
+                        source_project_id: 15896155
+                        squash: false
+                        squash_commit_sha: null
+                        state: opened
+                        subscribed: true
+                        target_branch: master
+                        target_project_id: 15896155
+                        task_completion_status:
+                          completed_count: 0
+                          count: 0
+                        time_stats:
+                          human_time_estimate: null
+                          human_total_time_spent: null
+                          time_estimate: 0
+                          total_time_spent: 0
+                        title: 'WIP: Pr test1'
+                        updated_at: '2020-04-28T19:16:38.822Z'
+                        upvotes: 0
+                        user:
+                          can_merge: true
+                        user_notes_count: 0
+                        web_url: https://gitlab.com/mfocko/ogr-tests/-/merge_requests/1
+                        work_in_progress: true
+                      _next: null
+                      elapsed: 0.2
+                      encoding: null
+                      headers:
+                        CF-Cache-Status: DYNAMIC
+                        CF-RAY: 58b32ac30a41fca9-VIE
+                        Cache-Control: max-age=0, private, must-revalidate
+                        Connection: keep-alive
+                        Content-Encoding: gzip
+                        Content-Type: application/json
+                        Date: Fri, 01 Nov 2019 13-36-03 GMT
+                        Etag: W/"0397b9ffc6dcaa4d149592fd82cafc9a"
+                        Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                        GitLab-LB: fe-10-lb-gprd
+                        GitLab-SV: localhost
+                        RateLimit-Limit: '600'
+                        RateLimit-Observed: '3'
+                        RateLimit-Remaining: '597'
+                        RateLimit-Reset: '1588101964'
+                        RateLimit-ResetTime: Tue, 28 Apr 2020 19:26:04 GMT
+                        Referrer-Policy: strict-origin-when-cross-origin
+                        Server: cloudflare
+                        Strict-Transport-Security: max-age=31536000
+                        Transfer-Encoding: chunked
+                        Vary: Origin
+                        X-Content-Type-Options: nosniff
+                        X-Frame-Options: SAMEORIGIN
+                        X-Request-Id: CzdjFZklkp8
+                        X-Runtime: '0.075629'
+                        cf-request-id: 0263d90de00000fca94810e200000001
+                      raw: !!binary ""
+                      reason: OK
+                      status_code: 200
+        ogr.services.gitlab.project:
+          gitlab.exceptions:
+            gitlab.mixins:
+              gitlab:
+                requre.objects:
+                  requests.sessions:
+                    send:
+                    - metadata:
+                        latency: 0.3154630661010742
+                        module_call_list:
+                        - unittest.case
+                        - tests.integration.test_gitlab
+                        - ogr.services.gitlab.project
+                        - ogr.services.gitlab.pull_request
+                        - ogr.services.gitlab.project
+                        - gitlab.exceptions
+                        - gitlab.mixins
+                        - gitlab
+                        - requre.objects
+                        - requests.sessions
+                        - send
+                      output:
+                        __store_indicator: 2
+                        _content:
+                          _links:
+                            events: https://gitlab.com/api/v4/projects/15896155/events
+                            issues: https://gitlab.com/api/v4/projects/15896155/issues
+                            labels: https://gitlab.com/api/v4/projects/15896155/labels
+                            members: https://gitlab.com/api/v4/projects/15896155/members
+                            merge_requests: https://gitlab.com/api/v4/projects/15896155/merge_requests
+                            repo_branches: https://gitlab.com/api/v4/projects/15896155/repository/branches
+                            self: https://gitlab.com/api/v4/projects/15896155
+                          approvals_before_merge: 0
+                          archived: false
+                          auto_cancel_pending_pipelines: enabled
+                          auto_devops_deploy_strategy: continuous
+                          auto_devops_enabled: false
+                          autoclose_referenced_issues: true
+                          avatar_url: null
+                          build_coverage_regex: null
+                          build_git_strategy: fetch
+                          build_timeout: 3600
+                          builds_access_level: enabled
+                          can_create_merge_request_in: true
+                          ci_config_path: null
+                          ci_default_git_depth: 50
+                          container_registry_enabled: true
+                          created_at: '2019-12-16T11:13:20.567Z'
+                          creator_id: 375555
+                          default_branch: master
+                          description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+                          emails_disabled: null
+                          empty_repo: false
+                          external_authorization_classification_label: ''
+                          forked_from_project:
+                            avatar_url: null
+                            created_at: '2019-09-10T10:28:09.946Z'
+                            default_branch: master
+                            description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+                            forks_count: 4
+                            http_url_to_repo: https://gitlab.com/packit-service/ogr-tests.git
+                            id: 14233409
+                            last_activity_at: '2020-04-28T19:17:22.800Z'
+                            name: ogr-tests
+                            name_with_namespace: packit-service / ogr-tests
+                            namespace:
+                              avatar_url: /uploads/-/system/group/avatar/6032704/packit-logo.png
+                              full_path: packit-service
+                              id: 6032704
+                              kind: group
+                              name: packit-service
+                              parent_id: null
+                              path: packit-service
+                              web_url: https://gitlab.com/groups/packit-service
+                            path: ogr-tests
+                            path_with_namespace: packit-service/ogr-tests
+                            readme_url: https://gitlab.com/packit-service/ogr-tests/-/blob/master/README.md
+                            ssh_url_to_repo: git@gitlab.com:packit-service/ogr-tests.git
+                            star_count: 0
+                            tag_list: []
+                            web_url: https://gitlab.com/packit-service/ogr-tests
+                          forking_access_level: enabled
+                          forks_count: 0
+                          http_url_to_repo: https://gitlab.com/mfocko/ogr-tests.git
+                          id: 15896155
+                          import_error: null
+                          import_status: finished
+                          issues_access_level: enabled
+                          issues_enabled: true
+                          jobs_enabled: true
+                          last_activity_at: '2020-04-28T19:16:39.081Z'
+                          lfs_enabled: true
+                          marked_for_deletion_at: null
+                          marked_for_deletion_on: null
+                          merge_method: merge
+                          merge_requests_access_level: enabled
+                          merge_requests_enabled: true
+                          mirror: false
+                          name: ogr-tests
+                          name_with_namespace: Matej Focko / ogr-tests
+                          namespace:
+                            avatar_url: /uploads/-/system/user/avatar/375555/avatar.png
+                            full_path: mfocko
+                            id: 439774
+                            kind: user
+                            name: Matej Focko
+                            parent_id: null
+                            path: mfocko
+                            web_url: https://gitlab.com/mfocko
+                          only_allow_merge_if_all_discussions_are_resolved: false
+                          only_allow_merge_if_pipeline_succeeds: false
+                          open_issues_count: 0
+                          owner:
+                            avatar_url: https://assets.gitlab-static.net/uploads/-/system/user/avatar/375555/avatar.png
+                            id: 375555
+                            name: Matej Focko
+                            state: active
+                            username: mfocko
+                            web_url: https://gitlab.com/mfocko
+                          packages_enabled: true
+                          pages_access_level: enabled
+                          path: ogr-tests
+                          path_with_namespace: mfocko/ogr-tests
+                          permissions:
+                            group_access: null
+                            project_access:
+                              access_level: 40
+                              notification_level: 3
+                          printing_merge_request_link_enabled: true
+                          public_jobs: true
+                          readme_url: https://gitlab.com/mfocko/ogr-tests/-/blob/master/README.md
+                          remove_source_branch_after_merge: true
+                          repository_access_level: enabled
+                          request_access_enabled: true
+                          resolve_outdated_diff_discussions: false
+                          runners_token: WKy7SCDsumYRV5keeT8c
+                          service_desk_address: incoming+mfocko-ogr-tests-15896155-issue-@incoming.gitlab.com
+                          service_desk_enabled: true
+                          shared_runners_enabled: true
+                          shared_with_groups: []
+                          snippets_access_level: enabled
+                          snippets_enabled: true
+                          ssh_url_to_repo: git@gitlab.com:mfocko/ogr-tests.git
+                          star_count: 0
+                          suggestion_commit_message: null
+                          tag_list: []
+                          visibility: public
+                          web_url: https://gitlab.com/mfocko/ogr-tests
+                          wiki_access_level: enabled
+                          wiki_enabled: true
+                        _next: null
+                        elapsed: 0.2
+                        encoding: null
+                        headers:
+                          CF-Cache-Status: DYNAMIC
+                          CF-RAY: 58b32ac0dc04fca9-VIE
+                          Cache-Control: max-age=0, private, must-revalidate
+                          Connection: keep-alive
+                          Content-Encoding: gzip
+                          Content-Type: application/json
+                          Date: Fri, 01 Nov 2019 13-36-03 GMT
+                          Etag: W/"42f032d7c6839d85c235c52541b861bb"
+                          Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                          GitLab-LB: fe-18-lb-gprd
+                          GitLab-SV: localhost
+                          RateLimit-Limit: '600'
+                          RateLimit-Observed: '4'
+                          RateLimit-Remaining: '596'
+                          RateLimit-Reset: '1588101963'
+                          RateLimit-ResetTime: Tue, 28 Apr 2020 19:26:03 GMT
+                          Referrer-Policy: strict-origin-when-cross-origin
+                          Server: cloudflare
+                          Strict-Transport-Security: max-age=31536000
+                          Transfer-Encoding: chunked
+                          Vary: Origin
+                          X-Content-Type-Options: nosniff
+                          X-Frame-Options: SAMEORIGIN
+                          X-Request-Id: LyXHuXsWcn8
+                          X-Runtime: '0.096372'
+                          cf-request-id: 0263d90c890000fca9480f0200000001
+                        raw: !!binary ""
+                        reason: OK
+                        status_code: 200
+          ogr.services.gitlab.service:
+            gitlab:
+              gitlab.exceptions:
+                gitlab.mixins:
+                  gitlab:
+                    requre.objects:
+                      requests.sessions:
+                        send:
+                        - metadata:
+                            latency: 0.5142099857330322
+                            module_call_list:
+                            - unittest.case
+                            - tests.integration.test_gitlab
+                            - ogr.services.gitlab.project
+                            - ogr.services.gitlab.pull_request
+                            - ogr.services.gitlab.project
+                            - ogr.services.gitlab.service
+                            - gitlab
+                            - gitlab.exceptions
+                            - gitlab.mixins
+                            - gitlab
+                            - requre.objects
+                            - requests.sessions
+                            - send
+                          output:
+                            __store_indicator: 2
+                            _content:
+                              avatar_url: https://assets.gitlab-static.net/uploads/-/system/user/avatar/375555/avatar.png
+                              bio: ''
+                              can_create_group: true
+                              can_create_project: true
+                              color_scheme_id: 4
+                              confirmed_at: '2018-06-07T08:34:01.593Z'
+                              created_at: '2016-01-15T21:12:31.705Z'
+                              current_sign_in_at: '2020-04-22T11:44:25.029Z'
+                              email: matej.focko@outlook.com
+                              external: false
+                              extra_shared_runners_minutes_limit: null
+                              id: 375555
+                              identities: []
+                              job_title: ''
+                              last_activity_on: '2020-04-28'
+                              last_sign_in_at: '2020-04-19T14:53:06.287Z'
+                              linkedin: ''
+                              location: "Ko\u0161ice, Slovakia"
+                              name: Matej Focko
+                              organization: ''
+                              private_profile: false
+                              projects_limit: 100000
+                              public_email: ''
+                              shared_runners_minutes_limit: 2000
+                              skype: ''
+                              state: active
+                              theme_id: 7
+                              twitter: MatejFocko
+                              two_factor_enabled: true
+                              username: mfocko
+                              web_url: https://gitlab.com/mfocko
+                              website_url: ''
+                              work_information: null
+                            _next: null
+                            elapsed: 0.2
+                            encoding: null
+                            headers:
+                              CF-Cache-Status: DYNAMIC
+                              CF-RAY: 58b32abe4b70fca9-VIE
+                              Cache-Control: max-age=0, private, must-revalidate
+                              Connection: keep-alive
+                              Content-Encoding: gzip
+                              Content-Type: application/json
+                              Date: Fri, 01 Nov 2019 13-36-03 GMT
+                              Etag: W/"e6d354bf72a9220d014f2ce53e1c4be3"
+                              Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                              GitLab-LB: fe-18-lb-gprd
+                              GitLab-SV: localhost
+                              RateLimit-Limit: '600'
+                              RateLimit-Observed: '3'
+                              RateLimit-Remaining: '597'
+                              RateLimit-Reset: '1588101963'
+                              RateLimit-ResetTime: Tue, 28 Apr 2020 19:26:03 GMT
+                              Referrer-Policy: strict-origin-when-cross-origin
+                              Server: cloudflare
+                              Set-Cookie: __cfduid=dae51d90a99a8a14a684255674f1544c51588101903;
+                                expires=Thu, 28-May-20 19:25:03 GMT; path=/; domain=.gitlab.com;
+                                HttpOnly; SameSite=Lax; Secure
+                              Strict-Transport-Security: max-age=31536000
+                              Transfer-Encoding: chunked
+                              Vary: Origin
+                              X-Content-Type-Options: nosniff
+                              X-Frame-Options: SAMEORIGIN
+                              X-Request-Id: 16crp1OAH8a
+                              X-Runtime: '0.023142'
+                              cf-request-id: 0263d90aef0000fca9480b2200000001
+                            raw: !!binary ""
+                            reason: OK
+                            status_code: 200
+    ogr.services.gitlab.pull_request:
+      ogr.services.gitlab.service:
+        gitlab.exceptions:
+          gitlab.mixins:
+            gitlab:
+              requre.objects:
+                requests.sessions:
+                  send:
+                  - metadata:
+                      latency: 0.3890821933746338
+                      module_call_list:
+                      - unittest.case
+                      - tests.integration.test_gitlab
+                      - ogr.services.gitlab.pull_request
+                      - ogr.services.gitlab.service
+                      - gitlab.exceptions
+                      - gitlab.mixins
+                      - gitlab
+                      - requre.objects
+                      - requests.sessions
+                      - send
+                    output:
+                      __store_indicator: 2
+                      _content:
+                        _links:
+                          events: https://gitlab.com/api/v4/projects/15896155/events
+                          issues: https://gitlab.com/api/v4/projects/15896155/issues
+                          labels: https://gitlab.com/api/v4/projects/15896155/labels
+                          members: https://gitlab.com/api/v4/projects/15896155/members
+                          merge_requests: https://gitlab.com/api/v4/projects/15896155/merge_requests
+                          repo_branches: https://gitlab.com/api/v4/projects/15896155/repository/branches
+                          self: https://gitlab.com/api/v4/projects/15896155
+                        approvals_before_merge: 0
+                        archived: false
+                        auto_cancel_pending_pipelines: enabled
+                        auto_devops_deploy_strategy: continuous
+                        auto_devops_enabled: false
+                        autoclose_referenced_issues: true
+                        avatar_url: null
+                        build_coverage_regex: null
+                        build_git_strategy: fetch
+                        build_timeout: 3600
+                        builds_access_level: enabled
+                        can_create_merge_request_in: true
+                        ci_config_path: null
+                        ci_default_git_depth: 50
+                        container_registry_enabled: true
+                        created_at: '2019-12-16T11:13:20.567Z'
+                        creator_id: 375555
+                        default_branch: master
+                        description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+                        emails_disabled: null
+                        empty_repo: false
+                        external_authorization_classification_label: ''
+                        forked_from_project:
+                          avatar_url: null
+                          created_at: '2019-09-10T10:28:09.946Z'
+                          default_branch: master
+                          description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+                          forks_count: 4
+                          http_url_to_repo: https://gitlab.com/packit-service/ogr-tests.git
+                          id: 14233409
+                          last_activity_at: '2020-04-28T19:17:22.800Z'
+                          name: ogr-tests
+                          name_with_namespace: packit-service / ogr-tests
+                          namespace:
+                            avatar_url: /uploads/-/system/group/avatar/6032704/packit-logo.png
+                            full_path: packit-service
+                            id: 6032704
+                            kind: group
+                            name: packit-service
+                            parent_id: null
+                            path: packit-service
+                            web_url: https://gitlab.com/groups/packit-service
+                          path: ogr-tests
+                          path_with_namespace: packit-service/ogr-tests
+                          readme_url: https://gitlab.com/packit-service/ogr-tests/-/blob/master/README.md
+                          ssh_url_to_repo: git@gitlab.com:packit-service/ogr-tests.git
+                          star_count: 0
+                          tag_list: []
+                          web_url: https://gitlab.com/packit-service/ogr-tests
+                        forking_access_level: enabled
+                        forks_count: 0
+                        http_url_to_repo: https://gitlab.com/mfocko/ogr-tests.git
+                        id: 15896155
+                        import_error: null
+                        import_status: finished
+                        issues_access_level: enabled
+                        issues_enabled: true
+                        jobs_enabled: true
+                        last_activity_at: '2020-04-28T19:16:39.081Z'
+                        lfs_enabled: true
+                        marked_for_deletion_at: null
+                        marked_for_deletion_on: null
+                        merge_method: merge
+                        merge_requests_access_level: enabled
+                        merge_requests_enabled: true
+                        mirror: false
+                        name: ogr-tests
+                        name_with_namespace: Matej Focko / ogr-tests
+                        namespace:
+                          avatar_url: /uploads/-/system/user/avatar/375555/avatar.png
+                          full_path: mfocko
+                          id: 439774
+                          kind: user
+                          name: Matej Focko
+                          parent_id: null
+                          path: mfocko
+                          web_url: https://gitlab.com/mfocko
+                        only_allow_merge_if_all_discussions_are_resolved: false
+                        only_allow_merge_if_pipeline_succeeds: false
+                        open_issues_count: 0
+                        owner:
+                          avatar_url: https://assets.gitlab-static.net/uploads/-/system/user/avatar/375555/avatar.png
+                          id: 375555
+                          name: Matej Focko
+                          state: active
+                          username: mfocko
+                          web_url: https://gitlab.com/mfocko
+                        packages_enabled: true
+                        pages_access_level: enabled
+                        path: ogr-tests
+                        path_with_namespace: mfocko/ogr-tests
+                        permissions:
+                          group_access: null
+                          project_access:
+                            access_level: 40
+                            notification_level: 3
+                        printing_merge_request_link_enabled: true
+                        public_jobs: true
+                        readme_url: https://gitlab.com/mfocko/ogr-tests/-/blob/master/README.md
+                        remove_source_branch_after_merge: true
+                        repository_access_level: enabled
+                        request_access_enabled: true
+                        resolve_outdated_diff_discussions: false
+                        runners_token: WKy7SCDsumYRV5keeT8c
+                        service_desk_address: incoming+mfocko-ogr-tests-15896155-issue-@incoming.gitlab.com
+                        service_desk_enabled: true
+                        shared_runners_enabled: true
+                        shared_with_groups: []
+                        snippets_access_level: enabled
+                        snippets_enabled: true
+                        ssh_url_to_repo: git@gitlab.com:mfocko/ogr-tests.git
+                        star_count: 0
+                        suggestion_commit_message: null
+                        tag_list: []
+                        visibility: public
+                        web_url: https://gitlab.com/mfocko/ogr-tests
+                        wiki_access_level: enabled
+                        wiki_enabled: true
+                      _next: null
+                      elapsed: 0.2
+                      encoding: null
+                      headers:
+                        CF-Cache-Status: DYNAMIC
+                        CF-RAY: 58b32ac59b7cfca9-VIE
+                        Cache-Control: max-age=0, private, must-revalidate
+                        Connection: keep-alive
+                        Content-Encoding: gzip
+                        Content-Type: application/json
+                        Date: Fri, 01 Nov 2019 13-36-03 GMT
+                        Etag: W/"42f032d7c6839d85c235c52541b861bb"
+                        Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                        GitLab-LB: fe-07-lb-gprd
+                        GitLab-SV: localhost
+                        RateLimit-Limit: '600'
+                        RateLimit-Observed: '3'
+                        RateLimit-Remaining: '597'
+                        RateLimit-Reset: '1588101964'
+                        RateLimit-ResetTime: Tue, 28 Apr 2020 19:26:04 GMT
+                        Referrer-Policy: strict-origin-when-cross-origin
+                        Server: cloudflare
+                        Strict-Transport-Security: max-age=31536000
+                        Transfer-Encoding: chunked
+                        Vary: Origin
+                        X-Content-Type-Options: nosniff
+                        X-Frame-Options: SAMEORIGIN
+                        X-Request-Id: nxmkwNlFLA2
+                        X-Runtime: '0.092381'
+                        cf-request-id: 0263d90f7d0000fca948137200000001
+                      raw: !!binary ""
+                      reason: OK
+                      status_code: 200

--- a/tests/integration/test_data/test_gitlab/tests.integration.test_gitlab.PullRequests.test_source_project_other_fork_fork.yaml
+++ b/tests/integration/test_data/test_gitlab/tests.integration.test_gitlab.PullRequests.test_source_project_other_fork_fork.yaml
@@ -1,0 +1,594 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectFull
+  version_storage_file: 2
+unittest.case:
+  tests.integration.test_gitlab:
+    ogr.services.gitlab.project:
+      ogr.services.gitlab.pull_request:
+        gitlab.exceptions:
+          gitlab.mixins:
+            gitlab:
+              requre.objects:
+                requests.sessions:
+                  send:
+                  - metadata:
+                      latency: 0.2589433193206787
+                      module_call_list:
+                      - unittest.case
+                      - tests.integration.test_gitlab
+                      - ogr.services.gitlab.project
+                      - ogr.services.gitlab.pull_request
+                      - gitlab.exceptions
+                      - gitlab.mixins
+                      - gitlab
+                      - requre.objects
+                      - requests.sessions
+                      - send
+                    output:
+                      __store_indicator: 2
+                      _content:
+                        allow_collaboration: false
+                        allow_maintainer_to_push: false
+                        approvals_before_merge: null
+                        assignee: null
+                        assignees: []
+                        author:
+                          avatar_url: https://assets.gitlab-static.net/uploads/-/system/user/avatar/375555/avatar.png
+                          id: 375555
+                          name: Matej Focko
+                          state: active
+                          username: mfocko
+                          web_url: https://gitlab.com/mfocko
+                        blocking_discussions_resolved: true
+                        changes_count: '1'
+                        closed_at: null
+                        closed_by: null
+                        created_at: '2020-04-28T19:18:13.955Z'
+                        description: ''
+                        diff_refs:
+                          base_sha: 1050fc5e57a5d145ebaadb0e1748fbc1d94e7b4c
+                          head_sha: 257ce9fd8c5421d2e116337847710ba70d215aa6
+                          start_sha: 1050fc5e57a5d145ebaadb0e1748fbc1d94e7b4c
+                        discussion_locked: null
+                        downvotes: 0
+                        first_contribution: true
+                        first_deployed_to_production_at: null
+                        force_remove_source_branch: true
+                        has_conflicts: false
+                        head_pipeline: null
+                        id: 57207383
+                        iid: 1
+                        labels: []
+                        latest_build_finished_at: null
+                        latest_build_started_at: null
+                        merge_commit_sha: null
+                        merge_error: null
+                        merge_status: can_be_merged
+                        merge_when_pipeline_succeeds: false
+                        merged_at: null
+                        merged_by: null
+                        milestone: null
+                        pipeline: null
+                        project_id: 14255608
+                        reference: '!1'
+                        references:
+                          full: lachmanfrantisek/ogr-tests!1
+                          relative: '!1'
+                          short: '!1'
+                        sha: 257ce9fd8c5421d2e116337847710ba70d215aa6
+                        should_remove_source_branch: null
+                        source_branch: pr-test1
+                        source_project_id: 15896155
+                        squash: false
+                        squash_commit_sha: null
+                        state: opened
+                        subscribed: true
+                        target_branch: master
+                        target_project_id: 14255608
+                        task_completion_status:
+                          completed_count: 0
+                          count: 0
+                        time_stats:
+                          human_time_estimate: null
+                          human_total_time_spent: null
+                          time_estimate: 0
+                          total_time_spent: 0
+                        title: '[ogr] fork to fork test'
+                        updated_at: '2020-04-28T19:18:13.955Z'
+                        upvotes: 0
+                        user:
+                          can_merge: false
+                        user_notes_count: 0
+                        web_url: https://gitlab.com/lachmanfrantisek/ogr-tests/-/merge_requests/1
+                        work_in_progress: false
+                      _next: null
+                      elapsed: 0.2
+                      encoding: null
+                      headers:
+                        CF-Cache-Status: DYNAMIC
+                        CF-RAY: 58b32acd19bf8cb6-VIE
+                        Cache-Control: max-age=0, private, must-revalidate
+                        Connection: keep-alive
+                        Content-Encoding: gzip
+                        Content-Type: application/json
+                        Date: Fri, 01 Nov 2019 13-36-03 GMT
+                        Etag: W/"f8ce00ee562d738c4ea1d1fc233a3786"
+                        Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                        GitLab-LB: fe-05-lb-gprd
+                        GitLab-SV: localhost
+                        RateLimit-Limit: '600'
+                        RateLimit-Observed: '6'
+                        RateLimit-Remaining: '594'
+                        RateLimit-Reset: '1588101965'
+                        RateLimit-ResetTime: Tue, 28 Apr 2020 19:26:05 GMT
+                        Referrer-Policy: strict-origin-when-cross-origin
+                        Server: cloudflare
+                        Strict-Transport-Security: max-age=31536000
+                        Transfer-Encoding: chunked
+                        Vary: Origin
+                        X-Content-Type-Options: nosniff
+                        X-Frame-Options: SAMEORIGIN
+                        X-Request-Id: PeqiQGKav07
+                        X-Runtime: '0.071449'
+                        cf-request-id: 0263d9143300008cb6a0839200000001
+                      raw: !!binary ""
+                      reason: OK
+                      status_code: 200
+        ogr.services.gitlab.project:
+          gitlab.exceptions:
+            gitlab.mixins:
+              gitlab:
+                requre.objects:
+                  requests.sessions:
+                    send:
+                    - metadata:
+                        latency: 0.39944958686828613
+                        module_call_list:
+                        - unittest.case
+                        - tests.integration.test_gitlab
+                        - ogr.services.gitlab.project
+                        - ogr.services.gitlab.pull_request
+                        - ogr.services.gitlab.project
+                        - gitlab.exceptions
+                        - gitlab.mixins
+                        - gitlab
+                        - requre.objects
+                        - requests.sessions
+                        - send
+                      output:
+                        __store_indicator: 2
+                        _content:
+                          _links:
+                            events: https://gitlab.com/api/v4/projects/14255608/events
+                            issues: https://gitlab.com/api/v4/projects/14255608/issues
+                            labels: https://gitlab.com/api/v4/projects/14255608/labels
+                            members: https://gitlab.com/api/v4/projects/14255608/members
+                            merge_requests: https://gitlab.com/api/v4/projects/14255608/merge_requests
+                            repo_branches: https://gitlab.com/api/v4/projects/14255608/repository/branches
+                            self: https://gitlab.com/api/v4/projects/14255608
+                          approvals_before_merge: 0
+                          archived: false
+                          auto_cancel_pending_pipelines: enabled
+                          auto_devops_deploy_strategy: continuous
+                          auto_devops_enabled: false
+                          autoclose_referenced_issues: true
+                          avatar_url: null
+                          build_coverage_regex: null
+                          build_timeout: 3600
+                          builds_access_level: enabled
+                          can_create_merge_request_in: true
+                          ci_config_path: null
+                          ci_default_git_depth: 50
+                          container_registry_enabled: true
+                          created_at: '2019-09-11T13:37:07.678Z'
+                          creator_id: 433670
+                          default_branch: master
+                          description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+                          emails_disabled: null
+                          empty_repo: false
+                          external_authorization_classification_label: ''
+                          forked_from_project:
+                            avatar_url: null
+                            created_at: '2019-09-10T10:28:09.946Z'
+                            default_branch: master
+                            description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+                            forks_count: 4
+                            http_url_to_repo: https://gitlab.com/packit-service/ogr-tests.git
+                            id: 14233409
+                            last_activity_at: '2020-04-28T19:17:22.800Z'
+                            name: ogr-tests
+                            name_with_namespace: packit-service / ogr-tests
+                            namespace:
+                              avatar_url: /uploads/-/system/group/avatar/6032704/packit-logo.png
+                              full_path: packit-service
+                              id: 6032704
+                              kind: group
+                              name: packit-service
+                              parent_id: null
+                              path: packit-service
+                              web_url: https://gitlab.com/groups/packit-service
+                            path: ogr-tests
+                            path_with_namespace: packit-service/ogr-tests
+                            readme_url: https://gitlab.com/packit-service/ogr-tests/-/blob/master/README.md
+                            ssh_url_to_repo: git@gitlab.com:packit-service/ogr-tests.git
+                            star_count: 0
+                            tag_list: []
+                            web_url: https://gitlab.com/packit-service/ogr-tests
+                          forking_access_level: enabled
+                          forks_count: 0
+                          http_url_to_repo: https://gitlab.com/lachmanfrantisek/ogr-tests.git
+                          id: 14255608
+                          import_status: finished
+                          issues_access_level: enabled
+                          issues_enabled: true
+                          jobs_enabled: true
+                          last_activity_at: '2020-04-28T19:18:14.531Z'
+                          lfs_enabled: true
+                          marked_for_deletion_at: null
+                          marked_for_deletion_on: null
+                          merge_method: merge
+                          merge_requests_access_level: enabled
+                          merge_requests_enabled: true
+                          mirror: false
+                          name: ogr-tests
+                          name_with_namespace: "Franti\u0161ek Lachman / ogr-tests"
+                          namespace:
+                            avatar_url: /uploads/-/system/user/avatar/433670/avatar.png
+                            full_path: lachmanfrantisek
+                            id: 509438
+                            kind: user
+                            name: "Franti\u0161ek Lachman"
+                            parent_id: null
+                            path: lachmanfrantisek
+                            web_url: https://gitlab.com/lachmanfrantisek
+                          only_allow_merge_if_all_discussions_are_resolved: false
+                          only_allow_merge_if_pipeline_succeeds: false
+                          open_issues_count: 0
+                          owner:
+                            avatar_url: https://assets.gitlab-static.net/uploads/-/system/user/avatar/433670/avatar.png
+                            id: 433670
+                            name: "Franti\u0161ek Lachman"
+                            state: active
+                            username: lachmanfrantisek
+                            web_url: https://gitlab.com/lachmanfrantisek
+                          packages_enabled: true
+                          pages_access_level: enabled
+                          path: ogr-tests
+                          path_with_namespace: lachmanfrantisek/ogr-tests
+                          permissions:
+                            group_access: null
+                            project_access: null
+                          printing_merge_request_link_enabled: true
+                          public_jobs: true
+                          readme_url: https://gitlab.com/lachmanfrantisek/ogr-tests/-/blob/master/README.md
+                          remove_source_branch_after_merge: null
+                          repository_access_level: enabled
+                          request_access_enabled: false
+                          resolve_outdated_diff_discussions: false
+                          service_desk_address: incoming+lachmanfrantisek-ogr-tests-14255608-issue-@incoming.gitlab.com
+                          service_desk_enabled: true
+                          shared_runners_enabled: true
+                          shared_with_groups: []
+                          snippets_access_level: enabled
+                          snippets_enabled: true
+                          ssh_url_to_repo: git@gitlab.com:lachmanfrantisek/ogr-tests.git
+                          star_count: 0
+                          suggestion_commit_message: null
+                          tag_list: []
+                          visibility: public
+                          web_url: https://gitlab.com/lachmanfrantisek/ogr-tests
+                          wiki_access_level: enabled
+                          wiki_enabled: true
+                        _next: null
+                        elapsed: 0.2
+                        encoding: null
+                        headers:
+                          CF-Cache-Status: DYNAMIC
+                          CF-RAY: 58b32aca98038cb6-VIE
+                          Cache-Control: max-age=0, private, must-revalidate
+                          Connection: keep-alive
+                          Content-Encoding: gzip
+                          Content-Type: application/json
+                          Date: Fri, 01 Nov 2019 13-36-03 GMT
+                          Etag: W/"9f93a34438cb8e559369545acf65bf9b"
+                          Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                          GitLab-LB: fe-22-lb-gprd
+                          GitLab-SV: localhost
+                          RateLimit-Limit: '600'
+                          RateLimit-Observed: '5'
+                          RateLimit-Remaining: '595'
+                          RateLimit-Reset: '1588101965'
+                          RateLimit-ResetTime: Tue, 28 Apr 2020 19:26:05 GMT
+                          Referrer-Policy: strict-origin-when-cross-origin
+                          Server: cloudflare
+                          Strict-Transport-Security: max-age=31536000
+                          Transfer-Encoding: chunked
+                          Vary: Origin
+                          X-Content-Type-Options: nosniff
+                          X-Frame-Options: SAMEORIGIN
+                          X-Request-Id: lf0jAUkIpoa
+                          X-Runtime: '0.120257'
+                          cf-request-id: 0263d9129e00008cb6a0bd6200000001
+                        raw: !!binary ""
+                        reason: OK
+                        status_code: 200
+          ogr.services.gitlab.service:
+            gitlab:
+              gitlab.exceptions:
+                gitlab.mixins:
+                  gitlab:
+                    requre.objects:
+                      requests.sessions:
+                        send:
+                        - metadata:
+                            latency: 0.3607170581817627
+                            module_call_list:
+                            - unittest.case
+                            - tests.integration.test_gitlab
+                            - ogr.services.gitlab.project
+                            - ogr.services.gitlab.pull_request
+                            - ogr.services.gitlab.project
+                            - ogr.services.gitlab.service
+                            - gitlab
+                            - gitlab.exceptions
+                            - gitlab.mixins
+                            - gitlab
+                            - requre.objects
+                            - requests.sessions
+                            - send
+                          output:
+                            __store_indicator: 2
+                            _content:
+                              avatar_url: https://assets.gitlab-static.net/uploads/-/system/user/avatar/375555/avatar.png
+                              bio: ''
+                              can_create_group: true
+                              can_create_project: true
+                              color_scheme_id: 4
+                              confirmed_at: '2018-06-07T08:34:01.593Z'
+                              created_at: '2016-01-15T21:12:31.705Z'
+                              current_sign_in_at: '2020-04-22T11:44:25.029Z'
+                              email: matej.focko@outlook.com
+                              external: false
+                              extra_shared_runners_minutes_limit: null
+                              id: 375555
+                              identities: []
+                              job_title: ''
+                              last_activity_on: '2020-04-28'
+                              last_sign_in_at: '2020-04-19T14:53:06.287Z'
+                              linkedin: ''
+                              location: "Ko\u0161ice, Slovakia"
+                              name: Matej Focko
+                              organization: ''
+                              private_profile: false
+                              projects_limit: 100000
+                              public_email: ''
+                              shared_runners_minutes_limit: 2000
+                              skype: ''
+                              state: active
+                              theme_id: 7
+                              twitter: MatejFocko
+                              two_factor_enabled: true
+                              username: mfocko
+                              web_url: https://gitlab.com/mfocko
+                              website_url: ''
+                              work_information: null
+                            _next: null
+                            elapsed: 0.2
+                            encoding: null
+                            headers:
+                              CF-Cache-Status: DYNAMIC
+                              CF-RAY: 58b32ac8be238cb6-VIE
+                              Cache-Control: max-age=0, private, must-revalidate
+                              Connection: keep-alive
+                              Content-Encoding: gzip
+                              Content-Type: application/json
+                              Date: Fri, 01 Nov 2019 13-36-03 GMT
+                              Etag: W/"e6d354bf72a9220d014f2ce53e1c4be3"
+                              Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                              GitLab-LB: fe-12-lb-gprd
+                              GitLab-SV: localhost
+                              RateLimit-Limit: '600'
+                              RateLimit-Observed: '4'
+                              RateLimit-Remaining: '596'
+                              RateLimit-Reset: '1588101964'
+                              RateLimit-ResetTime: Tue, 28 Apr 2020 19:26:04 GMT
+                              Referrer-Policy: strict-origin-when-cross-origin
+                              Server: cloudflare
+                              Set-Cookie: __cfduid=d5aa339c2cbe1ac34a1cc3e44d7a6faf61588101904;
+                                expires=Thu, 28-May-20 19:25:04 GMT; path=/; domain=.gitlab.com;
+                                HttpOnly; SameSite=Lax; Secure
+                              Strict-Transport-Security: max-age=31536000
+                              Transfer-Encoding: chunked
+                              Vary: Origin
+                              X-Content-Type-Options: nosniff
+                              X-Frame-Options: SAMEORIGIN
+                              X-Request-Id: So4sgV7pQ91
+                              X-Runtime: '0.026398'
+                              cf-request-id: 0263d9117600008cb6a0b7d200000001
+                            raw: !!binary ""
+                            reason: OK
+                            status_code: 200
+    ogr.services.gitlab.pull_request:
+      ogr.services.gitlab.service:
+        gitlab.exceptions:
+          gitlab.mixins:
+            gitlab:
+              requre.objects:
+                requests.sessions:
+                  send:
+                  - metadata:
+                      latency: 0.32614994049072266
+                      module_call_list:
+                      - unittest.case
+                      - tests.integration.test_gitlab
+                      - ogr.services.gitlab.pull_request
+                      - ogr.services.gitlab.service
+                      - gitlab.exceptions
+                      - gitlab.mixins
+                      - gitlab
+                      - requre.objects
+                      - requests.sessions
+                      - send
+                    output:
+                      __store_indicator: 2
+                      _content:
+                        _links:
+                          events: https://gitlab.com/api/v4/projects/15896155/events
+                          issues: https://gitlab.com/api/v4/projects/15896155/issues
+                          labels: https://gitlab.com/api/v4/projects/15896155/labels
+                          members: https://gitlab.com/api/v4/projects/15896155/members
+                          merge_requests: https://gitlab.com/api/v4/projects/15896155/merge_requests
+                          repo_branches: https://gitlab.com/api/v4/projects/15896155/repository/branches
+                          self: https://gitlab.com/api/v4/projects/15896155
+                        approvals_before_merge: 0
+                        archived: false
+                        auto_cancel_pending_pipelines: enabled
+                        auto_devops_deploy_strategy: continuous
+                        auto_devops_enabled: false
+                        autoclose_referenced_issues: true
+                        avatar_url: null
+                        build_coverage_regex: null
+                        build_git_strategy: fetch
+                        build_timeout: 3600
+                        builds_access_level: enabled
+                        can_create_merge_request_in: true
+                        ci_config_path: null
+                        ci_default_git_depth: 50
+                        container_registry_enabled: true
+                        created_at: '2019-12-16T11:13:20.567Z'
+                        creator_id: 375555
+                        default_branch: master
+                        description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+                        emails_disabled: null
+                        empty_repo: false
+                        external_authorization_classification_label: ''
+                        forked_from_project:
+                          avatar_url: null
+                          created_at: '2019-09-10T10:28:09.946Z'
+                          default_branch: master
+                          description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+                          forks_count: 4
+                          http_url_to_repo: https://gitlab.com/packit-service/ogr-tests.git
+                          id: 14233409
+                          last_activity_at: '2020-04-28T19:17:22.800Z'
+                          name: ogr-tests
+                          name_with_namespace: packit-service / ogr-tests
+                          namespace:
+                            avatar_url: /uploads/-/system/group/avatar/6032704/packit-logo.png
+                            full_path: packit-service
+                            id: 6032704
+                            kind: group
+                            name: packit-service
+                            parent_id: null
+                            path: packit-service
+                            web_url: https://gitlab.com/groups/packit-service
+                          path: ogr-tests
+                          path_with_namespace: packit-service/ogr-tests
+                          readme_url: https://gitlab.com/packit-service/ogr-tests/-/blob/master/README.md
+                          ssh_url_to_repo: git@gitlab.com:packit-service/ogr-tests.git
+                          star_count: 0
+                          tag_list: []
+                          web_url: https://gitlab.com/packit-service/ogr-tests
+                        forking_access_level: enabled
+                        forks_count: 0
+                        http_url_to_repo: https://gitlab.com/mfocko/ogr-tests.git
+                        id: 15896155
+                        import_error: null
+                        import_status: finished
+                        issues_access_level: enabled
+                        issues_enabled: true
+                        jobs_enabled: true
+                        last_activity_at: '2020-04-28T19:16:39.081Z'
+                        lfs_enabled: true
+                        marked_for_deletion_at: null
+                        marked_for_deletion_on: null
+                        merge_method: merge
+                        merge_requests_access_level: enabled
+                        merge_requests_enabled: true
+                        mirror: false
+                        name: ogr-tests
+                        name_with_namespace: Matej Focko / ogr-tests
+                        namespace:
+                          avatar_url: /uploads/-/system/user/avatar/375555/avatar.png
+                          full_path: mfocko
+                          id: 439774
+                          kind: user
+                          name: Matej Focko
+                          parent_id: null
+                          path: mfocko
+                          web_url: https://gitlab.com/mfocko
+                        only_allow_merge_if_all_discussions_are_resolved: false
+                        only_allow_merge_if_pipeline_succeeds: false
+                        open_issues_count: 0
+                        owner:
+                          avatar_url: https://assets.gitlab-static.net/uploads/-/system/user/avatar/375555/avatar.png
+                          id: 375555
+                          name: Matej Focko
+                          state: active
+                          username: mfocko
+                          web_url: https://gitlab.com/mfocko
+                        packages_enabled: true
+                        pages_access_level: enabled
+                        path: ogr-tests
+                        path_with_namespace: mfocko/ogr-tests
+                        permissions:
+                          group_access: null
+                          project_access:
+                            access_level: 40
+                            notification_level: 3
+                        printing_merge_request_link_enabled: true
+                        public_jobs: true
+                        readme_url: https://gitlab.com/mfocko/ogr-tests/-/blob/master/README.md
+                        remove_source_branch_after_merge: true
+                        repository_access_level: enabled
+                        request_access_enabled: true
+                        resolve_outdated_diff_discussions: false
+                        runners_token: WKy7SCDsumYRV5keeT8c
+                        service_desk_address: incoming+mfocko-ogr-tests-15896155-issue-@incoming.gitlab.com
+                        service_desk_enabled: true
+                        shared_runners_enabled: true
+                        shared_with_groups: []
+                        snippets_access_level: enabled
+                        snippets_enabled: true
+                        ssh_url_to_repo: git@gitlab.com:mfocko/ogr-tests.git
+                        star_count: 0
+                        suggestion_commit_message: null
+                        tag_list: []
+                        visibility: public
+                        web_url: https://gitlab.com/mfocko/ogr-tests
+                        wiki_access_level: enabled
+                        wiki_enabled: true
+                      _next: null
+                      elapsed: 0.2
+                      encoding: null
+                      headers:
+                        CF-Cache-Status: DYNAMIC
+                        CF-RAY: 58b32aceeabb8cb6-VIE
+                        Cache-Control: max-age=0, private, must-revalidate
+                        Connection: keep-alive
+                        Content-Encoding: gzip
+                        Content-Type: application/json
+                        Date: Fri, 01 Nov 2019 13-36-03 GMT
+                        Etag: W/"42f032d7c6839d85c235c52541b861bb"
+                        Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                        GitLab-LB: fe-16-lb-gprd
+                        GitLab-SV: localhost
+                        RateLimit-Limit: '600'
+                        RateLimit-Observed: '7'
+                        RateLimit-Remaining: '593'
+                        RateLimit-Reset: '1588101965'
+                        RateLimit-ResetTime: Tue, 28 Apr 2020 19:26:05 GMT
+                        Referrer-Policy: strict-origin-when-cross-origin
+                        Server: cloudflare
+                        Strict-Transport-Security: max-age=31536000
+                        Transfer-Encoding: chunked
+                        Vary: Origin
+                        X-Content-Type-Options: nosniff
+                        X-Frame-Options: SAMEORIGIN
+                        X-Request-Id: TLpvPigIM95
+                        X-Runtime: '0.089861'
+                        cf-request-id: 0263d9154f00008cb6a0859200000001
+                      raw: !!binary ""
+                      reason: OK
+                      status_code: 200

--- a/tests/integration/test_data/test_gitlab/tests.integration.test_gitlab.PullRequests.test_source_project_renamed_fork.yaml
+++ b/tests/integration/test_data/test_gitlab/tests.integration.test_gitlab.PullRequests.test_source_project_renamed_fork.yaml
@@ -1,0 +1,565 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectFull
+  version_storage_file: 2
+unittest.case:
+  tests.integration.test_gitlab:
+    ogr.services.gitlab.project:
+      ogr.services.gitlab.pull_request:
+        gitlab.exceptions:
+          gitlab.mixins:
+            gitlab:
+              requre.objects:
+                requests.sessions:
+                  send:
+                  - metadata:
+                      latency: 0.2888467311859131
+                      module_call_list:
+                      - unittest.case
+                      - tests.integration.test_gitlab
+                      - ogr.services.gitlab.project
+                      - ogr.services.gitlab.pull_request
+                      - gitlab.exceptions
+                      - gitlab.mixins
+                      - gitlab
+                      - requre.objects
+                      - requests.sessions
+                      - send
+                    output:
+                      __store_indicator: 2
+                      _content:
+                        allow_collaboration: false
+                        allow_maintainer_to_push: false
+                        approvals_before_merge: null
+                        assignee: null
+                        assignees: []
+                        author:
+                          avatar_url: https://assets.gitlab-static.net/uploads/-/system/user/avatar/375555/avatar.png
+                          id: 375555
+                          name: Matej Focko
+                          state: active
+                          username: mfocko
+                          web_url: https://gitlab.com/mfocko
+                        blocking_discussions_resolved: true
+                        changes_count: null
+                        closed_at: null
+                        closed_by: null
+                        created_at: '2020-04-28T19:27:39.008Z'
+                        description: ''
+                        diff_refs:
+                          base_sha: 6970eae72f9ecee667183f52880ca76126bd8b38
+                          head_sha: 6970eae72f9ecee667183f52880ca76126bd8b38
+                          start_sha: b8e18207cfdad954f1b3a96db34d0706b272e6cf
+                        discussion_locked: null
+                        downvotes: 0
+                        first_contribution: false
+                        first_deployed_to_production_at: null
+                        force_remove_source_branch: true
+                        has_conflicts: true
+                        head_pipeline: null
+                        id: 57208001
+                        iid: 24
+                        labels: []
+                        latest_build_finished_at: null
+                        latest_build_started_at: null
+                        merge_commit_sha: null
+                        merge_error: null
+                        merge_status: cannot_be_merged
+                        merge_when_pipeline_succeeds: false
+                        merged_at: null
+                        merged_by: null
+                        milestone: null
+                        pipeline: null
+                        project_id: 14233409
+                        reference: '!24'
+                        references:
+                          full: packit-service/ogr-tests!24
+                          relative: '!24'
+                          short: '!24'
+                        sha: 6970eae72f9ecee667183f52880ca76126bd8b38
+                        should_remove_source_branch: null
+                        source_branch: pr-test3
+                        source_project_id: 15896155
+                        squash: false
+                        squash_commit_sha: null
+                        state: opened
+                        subscribed: true
+                        target_branch: master
+                        target_project_id: 14233409
+                        task_completion_status:
+                          completed_count: 0
+                          count: 0
+                        time_stats:
+                          human_time_estimate: null
+                          human_total_time_spent: null
+                          time_estimate: 0
+                          total_time_spent: 0
+                        title: 'WIP: Pr test3'
+                        updated_at: '2020-04-28T19:27:39.008Z'
+                        upvotes: 0
+                        user:
+                          can_merge: true
+                        user_notes_count: 0
+                        web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/24
+                        work_in_progress: true
+                      _next: null
+                      elapsed: 0.2
+                      encoding: null
+                      headers:
+                        CF-Cache-Status: DYNAMIC
+                        CF-RAY: 58b32f339d77fca1-VIE
+                        Cache-Control: max-age=0, private, must-revalidate
+                        Connection: keep-alive
+                        Content-Encoding: gzip
+                        Content-Type: application/json
+                        Date: Fri, 01 Nov 2019 13-36-03 GMT
+                        Etag: W/"f6d26bd905fd1a635d3c4304226e9d55"
+                        Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                        GitLab-LB: fe-07-lb-gprd
+                        GitLab-SV: localhost
+                        RateLimit-Limit: '600'
+                        RateLimit-Observed: '4'
+                        RateLimit-Remaining: '596'
+                        RateLimit-Reset: '1588102145'
+                        RateLimit-ResetTime: Tue, 28 Apr 2020 19:29:05 GMT
+                        Referrer-Policy: strict-origin-when-cross-origin
+                        Server: cloudflare
+                        Strict-Transport-Security: max-age=31536000
+                        Transfer-Encoding: chunked
+                        Vary: Origin
+                        X-Content-Type-Options: nosniff
+                        X-Frame-Options: SAMEORIGIN
+                        X-Request-Id: d1VILtztQX1
+                        X-Runtime: '0.073083'
+                        cf-request-id: 0263dbd4400000fca1b6a80200000001
+                      raw: !!binary ""
+                      reason: OK
+                      status_code: 200
+        ogr.services.gitlab.project:
+          gitlab.exceptions:
+            gitlab.mixins:
+              gitlab:
+                requre.objects:
+                  requests.sessions:
+                    send:
+                    - metadata:
+                        latency: 0.2981410026550293
+                        module_call_list:
+                        - unittest.case
+                        - tests.integration.test_gitlab
+                        - ogr.services.gitlab.project
+                        - ogr.services.gitlab.pull_request
+                        - ogr.services.gitlab.project
+                        - gitlab.exceptions
+                        - gitlab.mixins
+                        - gitlab
+                        - requre.objects
+                        - requests.sessions
+                        - send
+                      output:
+                        __store_indicator: 2
+                        _content:
+                          _links:
+                            events: https://gitlab.com/api/v4/projects/14233409/events
+                            issues: https://gitlab.com/api/v4/projects/14233409/issues
+                            labels: https://gitlab.com/api/v4/projects/14233409/labels
+                            members: https://gitlab.com/api/v4/projects/14233409/members
+                            merge_requests: https://gitlab.com/api/v4/projects/14233409/merge_requests
+                            repo_branches: https://gitlab.com/api/v4/projects/14233409/repository/branches
+                            self: https://gitlab.com/api/v4/projects/14233409
+                          approvals_before_merge: 0
+                          archived: false
+                          auto_cancel_pending_pipelines: enabled
+                          auto_devops_deploy_strategy: continuous
+                          auto_devops_enabled: false
+                          autoclose_referenced_issues: true
+                          avatar_url: null
+                          build_coverage_regex: null
+                          build_git_strategy: fetch
+                          build_timeout: 3600
+                          builds_access_level: enabled
+                          can_create_merge_request_in: true
+                          ci_config_path: null
+                          ci_default_git_depth: 50
+                          container_registry_enabled: true
+                          created_at: '2019-09-10T10:28:09.946Z'
+                          creator_id: 433670
+                          default_branch: master
+                          description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+                          emails_disabled: null
+                          empty_repo: false
+                          external_authorization_classification_label: ''
+                          forking_access_level: enabled
+                          forks_count: 4
+                          http_url_to_repo: https://gitlab.com/packit-service/ogr-tests.git
+                          id: 14233409
+                          import_error: null
+                          import_status: none
+                          issues_access_level: enabled
+                          issues_enabled: true
+                          jobs_enabled: true
+                          last_activity_at: '2020-04-28T19:17:22.800Z'
+                          lfs_enabled: true
+                          marked_for_deletion_at: null
+                          marked_for_deletion_on: null
+                          merge_method: merge
+                          merge_requests_access_level: enabled
+                          merge_requests_enabled: true
+                          mirror: false
+                          name: ogr-tests
+                          name_with_namespace: packit-service / ogr-tests
+                          namespace:
+                            avatar_url: /uploads/-/system/group/avatar/6032704/packit-logo.png
+                            full_path: packit-service
+                            id: 6032704
+                            kind: group
+                            name: packit-service
+                            parent_id: null
+                            path: packit-service
+                            web_url: https://gitlab.com/groups/packit-service
+                          only_allow_merge_if_all_discussions_are_resolved: false
+                          only_allow_merge_if_pipeline_succeeds: false
+                          open_issues_count: 42
+                          packages_enabled: true
+                          pages_access_level: enabled
+                          path: ogr-tests
+                          path_with_namespace: packit-service/ogr-tests
+                          permissions:
+                            group_access:
+                              access_level: 40
+                              notification_level: 3
+                            project_access: null
+                          printing_merge_request_link_enabled: true
+                          public_jobs: true
+                          readme_url: https://gitlab.com/packit-service/ogr-tests/-/blob/master/README.md
+                          remove_source_branch_after_merge: null
+                          repository_access_level: enabled
+                          request_access_enabled: false
+                          resolve_outdated_diff_discussions: false
+                          runners_token: VjGdzzwZbsTY37sxUeWL
+                          service_desk_address: incoming+packit-service-ogr-tests-14233409-issue-@incoming.gitlab.com
+                          service_desk_enabled: true
+                          shared_runners_enabled: true
+                          shared_with_groups: []
+                          snippets_access_level: enabled
+                          snippets_enabled: true
+                          ssh_url_to_repo: git@gitlab.com:packit-service/ogr-tests.git
+                          star_count: 0
+                          suggestion_commit_message: null
+                          tag_list: []
+                          visibility: public
+                          web_url: https://gitlab.com/packit-service/ogr-tests
+                          wiki_access_level: enabled
+                          wiki_enabled: true
+                        _next: null
+                        elapsed: 0.2
+                        encoding: null
+                        headers:
+                          CF-Cache-Status: DYNAMIC
+                          CF-RAY: 58b32f31af76fca1-VIE
+                          Cache-Control: max-age=0, private, must-revalidate
+                          Connection: keep-alive
+                          Content-Encoding: gzip
+                          Content-Type: application/json
+                          Date: Fri, 01 Nov 2019 13-36-03 GMT
+                          Etag: W/"96fed4967a78dc12084759cad53b6235"
+                          Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                          GitLab-LB: fe-23-lb-gprd
+                          GitLab-SV: localhost
+                          RateLimit-Limit: '600'
+                          RateLimit-Observed: '3'
+                          RateLimit-Remaining: '597'
+                          RateLimit-Reset: '1588102145'
+                          RateLimit-ResetTime: Tue, 28 Apr 2020 19:29:05 GMT
+                          Referrer-Policy: strict-origin-when-cross-origin
+                          Server: cloudflare
+                          Strict-Transport-Security: max-age=31536000
+                          Transfer-Encoding: chunked
+                          Vary: Origin
+                          X-Content-Type-Options: nosniff
+                          X-Frame-Options: SAMEORIGIN
+                          X-Request-Id: 0fiAdegWVN3
+                          X-Runtime: '0.082654'
+                          cf-request-id: 0263dbd30a0000fca1b69fd200000001
+                        raw: !!binary ""
+                        reason: OK
+                        status_code: 200
+          ogr.services.gitlab.service:
+            gitlab:
+              gitlab.exceptions:
+                gitlab.mixins:
+                  gitlab:
+                    requre.objects:
+                      requests.sessions:
+                        send:
+                        - metadata:
+                            latency: 0.35137009620666504
+                            module_call_list:
+                            - unittest.case
+                            - tests.integration.test_gitlab
+                            - ogr.services.gitlab.project
+                            - ogr.services.gitlab.pull_request
+                            - ogr.services.gitlab.project
+                            - ogr.services.gitlab.service
+                            - gitlab
+                            - gitlab.exceptions
+                            - gitlab.mixins
+                            - gitlab
+                            - requre.objects
+                            - requests.sessions
+                            - send
+                          output:
+                            __store_indicator: 2
+                            _content:
+                              avatar_url: https://assets.gitlab-static.net/uploads/-/system/user/avatar/375555/avatar.png
+                              bio: ''
+                              can_create_group: true
+                              can_create_project: true
+                              color_scheme_id: 4
+                              confirmed_at: '2018-06-07T08:34:01.593Z'
+                              created_at: '2016-01-15T21:12:31.705Z'
+                              current_sign_in_at: '2020-04-22T11:44:25.029Z'
+                              email: matej.focko@outlook.com
+                              external: false
+                              extra_shared_runners_minutes_limit: null
+                              id: 375555
+                              identities: []
+                              job_title: ''
+                              last_activity_on: '2020-04-28'
+                              last_sign_in_at: '2020-04-19T14:53:06.287Z'
+                              linkedin: ''
+                              location: "Ko\u0161ice, Slovakia"
+                              name: Matej Focko
+                              organization: ''
+                              private_profile: false
+                              projects_limit: 100000
+                              public_email: ''
+                              shared_runners_minutes_limit: 2000
+                              skype: ''
+                              state: active
+                              theme_id: 7
+                              twitter: MatejFocko
+                              two_factor_enabled: true
+                              username: mfocko
+                              web_url: https://gitlab.com/mfocko
+                              website_url: ''
+                              work_information: null
+                            _next: null
+                            elapsed: 0.2
+                            encoding: null
+                            headers:
+                              CF-Cache-Status: DYNAMIC
+                              CF-RAY: 58b32f2fd9f1fca1-VIE
+                              Cache-Control: max-age=0, private, must-revalidate
+                              Connection: keep-alive
+                              Content-Encoding: gzip
+                              Content-Type: application/json
+                              Date: Fri, 01 Nov 2019 13-36-03 GMT
+                              Etag: W/"e6d354bf72a9220d014f2ce53e1c4be3"
+                              Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                              GitLab-LB: fe-20-lb-gprd
+                              GitLab-SV: localhost
+                              RateLimit-Limit: '600'
+                              RateLimit-Observed: '2'
+                              RateLimit-Remaining: '598'
+                              RateLimit-Reset: '1588102145'
+                              RateLimit-ResetTime: Tue, 28 Apr 2020 19:29:05 GMT
+                              Referrer-Policy: strict-origin-when-cross-origin
+                              Server: cloudflare
+                              Set-Cookie: __cfduid=de4eb7dbddc037ea1cd8aef1a22f438671588102085;
+                                expires=Thu, 28-May-20 19:28:05 GMT; path=/; domain=.gitlab.com;
+                                HttpOnly; SameSite=Lax; Secure
+                              Strict-Transport-Security: max-age=31536000
+                              Transfer-Encoding: chunked
+                              Vary: Origin
+                              X-Content-Type-Options: nosniff
+                              X-Frame-Options: SAMEORIGIN
+                              X-Request-Id: AMENRnACN63
+                              X-Runtime: '0.036032'
+                              cf-request-id: 0263dbd1e60000fca1b69d3200000001
+                            raw: !!binary ""
+                            reason: OK
+                            status_code: 200
+    ogr.services.gitlab.pull_request:
+      ogr.services.gitlab.service:
+        gitlab.exceptions:
+          gitlab.mixins:
+            gitlab:
+              requre.objects:
+                requests.sessions:
+                  send:
+                  - metadata:
+                      latency: 0.28938889503479004
+                      module_call_list:
+                      - unittest.case
+                      - tests.integration.test_gitlab
+                      - ogr.services.gitlab.pull_request
+                      - ogr.services.gitlab.service
+                      - gitlab.exceptions
+                      - gitlab.mixins
+                      - gitlab
+                      - requre.objects
+                      - requests.sessions
+                      - send
+                    output:
+                      __store_indicator: 2
+                      _content:
+                        _links:
+                          events: https://gitlab.com/api/v4/projects/15896155/events
+                          issues: https://gitlab.com/api/v4/projects/15896155/issues
+                          labels: https://gitlab.com/api/v4/projects/15896155/labels
+                          members: https://gitlab.com/api/v4/projects/15896155/members
+                          merge_requests: https://gitlab.com/api/v4/projects/15896155/merge_requests
+                          repo_branches: https://gitlab.com/api/v4/projects/15896155/repository/branches
+                          self: https://gitlab.com/api/v4/projects/15896155
+                        approvals_before_merge: 0
+                        archived: false
+                        auto_cancel_pending_pipelines: enabled
+                        auto_devops_deploy_strategy: continuous
+                        auto_devops_enabled: false
+                        autoclose_referenced_issues: true
+                        avatar_url: null
+                        build_coverage_regex: null
+                        build_git_strategy: fetch
+                        build_timeout: 3600
+                        builds_access_level: enabled
+                        can_create_merge_request_in: true
+                        ci_config_path: null
+                        ci_default_git_depth: 50
+                        container_registry_enabled: true
+                        created_at: '2019-12-16T11:13:20.567Z'
+                        creator_id: 375555
+                        default_branch: master
+                        description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+                        emails_disabled: null
+                        empty_repo: false
+                        external_authorization_classification_label: ''
+                        forked_from_project:
+                          avatar_url: null
+                          created_at: '2019-09-10T10:28:09.946Z'
+                          default_branch: master
+                          description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+                          forks_count: 4
+                          http_url_to_repo: https://gitlab.com/packit-service/ogr-tests.git
+                          id: 14233409
+                          last_activity_at: '2020-04-28T19:17:22.800Z'
+                          name: ogr-tests
+                          name_with_namespace: packit-service / ogr-tests
+                          namespace:
+                            avatar_url: /uploads/-/system/group/avatar/6032704/packit-logo.png
+                            full_path: packit-service
+                            id: 6032704
+                            kind: group
+                            name: packit-service
+                            parent_id: null
+                            path: packit-service
+                            web_url: https://gitlab.com/groups/packit-service
+                          path: ogr-tests
+                          path_with_namespace: packit-service/ogr-tests
+                          readme_url: https://gitlab.com/packit-service/ogr-tests/-/blob/master/README.md
+                          ssh_url_to_repo: git@gitlab.com:packit-service/ogr-tests.git
+                          star_count: 0
+                          tag_list: []
+                          web_url: https://gitlab.com/packit-service/ogr-tests
+                        forking_access_level: enabled
+                        forks_count: 0
+                        http_url_to_repo: https://gitlab.com/mfocko/definitely-not-ogr-tests.git
+                        id: 15896155
+                        import_error: null
+                        import_status: finished
+                        issues_access_level: enabled
+                        issues_enabled: true
+                        jobs_enabled: true
+                        last_activity_at: '2020-04-28T19:16:39.081Z'
+                        lfs_enabled: true
+                        marked_for_deletion_at: null
+                        marked_for_deletion_on: null
+                        merge_method: merge
+                        merge_requests_access_level: enabled
+                        merge_requests_enabled: true
+                        mirror: false
+                        name: ogr-tests
+                        name_with_namespace: Matej Focko / ogr-tests
+                        namespace:
+                          avatar_url: /uploads/-/system/user/avatar/375555/avatar.png
+                          full_path: mfocko
+                          id: 439774
+                          kind: user
+                          name: Matej Focko
+                          parent_id: null
+                          path: mfocko
+                          web_url: https://gitlab.com/mfocko
+                        only_allow_merge_if_all_discussions_are_resolved: false
+                        only_allow_merge_if_pipeline_succeeds: false
+                        open_issues_count: 0
+                        owner:
+                          avatar_url: https://assets.gitlab-static.net/uploads/-/system/user/avatar/375555/avatar.png
+                          id: 375555
+                          name: Matej Focko
+                          state: active
+                          username: mfocko
+                          web_url: https://gitlab.com/mfocko
+                        packages_enabled: true
+                        pages_access_level: enabled
+                        path: definitely-not-ogr-tests
+                        path_with_namespace: mfocko/definitely-not-ogr-tests
+                        permissions:
+                          group_access: null
+                          project_access:
+                            access_level: 40
+                            notification_level: 3
+                        printing_merge_request_link_enabled: true
+                        public_jobs: true
+                        readme_url: https://gitlab.com/mfocko/definitely-not-ogr-tests/-/blob/master/README.md
+                        remove_source_branch_after_merge: true
+                        repository_access_level: enabled
+                        request_access_enabled: true
+                        resolve_outdated_diff_discussions: false
+                        runners_token: WKy7SCDsumYRV5keeT8c
+                        service_desk_address: incoming+mfocko-definitely-not-ogr-tests-15896155-issue-@incoming.gitlab.com
+                        service_desk_enabled: true
+                        shared_runners_enabled: true
+                        shared_with_groups: []
+                        snippets_access_level: enabled
+                        snippets_enabled: true
+                        ssh_url_to_repo: git@gitlab.com:mfocko/definitely-not-ogr-tests.git
+                        star_count: 0
+                        suggestion_commit_message: null
+                        tag_list: []
+                        visibility: public
+                        web_url: https://gitlab.com/mfocko/definitely-not-ogr-tests
+                        wiki_access_level: enabled
+                        wiki_enabled: true
+                      _next: null
+                      elapsed: 0.2
+                      encoding: null
+                      headers:
+                        CF-Cache-Status: DYNAMIC
+                        CF-RAY: 58b32f357a75fca1-VIE
+                        Cache-Control: max-age=0, private, must-revalidate
+                        Connection: keep-alive
+                        Content-Encoding: gzip
+                        Content-Type: application/json
+                        Date: Fri, 01 Nov 2019 13-36-03 GMT
+                        Etag: W/"e69c03edeba89e0dcce78e6de19a0ba2"
+                        Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                        GitLab-LB: fe-15-lb-gprd
+                        GitLab-SV: localhost
+                        RateLimit-Limit: '600'
+                        RateLimit-Observed: '5'
+                        RateLimit-Remaining: '595'
+                        RateLimit-Reset: '1588102146'
+                        RateLimit-ResetTime: Tue, 28 Apr 2020 19:29:06 GMT
+                        Referrer-Policy: strict-origin-when-cross-origin
+                        Server: cloudflare
+                        Strict-Transport-Security: max-age=31536000
+                        Transfer-Encoding: chunked
+                        Vary: Origin
+                        X-Content-Type-Options: nosniff
+                        X-Frame-Options: SAMEORIGIN
+                        X-Request-Id: JoyGOydZaTa
+                        X-Runtime: '0.094175'
+                        cf-request-id: 0263dbd56a0000fca1b6aa0200000001
+                      raw: !!binary ""
+                      reason: OK
+                      status_code: 200

--- a/tests/integration/test_data/test_gitlab/tests.integration.test_gitlab.PullRequests.test_source_project_renamed_upstream.yaml
+++ b/tests/integration/test_data/test_gitlab/tests.integration.test_gitlab.PullRequests.test_source_project_renamed_upstream.yaml
@@ -1,0 +1,559 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectFull
+  version_storage_file: 2
+unittest.case:
+  tests.integration.test_gitlab:
+    ogr.services.gitlab.project:
+      ogr.services.gitlab.pull_request:
+        gitlab.exceptions:
+          gitlab.mixins:
+            gitlab:
+              requre.objects:
+                requests.sessions:
+                  send:
+                  - metadata:
+                      latency: 0.29004406929016113
+                      module_call_list:
+                      - unittest.case
+                      - tests.integration.test_gitlab
+                      - ogr.services.gitlab.project
+                      - ogr.services.gitlab.pull_request
+                      - gitlab.exceptions
+                      - gitlab.mixins
+                      - gitlab
+                      - requre.objects
+                      - requests.sessions
+                      - send
+                    output:
+                      __store_indicator: 2
+                      _content:
+                        allow_collaboration: false
+                        allow_maintainer_to_push: false
+                        approvals_before_merge: null
+                        assignee: null
+                        assignees: []
+                        author:
+                          avatar_url: https://assets.gitlab-static.net/uploads/-/system/user/avatar/375555/avatar.png
+                          id: 375555
+                          name: Matej Focko
+                          state: active
+                          username: mfocko
+                          web_url: https://gitlab.com/mfocko
+                        blocking_discussions_resolved: true
+                        changes_count: '1'
+                        closed_at: null
+                        closed_by: null
+                        created_at: '2020-04-29T13:23:38.510Z'
+                        description: ''
+                        diff_refs:
+                          base_sha: 3c5fa1d2a454e7be74a7e7fe62b336db5f7cb135
+                          head_sha: 2984c60e7db66627d6bc06b9e276223615389a72
+                          start_sha: 3c5fa1d2a454e7be74a7e7fe62b336db5f7cb135
+                        discussion_locked: null
+                        downvotes: 0
+                        first_contribution: false
+                        first_deployed_to_production_at: null
+                        force_remove_source_branch: true
+                        has_conflicts: false
+                        head_pipeline: null
+                        id: 57290293
+                        iid: 1
+                        labels: []
+                        latest_build_finished_at: null
+                        latest_build_started_at: null
+                        merge_commit_sha: null
+                        merge_error: null
+                        merge_status: can_be_merged
+                        merge_when_pipeline_succeeds: false
+                        merged_at: null
+                        merged_by: null
+                        milestone: null
+                        pipeline: null
+                        project_id: 14529939
+                        reference: '!1'
+                        references:
+                          full: packit-service/old-ogr-testing-repo-in-the-group!1
+                          relative: '!1'
+                          short: '!1'
+                        sha: 2984c60e7db66627d6bc06b9e276223615389a72
+                        should_remove_source_branch: null
+                        source_branch: test-mr
+                        source_project_id: 18483385
+                        squash: false
+                        squash_commit_sha: null
+                        state: opened
+                        subscribed: true
+                        target_branch: master
+                        target_project_id: 14529939
+                        task_completion_status:
+                          completed_count: 0
+                          count: 0
+                        time_stats:
+                          human_time_estimate: null
+                          human_total_time_spent: null
+                          time_estimate: 0
+                          total_time_spent: 0
+                        title: '[ogr-test]change readme'
+                        updated_at: '2020-04-29T13:23:38.510Z'
+                        upvotes: 0
+                        user:
+                          can_merge: true
+                        user_notes_count: 0
+                        web_url: https://gitlab.com/packit-service/old-ogr-testing-repo-in-the-group/-/merge_requests/1
+                        work_in_progress: false
+                      _next: null
+                      elapsed: 0.2
+                      encoding: null
+                      headers:
+                        CF-Cache-Status: DYNAMIC
+                        CF-RAY: 58b959d1cd0efcad-VIE
+                        Cache-Control: max-age=0, private, must-revalidate
+                        Connection: keep-alive
+                        Content-Encoding: gzip
+                        Content-Type: application/json
+                        Date: Fri, 01 Nov 2019 13-36-03 GMT
+                        Etag: W/"b802ed702024c92331ff8642c56300fd"
+                        Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                        GitLab-LB: fe-13-lb-gprd
+                        GitLab-SV: localhost
+                        RateLimit-Limit: '600'
+                        RateLimit-Observed: '2'
+                        RateLimit-Remaining: '598'
+                        RateLimit-Reset: '1588166806'
+                        RateLimit-ResetTime: Wed, 29 Apr 2020 13:26:46 GMT
+                        Referrer-Policy: strict-origin-when-cross-origin
+                        Server: cloudflare
+                        Strict-Transport-Security: max-age=31536000
+                        Transfer-Encoding: chunked
+                        Vary: Origin
+                        X-Content-Type-Options: nosniff
+                        X-Frame-Options: SAMEORIGIN
+                        X-Request-Id: eppPyoce0B3
+                        X-Runtime: '0.073661'
+                        cf-request-id: 0267b6771c0000fcad41b67200000001
+                      raw: !!binary ""
+                      reason: OK
+                      status_code: 200
+        ogr.services.gitlab.project:
+          gitlab.exceptions:
+            gitlab.mixins:
+              gitlab:
+                requre.objects:
+                  requests.sessions:
+                    send:
+                    - metadata:
+                        latency: 0.3711686134338379
+                        module_call_list:
+                        - unittest.case
+                        - tests.integration.test_gitlab
+                        - ogr.services.gitlab.project
+                        - ogr.services.gitlab.pull_request
+                        - ogr.services.gitlab.project
+                        - gitlab.exceptions
+                        - gitlab.mixins
+                        - gitlab
+                        - requre.objects
+                        - requests.sessions
+                        - send
+                      output:
+                        __store_indicator: 2
+                        _content:
+                          _links:
+                            events: https://gitlab.com/api/v4/projects/14529939/events
+                            issues: https://gitlab.com/api/v4/projects/14529939/issues
+                            labels: https://gitlab.com/api/v4/projects/14529939/labels
+                            members: https://gitlab.com/api/v4/projects/14529939/members
+                            merge_requests: https://gitlab.com/api/v4/projects/14529939/merge_requests
+                            repo_branches: https://gitlab.com/api/v4/projects/14529939/repository/branches
+                            self: https://gitlab.com/api/v4/projects/14529939
+                          archived: false
+                          auto_cancel_pending_pipelines: enabled
+                          auto_devops_deploy_strategy: continuous
+                          auto_devops_enabled: false
+                          autoclose_referenced_issues: true
+                          avatar_url: null
+                          build_coverage_regex: null
+                          build_git_strategy: fetch
+                          build_timeout: 3600
+                          builds_access_level: enabled
+                          can_create_merge_request_in: true
+                          ci_config_path: null
+                          ci_default_git_depth: 50
+                          container_registry_enabled: true
+                          created_at: '2019-09-27T08:54:07.428Z'
+                          creator_id: 4626962
+                          default_branch: master
+                          description: null
+                          emails_disabled: null
+                          empty_repo: false
+                          external_authorization_classification_label: ''
+                          forking_access_level: enabled
+                          forks_count: 1
+                          http_url_to_repo: https://gitlab.com/packit-service/old-ogr-testing-repo-in-the-group.git
+                          id: 14529939
+                          import_error: null
+                          import_status: none
+                          issues_access_level: enabled
+                          issues_enabled: true
+                          jobs_enabled: true
+                          last_activity_at: '2020-04-29T13:19:29.759Z'
+                          lfs_enabled: true
+                          merge_method: merge
+                          merge_requests_access_level: enabled
+                          merge_requests_enabled: true
+                          name: new-ogr-testing-repo-in-the-group
+                          name_with_namespace: packit-service / new-ogr-testing-repo-in-the-group
+                          namespace:
+                            avatar_url: /uploads/-/system/group/avatar/6032704/packit-logo.png
+                            full_path: packit-service
+                            id: 6032704
+                            kind: group
+                            name: packit-service
+                            parent_id: null
+                            path: packit-service
+                            web_url: https://gitlab.com/groups/packit-service
+                          only_allow_merge_if_all_discussions_are_resolved: false
+                          only_allow_merge_if_pipeline_succeeds: false
+                          open_issues_count: 0
+                          pages_access_level: private
+                          path: old-ogr-testing-repo-in-the-group
+                          path_with_namespace: packit-service/old-ogr-testing-repo-in-the-group
+                          permissions:
+                            group_access:
+                              access_level: 40
+                              notification_level: 3
+                            project_access: null
+                          printing_merge_request_link_enabled: true
+                          public_jobs: true
+                          readme_url: https://gitlab.com/packit-service/old-ogr-testing-repo-in-the-group/-/blob/master/README.md
+                          remove_source_branch_after_merge: null
+                          repository_access_level: enabled
+                          request_access_enabled: false
+                          resolve_outdated_diff_discussions: false
+                          runners_token: yJcqjaBB4zqiyvFcpbvB
+                          shared_runners_enabled: true
+                          shared_with_groups: []
+                          snippets_access_level: enabled
+                          snippets_enabled: true
+                          ssh_url_to_repo: git@gitlab.com:packit-service/old-ogr-testing-repo-in-the-group.git
+                          star_count: 0
+                          suggestion_commit_message: null
+                          tag_list: []
+                          visibility: private
+                          web_url: https://gitlab.com/packit-service/old-ogr-testing-repo-in-the-group
+                          wiki_access_level: enabled
+                          wiki_enabled: true
+                        _next: null
+                        elapsed: 0.2
+                        encoding: null
+                        headers:
+                          CF-Cache-Status: DYNAMIC
+                          CF-RAY: 58b959cf5dc8fcad-VIE
+                          Cache-Control: max-age=0, private, must-revalidate
+                          Connection: keep-alive
+                          Content-Encoding: gzip
+                          Content-Type: application/json
+                          Date: Fri, 01 Nov 2019 13-36-03 GMT
+                          Etag: W/"f8bccd89cdf2305f0d5d4966b0046c97"
+                          Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                          GitLab-LB: fe-06-lb-gprd
+                          GitLab-SV: localhost
+                          RateLimit-Limit: '600'
+                          RateLimit-Observed: '2'
+                          RateLimit-Remaining: '598'
+                          RateLimit-Reset: '1588166805'
+                          RateLimit-ResetTime: Wed, 29 Apr 2020 13:26:45 GMT
+                          Referrer-Policy: strict-origin-when-cross-origin
+                          Server: cloudflare
+                          Strict-Transport-Security: max-age=31536000
+                          Transfer-Encoding: chunked
+                          Vary: Origin
+                          X-Content-Type-Options: nosniff
+                          X-Frame-Options: SAMEORIGIN
+                          X-Request-Id: nQpOsH6ayP7
+                          X-Runtime: '0.094117'
+                          cf-request-id: 0267b675930000fcad41b3a200000001
+                        raw: !!binary ""
+                        reason: OK
+                        status_code: 200
+          ogr.services.gitlab.service:
+            gitlab:
+              gitlab.exceptions:
+                gitlab.mixins:
+                  gitlab:
+                    requre.objects:
+                      requests.sessions:
+                        send:
+                        - metadata:
+                            latency: 0.36783504486083984
+                            module_call_list:
+                            - unittest.case
+                            - tests.integration.test_gitlab
+                            - ogr.services.gitlab.project
+                            - ogr.services.gitlab.pull_request
+                            - ogr.services.gitlab.project
+                            - ogr.services.gitlab.service
+                            - gitlab
+                            - gitlab.exceptions
+                            - gitlab.mixins
+                            - gitlab
+                            - requre.objects
+                            - requests.sessions
+                            - send
+                          output:
+                            __store_indicator: 2
+                            _content:
+                              avatar_url: https://assets.gitlab-static.net/uploads/-/system/user/avatar/375555/avatar.png
+                              bio: ''
+                              can_create_group: true
+                              can_create_project: true
+                              color_scheme_id: 4
+                              confirmed_at: '2018-06-07T08:34:01.593Z'
+                              created_at: '2016-01-15T21:12:31.705Z'
+                              current_sign_in_at: '2020-04-22T11:44:25.029Z'
+                              email: matej.focko@outlook.com
+                              external: false
+                              extra_shared_runners_minutes_limit: null
+                              id: 375555
+                              identities: []
+                              job_title: ''
+                              last_activity_on: '2020-04-29'
+                              last_sign_in_at: '2020-04-19T14:53:06.287Z'
+                              linkedin: ''
+                              location: "Ko\u0161ice, Slovakia"
+                              name: Matej Focko
+                              organization: ''
+                              private_profile: false
+                              projects_limit: 100000
+                              public_email: ''
+                              shared_runners_minutes_limit: 2000
+                              skype: ''
+                              state: active
+                              theme_id: 7
+                              twitter: MatejFocko
+                              two_factor_enabled: true
+                              username: mfocko
+                              web_url: https://gitlab.com/mfocko
+                              website_url: ''
+                              work_information: null
+                            _next: null
+                            elapsed: 0.2
+                            encoding: null
+                            headers:
+                              CF-Cache-Status: DYNAMIC
+                              CF-RAY: 58b959cdb8f2fcad-VIE
+                              Cache-Control: max-age=0, private, must-revalidate
+                              Connection: keep-alive
+                              Content-Encoding: gzip
+                              Content-Type: application/json
+                              Date: Fri, 01 Nov 2019 13-36-03 GMT
+                              Etag: W/"4902cbd246858e1623c3e512c12a4958"
+                              Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                              GitLab-LB: fe-23-lb-gprd
+                              GitLab-SV: localhost
+                              RateLimit-Limit: '600'
+                              RateLimit-Observed: '1'
+                              RateLimit-Remaining: '599'
+                              RateLimit-Reset: '1588166805'
+                              RateLimit-ResetTime: Wed, 29 Apr 2020 13:26:45 GMT
+                              Referrer-Policy: strict-origin-when-cross-origin
+                              Server: cloudflare
+                              Set-Cookie: __cfduid=d3d32dacafde24cc7ece912bf998382341588166745;
+                                expires=Fri, 29-May-20 13:25:45 GMT; path=/; domain=.gitlab.com;
+                                HttpOnly; SameSite=Lax; Secure
+                              Strict-Transport-Security: max-age=31536000
+                              Transfer-Encoding: chunked
+                              Vary: Origin
+                              X-Content-Type-Options: nosniff
+                              X-Frame-Options: SAMEORIGIN
+                              X-Request-Id: Zj1vDTIUo08
+                              X-Runtime: '0.031715'
+                              cf-request-id: 0267b6748e0000fcad41aea200000001
+                            raw: !!binary ""
+                            reason: OK
+                            status_code: 200
+    ogr.services.gitlab.pull_request:
+      ogr.services.gitlab.service:
+        gitlab.exceptions:
+          gitlab.mixins:
+            gitlab:
+              requre.objects:
+                requests.sessions:
+                  send:
+                  - metadata:
+                      latency: 0.3907153606414795
+                      module_call_list:
+                      - unittest.case
+                      - tests.integration.test_gitlab
+                      - ogr.services.gitlab.pull_request
+                      - ogr.services.gitlab.service
+                      - gitlab.exceptions
+                      - gitlab.mixins
+                      - gitlab
+                      - requre.objects
+                      - requests.sessions
+                      - send
+                    output:
+                      __store_indicator: 2
+                      _content:
+                        _links:
+                          events: https://gitlab.com/api/v4/projects/18483385/events
+                          issues: https://gitlab.com/api/v4/projects/18483385/issues
+                          labels: https://gitlab.com/api/v4/projects/18483385/labels
+                          members: https://gitlab.com/api/v4/projects/18483385/members
+                          merge_requests: https://gitlab.com/api/v4/projects/18483385/merge_requests
+                          repo_branches: https://gitlab.com/api/v4/projects/18483385/repository/branches
+                          self: https://gitlab.com/api/v4/projects/18483385
+                        archived: false
+                        auto_cancel_pending_pipelines: enabled
+                        auto_devops_deploy_strategy: continuous
+                        auto_devops_enabled: false
+                        autoclose_referenced_issues: true
+                        avatar_url: null
+                        build_coverage_regex: null
+                        build_git_strategy: fetch
+                        build_timeout: 3600
+                        builds_access_level: enabled
+                        can_create_merge_request_in: true
+                        ci_config_path: null
+                        ci_default_git_depth: 50
+                        container_expiration_policy:
+                          cadence: 7d
+                          enabled: true
+                          keep_n: null
+                          name_regex: null
+                          name_regex_keep: null
+                          next_run_at: '2020-05-06T13:21:19.332Z'
+                          older_than: null
+                        container_registry_enabled: true
+                        created_at: '2020-04-29T13:21:19.321Z'
+                        creator_id: 375555
+                        default_branch: master
+                        description: null
+                        emails_disabled: null
+                        empty_repo: false
+                        external_authorization_classification_label: ''
+                        forked_from_project:
+                          avatar_url: null
+                          created_at: '2019-09-27T08:54:07.428Z'
+                          default_branch: master
+                          description: null
+                          forks_count: 1
+                          http_url_to_repo: https://gitlab.com/packit-service/old-ogr-testing-repo-in-the-group.git
+                          id: 14529939
+                          last_activity_at: '2020-04-29T13:19:29.759Z'
+                          name: new-ogr-testing-repo-in-the-group
+                          name_with_namespace: packit-service / new-ogr-testing-repo-in-the-group
+                          namespace:
+                            avatar_url: /uploads/-/system/group/avatar/6032704/packit-logo.png
+                            full_path: packit-service
+                            id: 6032704
+                            kind: group
+                            name: packit-service
+                            parent_id: null
+                            path: packit-service
+                            web_url: https://gitlab.com/groups/packit-service
+                          path: old-ogr-testing-repo-in-the-group
+                          path_with_namespace: packit-service/old-ogr-testing-repo-in-the-group
+                          readme_url: https://gitlab.com/packit-service/old-ogr-testing-repo-in-the-group/-/blob/master/README.md
+                          ssh_url_to_repo: git@gitlab.com:packit-service/old-ogr-testing-repo-in-the-group.git
+                          star_count: 0
+                          tag_list: []
+                          web_url: https://gitlab.com/packit-service/old-ogr-testing-repo-in-the-group
+                        forking_access_level: enabled
+                        forks_count: 0
+                        http_url_to_repo: https://gitlab.com/mfocko/new-ogr-testing-repo-in-the-group.git
+                        id: 18483385
+                        import_error: null
+                        import_status: finished
+                        issues_access_level: enabled
+                        issues_enabled: true
+                        jobs_enabled: true
+                        last_activity_at: '2020-04-29T13:21:19.321Z'
+                        lfs_enabled: true
+                        merge_method: merge
+                        merge_requests_access_level: enabled
+                        merge_requests_enabled: true
+                        name: new-ogr-testing-repo-in-the-group
+                        name_with_namespace: Matej Focko / new-ogr-testing-repo-in-the-group
+                        namespace:
+                          avatar_url: /uploads/-/system/user/avatar/375555/avatar.png
+                          full_path: mfocko
+                          id: 439774
+                          kind: user
+                          name: Matej Focko
+                          parent_id: null
+                          path: mfocko
+                          web_url: https://gitlab.com/mfocko
+                        only_allow_merge_if_all_discussions_are_resolved: false
+                        only_allow_merge_if_pipeline_succeeds: false
+                        open_issues_count: 0
+                        owner:
+                          avatar_url: https://assets.gitlab-static.net/uploads/-/system/user/avatar/375555/avatar.png
+                          id: 375555
+                          name: Matej Focko
+                          state: active
+                          username: mfocko
+                          web_url: https://gitlab.com/mfocko
+                        pages_access_level: private
+                        path: new-ogr-testing-repo-in-the-group
+                        path_with_namespace: mfocko/new-ogr-testing-repo-in-the-group
+                        permissions:
+                          group_access: null
+                          project_access:
+                            access_level: 40
+                            notification_level: 3
+                        printing_merge_request_link_enabled: true
+                        public_jobs: true
+                        readme_url: https://gitlab.com/mfocko/new-ogr-testing-repo-in-the-group/-/blob/master/README.md
+                        remove_source_branch_after_merge: true
+                        repository_access_level: enabled
+                        request_access_enabled: true
+                        resolve_outdated_diff_discussions: false
+                        runners_token: kodUaFAYnthNd_XsqJW1
+                        shared_runners_enabled: true
+                        shared_with_groups: []
+                        snippets_access_level: enabled
+                        snippets_enabled: true
+                        ssh_url_to_repo: git@gitlab.com:mfocko/new-ogr-testing-repo-in-the-group.git
+                        star_count: 0
+                        suggestion_commit_message: null
+                        tag_list: []
+                        visibility: private
+                        web_url: https://gitlab.com/mfocko/new-ogr-testing-repo-in-the-group
+                        wiki_access_level: enabled
+                        wiki_enabled: true
+                      _next: null
+                      elapsed: 0.2
+                      encoding: null
+                      headers:
+                        CF-Cache-Status: DYNAMIC
+                        CF-RAY: 58b959d3bac8fcad-VIE
+                        Cache-Control: max-age=0, private, must-revalidate
+                        Connection: keep-alive
+                        Content-Encoding: gzip
+                        Content-Type: application/json
+                        Date: Fri, 01 Nov 2019 13-36-03 GMT
+                        Etag: W/"7254558ad246826534bc11244081c4b2"
+                        Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                        GitLab-LB: fe-23-lb-gprd
+                        GitLab-SV: localhost
+                        RateLimit-Limit: '600'
+                        RateLimit-Observed: '2'
+                        RateLimit-Remaining: '598'
+                        RateLimit-Reset: '1588166806'
+                        RateLimit-ResetTime: Wed, 29 Apr 2020 13:26:46 GMT
+                        Referrer-Policy: strict-origin-when-cross-origin
+                        Server: cloudflare
+                        Strict-Transport-Security: max-age=31536000
+                        Transfer-Encoding: chunked
+                        Vary: Origin
+                        X-Content-Type-Options: nosniff
+                        X-Frame-Options: SAMEORIGIN
+                        X-Request-Id: rkHky4YDGW
+                        X-Runtime: '0.114573'
+                        cf-request-id: 0267b678540000fcad41b92200000001
+                      raw: !!binary ""
+                      reason: OK
+                      status_code: 200

--- a/tests/integration/test_data/test_gitlab/tests.integration.test_gitlab.PullRequests.test_source_project_upstream_branch.yaml
+++ b/tests/integration/test_data/test_gitlab/tests.integration.test_gitlab.PullRequests.test_source_project_upstream_branch.yaml
@@ -1,0 +1,529 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectFull
+  version_storage_file: 2
+unittest.case:
+  tests.integration.test_gitlab:
+    ogr.services.gitlab.project:
+      ogr.services.gitlab.pull_request:
+        gitlab.exceptions:
+          gitlab.mixins:
+            gitlab:
+              requre.objects:
+                requests.sessions:
+                  send:
+                  - metadata:
+                      latency: 0.2837347984313965
+                      module_call_list:
+                      - unittest.case
+                      - tests.integration.test_gitlab
+                      - ogr.services.gitlab.project
+                      - ogr.services.gitlab.pull_request
+                      - gitlab.exceptions
+                      - gitlab.mixins
+                      - gitlab
+                      - requre.objects
+                      - requests.sessions
+                      - send
+                    output:
+                      __store_indicator: 2
+                      _content:
+                        approvals_before_merge: null
+                        assignee: null
+                        assignees: []
+                        author:
+                          avatar_url: https://assets.gitlab-static.net/uploads/-/system/user/avatar/375555/avatar.png
+                          id: 375555
+                          name: Matej Focko
+                          state: active
+                          username: mfocko
+                          web_url: https://gitlab.com/mfocko
+                        blocking_discussions_resolved: true
+                        changes_count: null
+                        closed_at: null
+                        closed_by: null
+                        created_at: '2020-04-28T19:17:22.548Z'
+                        description: ''
+                        diff_refs:
+                          base_sha: db843cde94391923c6acb4cce938d830477a9732
+                          head_sha: db843cde94391923c6acb4cce938d830477a9732
+                          start_sha: b8e18207cfdad954f1b3a96db34d0706b272e6cf
+                        discussion_locked: null
+                        downvotes: 0
+                        first_contribution: false
+                        first_deployed_to_production_at: null
+                        force_remove_source_branch: false
+                        has_conflicts: true
+                        head_pipeline: null
+                        id: 57207332
+                        iid: 23
+                        labels: []
+                        latest_build_finished_at: null
+                        latest_build_started_at: null
+                        merge_commit_sha: null
+                        merge_error: null
+                        merge_status: cannot_be_merged
+                        merge_when_pipeline_succeeds: false
+                        merged_at: null
+                        merged_by: null
+                        milestone: null
+                        pipeline: null
+                        project_id: 14233409
+                        reference: '!23'
+                        references:
+                          full: packit-service/ogr-tests!23
+                          relative: '!23'
+                          short: '!23'
+                        sha: db843cde94391923c6acb4cce938d830477a9732
+                        should_remove_source_branch: null
+                        source_branch: pr-3
+                        source_project_id: 14233409
+                        squash: false
+                        squash_commit_sha: null
+                        state: opened
+                        subscribed: true
+                        target_branch: master
+                        target_project_id: 14233409
+                        task_completion_status:
+                          completed_count: 0
+                          count: 0
+                        time_stats:
+                          human_time_estimate: null
+                          human_total_time_spent: null
+                          time_estimate: 0
+                          total_time_spent: 0
+                        title: 'WIP: Pr 3'
+                        updated_at: '2020-04-28T19:17:22.548Z'
+                        upvotes: 0
+                        user:
+                          can_merge: true
+                        user_notes_count: 0
+                        web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/23
+                        work_in_progress: true
+                      _next: null
+                      elapsed: 0.2
+                      encoding: null
+                      headers:
+                        CF-Cache-Status: DYNAMIC
+                        CF-RAY: 58b32ad59fb3596a-VIE
+                        Cache-Control: max-age=0, private, must-revalidate
+                        Connection: keep-alive
+                        Content-Encoding: gzip
+                        Content-Type: application/json
+                        Date: Fri, 01 Nov 2019 13-36-03 GMT
+                        Etag: W/"2e9f911e3e2e60049b8bd876db4bad5f"
+                        Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                        GitLab-LB: fe-23-lb-gprd
+                        GitLab-SV: localhost
+                        RateLimit-Limit: '600'
+                        RateLimit-Observed: '10'
+                        RateLimit-Remaining: '590'
+                        RateLimit-Reset: '1588101966'
+                        RateLimit-ResetTime: Tue, 28 Apr 2020 19:26:06 GMT
+                        Referrer-Policy: strict-origin-when-cross-origin
+                        Server: cloudflare
+                        Strict-Transport-Security: max-age=31536000
+                        Transfer-Encoding: chunked
+                        Vary: Origin
+                        X-Content-Type-Options: nosniff
+                        X-Frame-Options: SAMEORIGIN
+                        X-Request-Id: gG71yWYWg36
+                        X-Runtime: '0.071968'
+                        cf-request-id: 0263d9197a0000596ac18d5200000001
+                      raw: !!binary ""
+                      reason: OK
+                      status_code: 200
+        ogr.services.gitlab.project:
+          gitlab.exceptions:
+            gitlab.mixins:
+              gitlab:
+                requre.objects:
+                  requests.sessions:
+                    send:
+                    - metadata:
+                        latency: 0.2990865707397461
+                        module_call_list:
+                        - unittest.case
+                        - tests.integration.test_gitlab
+                        - ogr.services.gitlab.project
+                        - ogr.services.gitlab.pull_request
+                        - ogr.services.gitlab.project
+                        - gitlab.exceptions
+                        - gitlab.mixins
+                        - gitlab
+                        - requre.objects
+                        - requests.sessions
+                        - send
+                      output:
+                        __store_indicator: 2
+                        _content:
+                          _links:
+                            events: https://gitlab.com/api/v4/projects/14233409/events
+                            issues: https://gitlab.com/api/v4/projects/14233409/issues
+                            labels: https://gitlab.com/api/v4/projects/14233409/labels
+                            members: https://gitlab.com/api/v4/projects/14233409/members
+                            merge_requests: https://gitlab.com/api/v4/projects/14233409/merge_requests
+                            repo_branches: https://gitlab.com/api/v4/projects/14233409/repository/branches
+                            self: https://gitlab.com/api/v4/projects/14233409
+                          approvals_before_merge: 0
+                          archived: false
+                          auto_cancel_pending_pipelines: enabled
+                          auto_devops_deploy_strategy: continuous
+                          auto_devops_enabled: false
+                          autoclose_referenced_issues: true
+                          avatar_url: null
+                          build_coverage_regex: null
+                          build_git_strategy: fetch
+                          build_timeout: 3600
+                          builds_access_level: enabled
+                          can_create_merge_request_in: true
+                          ci_config_path: null
+                          ci_default_git_depth: 50
+                          container_registry_enabled: true
+                          created_at: '2019-09-10T10:28:09.946Z'
+                          creator_id: 433670
+                          default_branch: master
+                          description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+                          emails_disabled: null
+                          empty_repo: false
+                          external_authorization_classification_label: ''
+                          forking_access_level: enabled
+                          forks_count: 4
+                          http_url_to_repo: https://gitlab.com/packit-service/ogr-tests.git
+                          id: 14233409
+                          import_error: null
+                          import_status: none
+                          issues_access_level: enabled
+                          issues_enabled: true
+                          jobs_enabled: true
+                          last_activity_at: '2020-04-28T19:17:22.800Z'
+                          lfs_enabled: true
+                          marked_for_deletion_at: null
+                          marked_for_deletion_on: null
+                          merge_method: merge
+                          merge_requests_access_level: enabled
+                          merge_requests_enabled: true
+                          mirror: false
+                          name: ogr-tests
+                          name_with_namespace: packit-service / ogr-tests
+                          namespace:
+                            avatar_url: /uploads/-/system/group/avatar/6032704/packit-logo.png
+                            full_path: packit-service
+                            id: 6032704
+                            kind: group
+                            name: packit-service
+                            parent_id: null
+                            path: packit-service
+                            web_url: https://gitlab.com/groups/packit-service
+                          only_allow_merge_if_all_discussions_are_resolved: false
+                          only_allow_merge_if_pipeline_succeeds: false
+                          open_issues_count: 42
+                          packages_enabled: true
+                          pages_access_level: enabled
+                          path: ogr-tests
+                          path_with_namespace: packit-service/ogr-tests
+                          permissions:
+                            group_access:
+                              access_level: 40
+                              notification_level: 3
+                            project_access: null
+                          printing_merge_request_link_enabled: true
+                          public_jobs: true
+                          readme_url: https://gitlab.com/packit-service/ogr-tests/-/blob/master/README.md
+                          remove_source_branch_after_merge: null
+                          repository_access_level: enabled
+                          request_access_enabled: false
+                          resolve_outdated_diff_discussions: false
+                          runners_token: VjGdzzwZbsTY37sxUeWL
+                          service_desk_address: incoming+packit-service-ogr-tests-14233409-issue-@incoming.gitlab.com
+                          service_desk_enabled: true
+                          shared_runners_enabled: true
+                          shared_with_groups: []
+                          snippets_access_level: enabled
+                          snippets_enabled: true
+                          ssh_url_to_repo: git@gitlab.com:packit-service/ogr-tests.git
+                          star_count: 0
+                          suggestion_commit_message: null
+                          tag_list: []
+                          visibility: public
+                          web_url: https://gitlab.com/packit-service/ogr-tests
+                          wiki_access_level: enabled
+                          wiki_enabled: true
+                        _next: null
+                        elapsed: 0.2
+                        encoding: null
+                        headers:
+                          CF-Cache-Status: DYNAMIC
+                          CF-RAY: 58b32ad38e7a596a-VIE
+                          Cache-Control: max-age=0, private, must-revalidate
+                          Connection: keep-alive
+                          Content-Encoding: gzip
+                          Content-Type: application/json
+                          Date: Fri, 01 Nov 2019 13-36-03 GMT
+                          Etag: W/"96fed4967a78dc12084759cad53b6235"
+                          Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                          GitLab-LB: fe-01-lb-gprd
+                          GitLab-SV: localhost
+                          RateLimit-Limit: '600'
+                          RateLimit-Observed: '9'
+                          RateLimit-Remaining: '591'
+                          RateLimit-Reset: '1588101966'
+                          RateLimit-ResetTime: Tue, 28 Apr 2020 19:26:06 GMT
+                          Referrer-Policy: strict-origin-when-cross-origin
+                          Server: cloudflare
+                          Strict-Transport-Security: max-age=31536000
+                          Transfer-Encoding: chunked
+                          Vary: Origin
+                          X-Content-Type-Options: nosniff
+                          X-Frame-Options: SAMEORIGIN
+                          X-Request-Id: hisvgYQD7k3
+                          X-Runtime: '0.079846'
+                          cf-request-id: 0263d918340000596ac18c3200000001
+                        raw: !!binary ""
+                        reason: OK
+                        status_code: 200
+          ogr.services.gitlab.service:
+            gitlab:
+              gitlab.exceptions:
+                gitlab.mixins:
+                  gitlab:
+                    requre.objects:
+                      requests.sessions:
+                        send:
+                        - metadata:
+                            latency: 0.33534717559814453
+                            module_call_list:
+                            - unittest.case
+                            - tests.integration.test_gitlab
+                            - ogr.services.gitlab.project
+                            - ogr.services.gitlab.pull_request
+                            - ogr.services.gitlab.project
+                            - ogr.services.gitlab.service
+                            - gitlab
+                            - gitlab.exceptions
+                            - gitlab.mixins
+                            - gitlab
+                            - requre.objects
+                            - requests.sessions
+                            - send
+                          output:
+                            __store_indicator: 2
+                            _content:
+                              avatar_url: https://assets.gitlab-static.net/uploads/-/system/user/avatar/375555/avatar.png
+                              bio: ''
+                              can_create_group: true
+                              can_create_project: true
+                              color_scheme_id: 4
+                              confirmed_at: '2018-06-07T08:34:01.593Z'
+                              created_at: '2016-01-15T21:12:31.705Z'
+                              current_sign_in_at: '2020-04-22T11:44:25.029Z'
+                              email: matej.focko@outlook.com
+                              external: false
+                              extra_shared_runners_minutes_limit: null
+                              id: 375555
+                              identities: []
+                              job_title: ''
+                              last_activity_on: '2020-04-28'
+                              last_sign_in_at: '2020-04-19T14:53:06.287Z'
+                              linkedin: ''
+                              location: "Ko\u0161ice, Slovakia"
+                              name: Matej Focko
+                              organization: ''
+                              private_profile: false
+                              projects_limit: 100000
+                              public_email: ''
+                              shared_runners_minutes_limit: 2000
+                              skype: ''
+                              state: active
+                              theme_id: 7
+                              twitter: MatejFocko
+                              two_factor_enabled: true
+                              username: mfocko
+                              web_url: https://gitlab.com/mfocko
+                              website_url: ''
+                              work_information: null
+                            _next: null
+                            elapsed: 0.2
+                            encoding: null
+                            headers:
+                              CF-Cache-Status: DYNAMIC
+                              CF-RAY: 58b32ad1dd8d596a-VIE
+                              Cache-Control: max-age=0, private, must-revalidate
+                              Connection: keep-alive
+                              Content-Encoding: gzip
+                              Content-Type: application/json
+                              Date: Fri, 01 Nov 2019 13-36-03 GMT
+                              Etag: W/"e6d354bf72a9220d014f2ce53e1c4be3"
+                              Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                              GitLab-LB: fe-16-lb-gprd
+                              GitLab-SV: localhost
+                              RateLimit-Limit: '600'
+                              RateLimit-Observed: '8'
+                              RateLimit-Remaining: '592'
+                              RateLimit-Reset: '1588101966'
+                              RateLimit-ResetTime: Tue, 28 Apr 2020 19:26:06 GMT
+                              Referrer-Policy: strict-origin-when-cross-origin
+                              Server: cloudflare
+                              Set-Cookie: __cfduid=dae807c19491e68a87fd0b792d9d1620d1588101906;
+                                expires=Thu, 28-May-20 19:25:06 GMT; path=/; domain=.gitlab.com;
+                                HttpOnly; SameSite=Lax; Secure
+                              Strict-Transport-Security: max-age=31536000
+                              Transfer-Encoding: chunked
+                              Vary: Origin
+                              X-Content-Type-Options: nosniff
+                              X-Frame-Options: SAMEORIGIN
+                              X-Request-Id: KumS1XzQ2E8
+                              X-Runtime: '0.022923'
+                              cf-request-id: 0263d917280000596ac18b0200000001
+                            raw: !!binary ""
+                            reason: OK
+                            status_code: 200
+    ogr.services.gitlab.pull_request:
+      ogr.services.gitlab.service:
+        gitlab.exceptions:
+          gitlab.mixins:
+            gitlab:
+              requre.objects:
+                requests.sessions:
+                  send:
+                  - metadata:
+                      latency: 0.39148640632629395
+                      module_call_list:
+                      - unittest.case
+                      - tests.integration.test_gitlab
+                      - ogr.services.gitlab.pull_request
+                      - ogr.services.gitlab.service
+                      - gitlab.exceptions
+                      - gitlab.mixins
+                      - gitlab
+                      - requre.objects
+                      - requests.sessions
+                      - send
+                    output:
+                      __store_indicator: 2
+                      _content:
+                        _links:
+                          events: https://gitlab.com/api/v4/projects/14233409/events
+                          issues: https://gitlab.com/api/v4/projects/14233409/issues
+                          labels: https://gitlab.com/api/v4/projects/14233409/labels
+                          members: https://gitlab.com/api/v4/projects/14233409/members
+                          merge_requests: https://gitlab.com/api/v4/projects/14233409/merge_requests
+                          repo_branches: https://gitlab.com/api/v4/projects/14233409/repository/branches
+                          self: https://gitlab.com/api/v4/projects/14233409
+                        approvals_before_merge: 0
+                        archived: false
+                        auto_cancel_pending_pipelines: enabled
+                        auto_devops_deploy_strategy: continuous
+                        auto_devops_enabled: false
+                        autoclose_referenced_issues: true
+                        avatar_url: null
+                        build_coverage_regex: null
+                        build_git_strategy: fetch
+                        build_timeout: 3600
+                        builds_access_level: enabled
+                        can_create_merge_request_in: true
+                        ci_config_path: null
+                        ci_default_git_depth: 50
+                        container_registry_enabled: true
+                        created_at: '2019-09-10T10:28:09.946Z'
+                        creator_id: 433670
+                        default_branch: master
+                        description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+                        emails_disabled: null
+                        empty_repo: false
+                        external_authorization_classification_label: ''
+                        forking_access_level: enabled
+                        forks_count: 4
+                        http_url_to_repo: https://gitlab.com/packit-service/ogr-tests.git
+                        id: 14233409
+                        import_error: null
+                        import_status: none
+                        issues_access_level: enabled
+                        issues_enabled: true
+                        jobs_enabled: true
+                        last_activity_at: '2020-04-28T19:17:22.800Z'
+                        lfs_enabled: true
+                        marked_for_deletion_at: null
+                        marked_for_deletion_on: null
+                        merge_method: merge
+                        merge_requests_access_level: enabled
+                        merge_requests_enabled: true
+                        mirror: false
+                        name: ogr-tests
+                        name_with_namespace: packit-service / ogr-tests
+                        namespace:
+                          avatar_url: /uploads/-/system/group/avatar/6032704/packit-logo.png
+                          full_path: packit-service
+                          id: 6032704
+                          kind: group
+                          name: packit-service
+                          parent_id: null
+                          path: packit-service
+                          web_url: https://gitlab.com/groups/packit-service
+                        only_allow_merge_if_all_discussions_are_resolved: false
+                        only_allow_merge_if_pipeline_succeeds: false
+                        open_issues_count: 42
+                        packages_enabled: true
+                        pages_access_level: enabled
+                        path: ogr-tests
+                        path_with_namespace: packit-service/ogr-tests
+                        permissions:
+                          group_access:
+                            access_level: 40
+                            notification_level: 3
+                          project_access: null
+                        printing_merge_request_link_enabled: true
+                        public_jobs: true
+                        readme_url: https://gitlab.com/packit-service/ogr-tests/-/blob/master/README.md
+                        remove_source_branch_after_merge: null
+                        repository_access_level: enabled
+                        request_access_enabled: false
+                        resolve_outdated_diff_discussions: false
+                        runners_token: VjGdzzwZbsTY37sxUeWL
+                        service_desk_address: incoming+packit-service-ogr-tests-14233409-issue-@incoming.gitlab.com
+                        service_desk_enabled: true
+                        shared_runners_enabled: true
+                        shared_with_groups: []
+                        snippets_access_level: enabled
+                        snippets_enabled: true
+                        ssh_url_to_repo: git@gitlab.com:packit-service/ogr-tests.git
+                        star_count: 0
+                        suggestion_commit_message: null
+                        tag_list: []
+                        visibility: public
+                        web_url: https://gitlab.com/packit-service/ogr-tests
+                        wiki_access_level: enabled
+                        wiki_enabled: true
+                      _next: null
+                      elapsed: 0.2
+                      encoding: null
+                      headers:
+                        CF-Cache-Status: DYNAMIC
+                        CF-RAY: 58b32ad77929596a-VIE
+                        Cache-Control: max-age=0, private, must-revalidate
+                        Connection: keep-alive
+                        Content-Encoding: gzip
+                        Content-Type: application/json
+                        Date: Fri, 01 Nov 2019 13-36-03 GMT
+                        Etag: W/"96fed4967a78dc12084759cad53b6235"
+                        Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                        GitLab-LB: fe-19-lb-gprd
+                        GitLab-SV: localhost
+                        RateLimit-Limit: '600'
+                        RateLimit-Observed: '11'
+                        RateLimit-Remaining: '589'
+                        RateLimit-Reset: '1588101967'
+                        RateLimit-ResetTime: Tue, 28 Apr 2020 19:26:07 GMT
+                        Referrer-Policy: strict-origin-when-cross-origin
+                        Server: cloudflare
+                        Strict-Transport-Security: max-age=31536000
+                        Transfer-Encoding: chunked
+                        Vary: Origin
+                        X-Content-Type-Options: nosniff
+                        X-Frame-Options: SAMEORIGIN
+                        X-Request-Id: r9DKr4jfJna
+                        X-Runtime: '0.074152'
+                        cf-request-id: 0263d91aa90000596ac18e5200000001
+                      raw: !!binary ""
+                      reason: OK
+                      status_code: 200

--- a/tests/integration/test_data/test_gitlab/tests.integration.test_gitlab.PullRequests.test_source_project_upstream_fork.yaml
+++ b/tests/integration/test_data/test_gitlab/tests.integration.test_gitlab.PullRequests.test_source_project_upstream_fork.yaml
@@ -1,0 +1,565 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectFull
+  version_storage_file: 2
+unittest.case:
+  tests.integration.test_gitlab:
+    ogr.services.gitlab.project:
+      ogr.services.gitlab.pull_request:
+        gitlab.exceptions:
+          gitlab.mixins:
+            gitlab:
+              requre.objects:
+                requests.sessions:
+                  send:
+                  - metadata:
+                      latency: 0.35188961029052734
+                      module_call_list:
+                      - unittest.case
+                      - tests.integration.test_gitlab
+                      - ogr.services.gitlab.project
+                      - ogr.services.gitlab.pull_request
+                      - gitlab.exceptions
+                      - gitlab.mixins
+                      - gitlab
+                      - requre.objects
+                      - requests.sessions
+                      - send
+                    output:
+                      __store_indicator: 2
+                      _content:
+                        allow_collaboration: false
+                        allow_maintainer_to_push: false
+                        approvals_before_merge: null
+                        assignee: null
+                        assignees: []
+                        author:
+                          avatar_url: https://assets.gitlab-static.net/uploads/-/system/user/avatar/375555/avatar.png
+                          id: 375555
+                          name: Matej Focko
+                          state: active
+                          username: mfocko
+                          web_url: https://gitlab.com/mfocko
+                        blocking_discussions_resolved: true
+                        changes_count: null
+                        closed_at: null
+                        closed_by: null
+                        created_at: '2020-04-27T21:39:58.418Z'
+                        description: ''
+                        diff_refs:
+                          base_sha: 257ce9fd8c5421d2e116337847710ba70d215aa6
+                          head_sha: 257ce9fd8c5421d2e116337847710ba70d215aa6
+                          start_sha: b8e18207cfdad954f1b3a96db34d0706b272e6cf
+                        discussion_locked: null
+                        downvotes: 0
+                        first_contribution: false
+                        first_deployed_to_production_at: null
+                        force_remove_source_branch: true
+                        has_conflicts: true
+                        head_pipeline: null
+                        id: 57082404
+                        iid: 22
+                        labels: []
+                        latest_build_finished_at: null
+                        latest_build_started_at: null
+                        merge_commit_sha: null
+                        merge_error: null
+                        merge_status: cannot_be_merged
+                        merge_when_pipeline_succeeds: false
+                        merged_at: null
+                        merged_by: null
+                        milestone: null
+                        pipeline: null
+                        project_id: 14233409
+                        reference: '!22'
+                        references:
+                          full: packit-service/ogr-tests!22
+                          relative: '!22'
+                          short: '!22'
+                        sha: 257ce9fd8c5421d2e116337847710ba70d215aa6
+                        should_remove_source_branch: null
+                        source_branch: pr-test1
+                        source_project_id: 15896155
+                        squash: false
+                        squash_commit_sha: null
+                        state: opened
+                        subscribed: true
+                        target_branch: master
+                        target_project_id: 14233409
+                        task_completion_status:
+                          completed_count: 0
+                          count: 0
+                        time_stats:
+                          human_time_estimate: null
+                          human_total_time_spent: null
+                          time_estimate: 0
+                          total_time_spent: 0
+                        title: gotta try with fork
+                        updated_at: '2020-04-27T21:39:58.418Z'
+                        upvotes: 0
+                        user:
+                          can_merge: true
+                        user_notes_count: 0
+                        web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/22
+                        work_in_progress: false
+                      _next: null
+                      elapsed: 0.2
+                      encoding: null
+                      headers:
+                        CF-Cache-Status: DYNAMIC
+                        CF-RAY: 58b32ba668345982-VIE
+                        Cache-Control: max-age=0, private, must-revalidate
+                        Connection: keep-alive
+                        Content-Encoding: gzip
+                        Content-Type: application/json
+                        Date: Fri, 01 Nov 2019 13-36-03 GMT
+                        Etag: W/"1501f5d8ac6d93dc7ff33c5e92c2f5c7"
+                        Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                        GitLab-LB: fe-16-lb-gprd
+                        GitLab-SV: localhost
+                        RateLimit-Limit: '600'
+                        RateLimit-Observed: '11'
+                        RateLimit-Remaining: '589'
+                        RateLimit-Reset: '1588102000'
+                        RateLimit-ResetTime: Tue, 28 Apr 2020 19:26:40 GMT
+                        Referrer-Policy: strict-origin-when-cross-origin
+                        Server: cloudflare
+                        Strict-Transport-Security: max-age=31536000
+                        Transfer-Encoding: chunked
+                        Vary: Origin
+                        X-Content-Type-Options: nosniff
+                        X-Frame-Options: SAMEORIGIN
+                        X-Request-Id: saFTcNc6dc5
+                        X-Runtime: '0.074694'
+                        cf-request-id: 0263d99bfe00005982953a0200000001
+                      raw: !!binary ""
+                      reason: OK
+                      status_code: 200
+        ogr.services.gitlab.project:
+          gitlab.exceptions:
+            gitlab.mixins:
+              gitlab:
+                requre.objects:
+                  requests.sessions:
+                    send:
+                    - metadata:
+                        latency: 0.3366391658782959
+                        module_call_list:
+                        - unittest.case
+                        - tests.integration.test_gitlab
+                        - ogr.services.gitlab.project
+                        - ogr.services.gitlab.pull_request
+                        - ogr.services.gitlab.project
+                        - gitlab.exceptions
+                        - gitlab.mixins
+                        - gitlab
+                        - requre.objects
+                        - requests.sessions
+                        - send
+                      output:
+                        __store_indicator: 2
+                        _content:
+                          _links:
+                            events: https://gitlab.com/api/v4/projects/14233409/events
+                            issues: https://gitlab.com/api/v4/projects/14233409/issues
+                            labels: https://gitlab.com/api/v4/projects/14233409/labels
+                            members: https://gitlab.com/api/v4/projects/14233409/members
+                            merge_requests: https://gitlab.com/api/v4/projects/14233409/merge_requests
+                            repo_branches: https://gitlab.com/api/v4/projects/14233409/repository/branches
+                            self: https://gitlab.com/api/v4/projects/14233409
+                          approvals_before_merge: 0
+                          archived: false
+                          auto_cancel_pending_pipelines: enabled
+                          auto_devops_deploy_strategy: continuous
+                          auto_devops_enabled: false
+                          autoclose_referenced_issues: true
+                          avatar_url: null
+                          build_coverage_regex: null
+                          build_git_strategy: fetch
+                          build_timeout: 3600
+                          builds_access_level: enabled
+                          can_create_merge_request_in: true
+                          ci_config_path: null
+                          ci_default_git_depth: 50
+                          container_registry_enabled: true
+                          created_at: '2019-09-10T10:28:09.946Z'
+                          creator_id: 433670
+                          default_branch: master
+                          description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+                          emails_disabled: null
+                          empty_repo: false
+                          external_authorization_classification_label: ''
+                          forking_access_level: enabled
+                          forks_count: 4
+                          http_url_to_repo: https://gitlab.com/packit-service/ogr-tests.git
+                          id: 14233409
+                          import_error: null
+                          import_status: none
+                          issues_access_level: enabled
+                          issues_enabled: true
+                          jobs_enabled: true
+                          last_activity_at: '2020-04-28T19:17:22.800Z'
+                          lfs_enabled: true
+                          marked_for_deletion_at: null
+                          marked_for_deletion_on: null
+                          merge_method: merge
+                          merge_requests_access_level: enabled
+                          merge_requests_enabled: true
+                          mirror: false
+                          name: ogr-tests
+                          name_with_namespace: packit-service / ogr-tests
+                          namespace:
+                            avatar_url: /uploads/-/system/group/avatar/6032704/packit-logo.png
+                            full_path: packit-service
+                            id: 6032704
+                            kind: group
+                            name: packit-service
+                            parent_id: null
+                            path: packit-service
+                            web_url: https://gitlab.com/groups/packit-service
+                          only_allow_merge_if_all_discussions_are_resolved: false
+                          only_allow_merge_if_pipeline_succeeds: false
+                          open_issues_count: 42
+                          packages_enabled: true
+                          pages_access_level: enabled
+                          path: ogr-tests
+                          path_with_namespace: packit-service/ogr-tests
+                          permissions:
+                            group_access:
+                              access_level: 40
+                              notification_level: 3
+                            project_access: null
+                          printing_merge_request_link_enabled: true
+                          public_jobs: true
+                          readme_url: https://gitlab.com/packit-service/ogr-tests/-/blob/master/README.md
+                          remove_source_branch_after_merge: null
+                          repository_access_level: enabled
+                          request_access_enabled: false
+                          resolve_outdated_diff_discussions: false
+                          runners_token: VjGdzzwZbsTY37sxUeWL
+                          service_desk_address: incoming+packit-service-ogr-tests-14233409-issue-@incoming.gitlab.com
+                          service_desk_enabled: true
+                          shared_runners_enabled: true
+                          shared_with_groups: []
+                          snippets_access_level: enabled
+                          snippets_enabled: true
+                          ssh_url_to_repo: git@gitlab.com:packit-service/ogr-tests.git
+                          star_count: 0
+                          suggestion_commit_message: null
+                          tag_list: []
+                          visibility: public
+                          web_url: https://gitlab.com/packit-service/ogr-tests
+                          wiki_access_level: enabled
+                          wiki_enabled: true
+                        _next: null
+                        elapsed: 0.2
+                        encoding: null
+                        headers:
+                          CF-Cache-Status: DYNAMIC
+                          CF-RAY: 58b32ba44f045982-VIE
+                          Cache-Control: max-age=0, private, must-revalidate
+                          Connection: keep-alive
+                          Content-Encoding: gzip
+                          Content-Type: application/json
+                          Date: Fri, 01 Nov 2019 13-36-03 GMT
+                          Etag: W/"96fed4967a78dc12084759cad53b6235"
+                          Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                          GitLab-LB: fe-23-lb-gprd
+                          GitLab-SV: localhost
+                          RateLimit-Limit: '600'
+                          RateLimit-Observed: '11'
+                          RateLimit-Remaining: '589'
+                          RateLimit-Reset: '1588102000'
+                          RateLimit-ResetTime: Tue, 28 Apr 2020 19:26:40 GMT
+                          Referrer-Policy: strict-origin-when-cross-origin
+                          Server: cloudflare
+                          Strict-Transport-Security: max-age=31536000
+                          Transfer-Encoding: chunked
+                          Vary: Origin
+                          X-Content-Type-Options: nosniff
+                          X-Frame-Options: SAMEORIGIN
+                          X-Request-Id: zxJcszk6qQ4
+                          X-Runtime: '0.071788'
+                          cf-request-id: 0263d99aaf0000598295387200000001
+                        raw: !!binary ""
+                        reason: OK
+                        status_code: 200
+          ogr.services.gitlab.service:
+            gitlab:
+              gitlab.exceptions:
+                gitlab.mixins:
+                  gitlab:
+                    requre.objects:
+                      requests.sessions:
+                        send:
+                        - metadata:
+                            latency: 0.37381577491760254
+                            module_call_list:
+                            - unittest.case
+                            - tests.integration.test_gitlab
+                            - ogr.services.gitlab.project
+                            - ogr.services.gitlab.pull_request
+                            - ogr.services.gitlab.project
+                            - ogr.services.gitlab.service
+                            - gitlab
+                            - gitlab.exceptions
+                            - gitlab.mixins
+                            - gitlab
+                            - requre.objects
+                            - requests.sessions
+                            - send
+                          output:
+                            __store_indicator: 2
+                            _content:
+                              avatar_url: https://assets.gitlab-static.net/uploads/-/system/user/avatar/375555/avatar.png
+                              bio: ''
+                              can_create_group: true
+                              can_create_project: true
+                              color_scheme_id: 4
+                              confirmed_at: '2018-06-07T08:34:01.593Z'
+                              created_at: '2016-01-15T21:12:31.705Z'
+                              current_sign_in_at: '2020-04-22T11:44:25.029Z'
+                              email: matej.focko@outlook.com
+                              external: false
+                              extra_shared_runners_minutes_limit: null
+                              id: 375555
+                              identities: []
+                              job_title: ''
+                              last_activity_on: '2020-04-28'
+                              last_sign_in_at: '2020-04-19T14:53:06.287Z'
+                              linkedin: ''
+                              location: "Ko\u0161ice, Slovakia"
+                              name: Matej Focko
+                              organization: ''
+                              private_profile: false
+                              projects_limit: 100000
+                              public_email: ''
+                              shared_runners_minutes_limit: 2000
+                              skype: ''
+                              state: active
+                              theme_id: 7
+                              twitter: MatejFocko
+                              two_factor_enabled: true
+                              username: mfocko
+                              web_url: https://gitlab.com/mfocko
+                              website_url: ''
+                              work_information: null
+                            _next: null
+                            elapsed: 0.2
+                            encoding: null
+                            headers:
+                              CF-Cache-Status: DYNAMIC
+                              CF-RAY: 58b32ba24d695982-VIE
+                              Cache-Control: max-age=0, private, must-revalidate
+                              Connection: keep-alive
+                              Content-Encoding: gzip
+                              Content-Type: application/json
+                              Date: Fri, 01 Nov 2019 13-36-03 GMT
+                              Etag: W/"e6d354bf72a9220d014f2ce53e1c4be3"
+                              Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                              GitLab-LB: fe-02-lb-gprd
+                              GitLab-SV: localhost
+                              RateLimit-Limit: '600'
+                              RateLimit-Observed: '10'
+                              RateLimit-Remaining: '590'
+                              RateLimit-Reset: '1588101999'
+                              RateLimit-ResetTime: Tue, 28 Apr 2020 19:26:39 GMT
+                              Referrer-Policy: strict-origin-when-cross-origin
+                              Server: cloudflare
+                              Set-Cookie: __cfduid=df1a04bd8bed4f277401781a632c79fe41588101939;
+                                expires=Thu, 28-May-20 19:25:39 GMT; path=/; domain=.gitlab.com;
+                                HttpOnly; SameSite=Lax; Secure
+                              Strict-Transport-Security: max-age=31536000
+                              Transfer-Encoding: chunked
+                              Vary: Origin
+                              X-Content-Type-Options: nosniff
+                              X-Frame-Options: SAMEORIGIN
+                              X-Request-Id: q7dmyiO7og1
+                              X-Runtime: '0.020446'
+                              cf-request-id: 0263d999700000598295375200000001
+                            raw: !!binary ""
+                            reason: OK
+                            status_code: 200
+    ogr.services.gitlab.pull_request:
+      ogr.services.gitlab.service:
+        gitlab.exceptions:
+          gitlab.mixins:
+            gitlab:
+              requre.objects:
+                requests.sessions:
+                  send:
+                  - metadata:
+                      latency: 0.3913295269012451
+                      module_call_list:
+                      - unittest.case
+                      - tests.integration.test_gitlab
+                      - ogr.services.gitlab.pull_request
+                      - ogr.services.gitlab.service
+                      - gitlab.exceptions
+                      - gitlab.mixins
+                      - gitlab
+                      - requre.objects
+                      - requests.sessions
+                      - send
+                    output:
+                      __store_indicator: 2
+                      _content:
+                        _links:
+                          events: https://gitlab.com/api/v4/projects/15896155/events
+                          issues: https://gitlab.com/api/v4/projects/15896155/issues
+                          labels: https://gitlab.com/api/v4/projects/15896155/labels
+                          members: https://gitlab.com/api/v4/projects/15896155/members
+                          merge_requests: https://gitlab.com/api/v4/projects/15896155/merge_requests
+                          repo_branches: https://gitlab.com/api/v4/projects/15896155/repository/branches
+                          self: https://gitlab.com/api/v4/projects/15896155
+                        approvals_before_merge: 0
+                        archived: false
+                        auto_cancel_pending_pipelines: enabled
+                        auto_devops_deploy_strategy: continuous
+                        auto_devops_enabled: false
+                        autoclose_referenced_issues: true
+                        avatar_url: null
+                        build_coverage_regex: null
+                        build_git_strategy: fetch
+                        build_timeout: 3600
+                        builds_access_level: enabled
+                        can_create_merge_request_in: true
+                        ci_config_path: null
+                        ci_default_git_depth: 50
+                        container_registry_enabled: true
+                        created_at: '2019-12-16T11:13:20.567Z'
+                        creator_id: 375555
+                        default_branch: master
+                        description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+                        emails_disabled: null
+                        empty_repo: false
+                        external_authorization_classification_label: ''
+                        forked_from_project:
+                          avatar_url: null
+                          created_at: '2019-09-10T10:28:09.946Z'
+                          default_branch: master
+                          description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+                          forks_count: 4
+                          http_url_to_repo: https://gitlab.com/packit-service/ogr-tests.git
+                          id: 14233409
+                          last_activity_at: '2020-04-28T19:17:22.800Z'
+                          name: ogr-tests
+                          name_with_namespace: packit-service / ogr-tests
+                          namespace:
+                            avatar_url: /uploads/-/system/group/avatar/6032704/packit-logo.png
+                            full_path: packit-service
+                            id: 6032704
+                            kind: group
+                            name: packit-service
+                            parent_id: null
+                            path: packit-service
+                            web_url: https://gitlab.com/groups/packit-service
+                          path: ogr-tests
+                          path_with_namespace: packit-service/ogr-tests
+                          readme_url: https://gitlab.com/packit-service/ogr-tests/-/blob/master/README.md
+                          ssh_url_to_repo: git@gitlab.com:packit-service/ogr-tests.git
+                          star_count: 0
+                          tag_list: []
+                          web_url: https://gitlab.com/packit-service/ogr-tests
+                        forking_access_level: enabled
+                        forks_count: 0
+                        http_url_to_repo: https://gitlab.com/mfocko/ogr-tests.git
+                        id: 15896155
+                        import_error: null
+                        import_status: finished
+                        issues_access_level: enabled
+                        issues_enabled: true
+                        jobs_enabled: true
+                        last_activity_at: '2020-04-28T19:16:39.081Z'
+                        lfs_enabled: true
+                        marked_for_deletion_at: null
+                        marked_for_deletion_on: null
+                        merge_method: merge
+                        merge_requests_access_level: enabled
+                        merge_requests_enabled: true
+                        mirror: false
+                        name: ogr-tests
+                        name_with_namespace: Matej Focko / ogr-tests
+                        namespace:
+                          avatar_url: /uploads/-/system/user/avatar/375555/avatar.png
+                          full_path: mfocko
+                          id: 439774
+                          kind: user
+                          name: Matej Focko
+                          parent_id: null
+                          path: mfocko
+                          web_url: https://gitlab.com/mfocko
+                        only_allow_merge_if_all_discussions_are_resolved: false
+                        only_allow_merge_if_pipeline_succeeds: false
+                        open_issues_count: 0
+                        owner:
+                          avatar_url: https://assets.gitlab-static.net/uploads/-/system/user/avatar/375555/avatar.png
+                          id: 375555
+                          name: Matej Focko
+                          state: active
+                          username: mfocko
+                          web_url: https://gitlab.com/mfocko
+                        packages_enabled: true
+                        pages_access_level: enabled
+                        path: ogr-tests
+                        path_with_namespace: mfocko/ogr-tests
+                        permissions:
+                          group_access: null
+                          project_access:
+                            access_level: 40
+                            notification_level: 3
+                        printing_merge_request_link_enabled: true
+                        public_jobs: true
+                        readme_url: https://gitlab.com/mfocko/ogr-tests/-/blob/master/README.md
+                        remove_source_branch_after_merge: true
+                        repository_access_level: enabled
+                        request_access_enabled: true
+                        resolve_outdated_diff_discussions: false
+                        runners_token: WKy7SCDsumYRV5keeT8c
+                        service_desk_address: incoming+mfocko-ogr-tests-15896155-issue-@incoming.gitlab.com
+                        service_desk_enabled: true
+                        shared_runners_enabled: true
+                        shared_with_groups: []
+                        snippets_access_level: enabled
+                        snippets_enabled: true
+                        ssh_url_to_repo: git@gitlab.com:mfocko/ogr-tests.git
+                        star_count: 0
+                        suggestion_commit_message: null
+                        tag_list: []
+                        visibility: public
+                        web_url: https://gitlab.com/mfocko/ogr-tests
+                        wiki_access_level: enabled
+                        wiki_enabled: true
+                      _next: null
+                      elapsed: 0.2
+                      encoding: null
+                      headers:
+                        CF-Cache-Status: DYNAMIC
+                        CF-RAY: 58b32ba8b9d35982-VIE
+                        Cache-Control: max-age=0, private, must-revalidate
+                        Connection: keep-alive
+                        Content-Encoding: gzip
+                        Content-Type: application/json
+                        Date: Fri, 01 Nov 2019 13-36-03 GMT
+                        Etag: W/"42f032d7c6839d85c235c52541b861bb"
+                        Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                        GitLab-LB: fe-19-lb-gprd
+                        GitLab-SV: localhost
+                        RateLimit-Limit: '600'
+                        RateLimit-Observed: '11'
+                        RateLimit-Remaining: '589'
+                        RateLimit-Reset: '1588102000'
+                        RateLimit-ResetTime: Tue, 28 Apr 2020 19:26:40 GMT
+                        Referrer-Policy: strict-origin-when-cross-origin
+                        Server: cloudflare
+                        Strict-Transport-Security: max-age=31536000
+                        Transfer-Encoding: chunked
+                        Vary: Origin
+                        X-Content-Type-Options: nosniff
+                        X-Frame-Options: SAMEORIGIN
+                        X-Request-Id: xy2WQ4K7B9
+                        X-Runtime: '0.095682'
+                        cf-request-id: 0263d99d7600005982953b5200000001
+                      raw: !!binary ""
+                      reason: OK
+                      status_code: 200

--- a/tests/integration/test_data/test_pagure/tests.integration.test_pagure.PullRequests.test_source_project_upstream_branch.yaml
+++ b/tests/integration/test_data/test_pagure/tests.integration.test_pagure.PullRequests.test_source_project_upstream_branch.yaml
@@ -1,0 +1,333 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectFull
+  version_storage_file: 2
+unittest.case:
+  tests.integration.test_pagure:
+    ogr.services.pagure.project:
+      ogr.services.pagure.pull_request:
+        ogr.services.pagure.project:
+          ogr.services.pagure.service:
+            requests.sessions:
+              requre.objects:
+                requests.sessions:
+                  send:
+                  - metadata:
+                      latency: 0.41466450691223145
+                      module_call_list:
+                      - unittest.case
+                      - tests.integration.test_pagure
+                      - ogr.services.pagure.project
+                      - ogr.services.pagure.pull_request
+                      - ogr.services.pagure.project
+                      - ogr.services.pagure.service
+                      - requests.sessions
+                      - requre.objects
+                      - requests.sessions
+                      - send
+                    output:
+                      __store_indicator: 2
+                      _content:
+                        assignee: null
+                        branch: master
+                        branch_from: testPR
+                        cached_merge_status: CONFLICTS
+                        closed_at: null
+                        closed_by: null
+                        comments:
+                        - comment: regex test
+                          commit: null
+                          date_created: '1570882883'
+                          edited_on: null
+                          editor: null
+                          filename: null
+                          id: 99124
+                          line: null
+                          notification: false
+                          parent: null
+                          reactions: {}
+                          tree: null
+                          user:
+                            fullname: Matej Focko
+                            name: mfocko
+                        - comment: ignored comment
+                          commit: null
+                          date_created: '1570882957'
+                          edited_on: null
+                          editor: null
+                          filename: null
+                          id: 99125
+                          line: null
+                          notification: false
+                          parent: null
+                          reactions: {}
+                          tree: null
+                          user:
+                            fullname: Matej Focko
+                            name: mfocko
+                        - comment: New
+                          commit: null
+                          date_created: '1574778296'
+                          edited_on: null
+                          editor: null
+                          filename: null
+                          id: 103393
+                          line: null
+                          notification: false
+                          parent: null
+                          reactions: {}
+                          tree: null
+                          user:
+                            fullname: Matej Focko
+                            name: mfocko
+                        - comment: Pull-Request has been merged by me
+                          commit: null
+                          date_created: '1574778348'
+                          edited_on: null
+                          editor: null
+                          filename: null
+                          id: 103394
+                          line: null
+                          notification: false
+                          parent: null
+                          reactions: {}
+                          tree: null
+                          user:
+                            fullname: Matej Focko
+                            name: mfocko
+                        - comment: PR comment aaaa
+                          commit: null
+                          date_created: '1574780915'
+                          edited_on: null
+                          editor: null
+                          filename: null
+                          id: 103403
+                          line: null
+                          notification: false
+                          parent: null
+                          reactions: {}
+                          tree: null
+                          user:
+                            fullname: Matej Focko
+                            name: mfocko
+                        - comment: PR comment 10
+                          commit: null
+                          date_created: '1574781247'
+                          edited_on: null
+                          editor: null
+                          filename: null
+                          id: 103404
+                          line: null
+                          notification: false
+                          parent: null
+                          reactions: {}
+                          tree: null
+                          user:
+                            fullname: Matej Focko
+                            name: mfocko
+                        commit_start: 360928f7ca08827e8e17cb26851ea57e8d197f87
+                        commit_stop: 360928f7ca08827e8e17cb26851ea57e8d197f87
+                        date_created: '1570615963'
+                        id: 4
+                        initial_comment: Testing PR
+                        last_updated: '1584525665'
+                        project:
+                          access_groups:
+                            admin: []
+                            commit: []
+                            ticket: []
+                          access_users:
+                            admin:
+                            - lbarczio
+                            - jscotka
+                            - mfocko
+                            commit: []
+                            owner:
+                            - lachmanfrantisek
+                            ticket: []
+                          close_status: []
+                          custom_keys: []
+                          date_created: '1570568389'
+                          date_modified: '1570568529'
+                          description: Testing repository for python-ogr package.
+                          fullname: ogr-tests
+                          id: 6826
+                          milestones: {}
+                          name: ogr-tests
+                          namespace: null
+                          parent: null
+                          priorities: {}
+                          tags: []
+                          url_path: ogr-tests
+                          user:
+                            fullname: "Franti\u0161ek Lachman"
+                            name: lachmanfrantisek
+                        remote_git: null
+                        repo_from:
+                          access_groups:
+                            admin: []
+                            commit: []
+                            ticket: []
+                          access_users:
+                            admin:
+                            - lbarczio
+                            - jscotka
+                            - mfocko
+                            commit: []
+                            owner:
+                            - lachmanfrantisek
+                            ticket: []
+                          close_status: []
+                          custom_keys: []
+                          date_created: '1570568389'
+                          date_modified: '1570568529'
+                          description: Testing repository for python-ogr package.
+                          fullname: ogr-tests
+                          id: 6826
+                          milestones: {}
+                          name: ogr-tests
+                          namespace: null
+                          parent: null
+                          priorities: {}
+                          tags: []
+                          url_path: ogr-tests
+                          user:
+                            fullname: "Franti\u0161ek Lachman"
+                            name: lachmanfrantisek
+                        status: Open
+                        tags: []
+                        threshold_reached: null
+                        title: Useless update of README
+                        uid: b2b290197e6943bab87ce368ff825c81
+                        updated_on: '1574781247'
+                        user:
+                          fullname: Matej Focko
+                          name: mfocko
+                      _next: null
+                      elapsed: 0.2
+                      encoding: null
+                      headers:
+                        Connection: Keep-Alive
+                        Content-Length: '4630'
+                        Content-Security-Policy: default-src 'self';script-src 'self'
+                          'nonce-YqLDC0BS8d7iY8mKO7VtBbIne' https://apps.fedoraproject.org;
+                          style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'; object-src
+                          'none';base-uri 'self';img-src 'self' https:;
+                        Content-Type: application/json
+                        Date: Fri, 01 Nov 2019 13-36-03 GMT
+                        Keep-Alive: timeout=5, max=99
+                        Referrer-Policy: same-origin
+                        Server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+                          mod_wsgi/3.4 Python/2.7.5
+                        Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiWm1VNU5UUmlZamMxTWpWa09UTXpOak14TXpGbE1qRXpNV0ZpWW1RNE9EazRaR00zT0RRM09RPT0ifX0.EYoY4Q.tWr76Qv3v14FZbBfszhLllRRQ3k;
+                          Expires=Fri, 29-May-2020 19:43:29 GMT; Secure; HttpOnly;
+                          Path=/
+                        Strict-Transport-Security: max-age=31536000; includeSubDomains;
+                          preload
+                        X-Content-Type-Options: nosniff
+                        X-Frame-Options: ALLOW-FROM https://pagure.io/
+                        X-Xss-Protection: 1; mode=block
+                      raw: !!binary ""
+                      reason: OK
+                      status_code: 200
+    ogr.services.pagure.pull_request:
+      ogr.services.pagure.service:
+        ogr.services.pagure.user:
+          ogr.services.pagure.service:
+            requests.sessions:
+              requre.objects:
+                requests.sessions:
+                  send:
+                  - metadata:
+                      latency: 0.24928689002990723
+                      module_call_list:
+                      - unittest.case
+                      - tests.integration.test_pagure
+                      - ogr.services.pagure.pull_request
+                      - ogr.services.pagure.service
+                      - ogr.services.pagure.user
+                      - ogr.services.pagure.service
+                      - requests.sessions
+                      - requre.objects
+                      - requests.sessions
+                      - send
+                    output:
+                      __store_indicator: 2
+                      _content:
+                        username: mfocko
+                      _next: null
+                      elapsed: 0.2
+                      encoding: null
+                      headers:
+                        Connection: Keep-Alive
+                        Content-Length: '26'
+                        Content-Security-Policy: default-src 'self';script-src 'self'
+                          'nonce-YqLDC0BS8d7iY8mKO7VtBbIne' https://apps.fedoraproject.org;
+                          style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'; object-src
+                          'none';base-uri 'self';img-src 'self' https:;
+                        Content-Type: application/json
+                        Date: Fri, 01 Nov 2019 13-36-03 GMT
+                        Keep-Alive: timeout=5, max=98
+                        Referrer-Policy: same-origin
+                        Server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+                          mod_wsgi/3.4 Python/2.7.5
+                        Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiWm1VNU5UUmlZamMxTWpWa09UTXpOak14TXpGbE1qRXpNV0ZpWW1RNE9EazRaR00zT0RRM09RPT0ifX0.EYoY4g.XL4hE-cPbd4JrSKqPHDgckPy914;
+                          Expires=Fri, 29-May-2020 19:43:30 GMT; Secure; HttpOnly;
+                          Path=/
+                        Strict-Transport-Security: max-age=31536000; includeSubDomains;
+                          preload
+                        X-Content-Type-Options: nosniff
+                        X-Frame-Options: ALLOW-FROM https://pagure.io/
+                        X-Xss-Protection: 1; mode=block
+                      raw: !!binary ""
+                      reason: OK
+                      status_code: 200
+    ogr.services.pagure.service:
+      ogr.services.pagure.user:
+        ogr.services.pagure.service:
+          requests.sessions:
+            requre.objects:
+              requests.sessions:
+                send:
+                - metadata:
+                    latency: 0.9315109252929688
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_pagure
+                    - ogr.services.pagure.service
+                    - ogr.services.pagure.user
+                    - ogr.services.pagure.service
+                    - requests.sessions
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      username: mfocko
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      Connection: Keep-Alive
+                      Content-Length: '26'
+                      Content-Security-Policy: default-src 'self';script-src 'self'
+                        'nonce-YqLDC0BS8d7iY8mKO7VtBbIne' https://apps.fedoraproject.org;
+                        style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'; object-src
+                        'none';base-uri 'self';img-src 'self' https:;
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Keep-Alive: timeout=5, max=100
+                      Referrer-Policy: same-origin
+                      Server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+                        mod_wsgi/3.4 Python/2.7.5
+                      Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiWm1VNU5UUmlZamMxTWpWa09UTXpOak14TXpGbE1qRXpNV0ZpWW1RNE9EazRaR00zT0RRM09RPT0ifX0.EYoY4Q.tWr76Qv3v14FZbBfszhLllRRQ3k;
+                        Expires=Fri, 29-May-2020 19:43:29 GMT; Secure; HttpOnly; Path=/
+                      Strict-Transport-Security: max-age=31536000; includeSubDomains;
+                        preload
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: ALLOW-FROM https://pagure.io/
+                      X-Xss-Protection: 1; mode=block
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200

--- a/tests/integration/test_data/test_pagure/tests.integration.test_pagure.PullRequests.test_source_project_upstream_fork.yaml
+++ b/tests/integration/test_data/test_pagure/tests.integration.test_pagure.PullRequests.test_source_project_upstream_fork.yaml
@@ -1,0 +1,233 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectFull
+  version_storage_file: 2
+unittest.case:
+  tests.integration.test_pagure:
+    ogr.services.pagure.project:
+      ogr.services.pagure.pull_request:
+        ogr.services.pagure.project:
+          ogr.services.pagure.service:
+            requests.sessions:
+              requre.objects:
+                requests.sessions:
+                  send:
+                  - metadata:
+                      latency: 0.3268544673919678
+                      module_call_list:
+                      - unittest.case
+                      - tests.integration.test_pagure
+                      - ogr.services.pagure.project
+                      - ogr.services.pagure.pull_request
+                      - ogr.services.pagure.project
+                      - ogr.services.pagure.service
+                      - requests.sessions
+                      - requre.objects
+                      - requests.sessions
+                      - send
+                    output:
+                      __store_indicator: 2
+                      _content:
+                        assignee: null
+                        branch: master
+                        branch_from: master
+                        cached_merge_status: NO_CHANGE
+                        closed_at: null
+                        closed_by: null
+                        comments:
+                        - comment: let's test it out """"
+                          commit: null
+                          date_created: '1587816397'
+                          edited_on: null
+                          editor: null
+                          filename: null
+                          id: 117651
+                          line: null
+                          notification: false
+                          parent: null
+                          reactions: {}
+                          tree: null
+                          user:
+                            fullname: Matej Focko
+                            name: mfocko
+                        commit_start: null
+                        commit_stop: null
+                        date_created: '1574795470'
+                        id: 6
+                        initial_comment: ''
+                        last_updated: '1587816397'
+                        project:
+                          access_groups:
+                            admin: []
+                            commit: []
+                            ticket: []
+                          access_users:
+                            admin:
+                            - jscotka
+                            - lbarczio
+                            - mfocko
+                            commit: []
+                            owner:
+                            - lachmanfrantisek
+                            ticket: []
+                          close_status: []
+                          custom_keys: []
+                          date_created: '1570568389'
+                          date_modified: '1570568529'
+                          description: Testing repository for python-ogr package.
+                          fullname: ogr-tests
+                          id: 6826
+                          milestones: {}
+                          name: ogr-tests
+                          namespace: null
+                          parent: null
+                          priorities: {}
+                          tags: []
+                          url_path: ogr-tests
+                          user:
+                            fullname: "Franti\u0161ek Lachman"
+                            name: lachmanfrantisek
+                        remote_git: null
+                        repo_from:
+                          access_groups:
+                            admin: []
+                            commit: []
+                            ticket: []
+                          access_users:
+                            admin: []
+                            commit: []
+                            owner:
+                            - mfocko
+                            ticket: []
+                          close_status: []
+                          custom_keys: []
+                          date_created: '1570604926'
+                          date_modified: '1570604926'
+                          description: Testing repository for python-ogr package.
+                          fullname: forks/mfocko/ogr-tests
+                          id: 6828
+                          milestones: {}
+                          name: ogr-tests
+                          namespace: null
+                          parent:
+                            access_groups:
+                              admin: []
+                              commit: []
+                              ticket: []
+                            access_users:
+                              admin:
+                              - jscotka
+                              - lbarczio
+                              - mfocko
+                              commit: []
+                              owner:
+                              - lachmanfrantisek
+                              ticket: []
+                            close_status: []
+                            custom_keys: []
+                            date_created: '1570568389'
+                            date_modified: '1570568529'
+                            description: Testing repository for python-ogr package.
+                            fullname: ogr-tests
+                            id: 6826
+                            milestones: {}
+                            name: ogr-tests
+                            namespace: null
+                            parent: null
+                            priorities: {}
+                            tags: []
+                            url_path: ogr-tests
+                            user:
+                              fullname: "Franti\u0161ek Lachman"
+                              name: lachmanfrantisek
+                          priorities: {}
+                          tags: []
+                          url_path: fork/mfocko/ogr-tests
+                          user:
+                            fullname: Matej Focko
+                            name: mfocko
+                        status: Open
+                        tags: []
+                        threshold_reached: null
+                        title: Testing PR
+                        uid: bd3715fe3a024a1785928c3e06ca95f9
+                        updated_on: '1587816397'
+                        user:
+                          fullname: Matej Focko
+                          name: mfocko
+                      _next: null
+                      elapsed: 0.2
+                      encoding: null
+                      headers:
+                        Connection: Keep-Alive
+                        Content-Length: '3338'
+                        Content-Security-Policy: default-src 'self';script-src 'self'
+                          'nonce-YqLDC0BS8d7iY8mKO7VtBbIne' https://apps.fedoraproject.org;
+                          style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'; object-src
+                          'none';base-uri 'self';img-src 'self' https:;
+                        Content-Type: application/json
+                        Date: Fri, 01 Nov 2019 13-36-03 GMT
+                        Keep-Alive: timeout=5, max=99
+                        Referrer-Policy: same-origin
+                        Server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+                          mod_wsgi/3.4 Python/2.7.5
+                        Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiWW1FNU1XWTJZakV6WkdJNU5UWmhOV0V3TkRabVl6UTNPRGRpWldFM05HSmlPRE0wWm1KaFpRPT0ifX0.EYoY4w.p1oAL97G-LXKh88izoHWiHi65W0;
+                          Expires=Fri, 29-May-2020 19:43:31 GMT; Secure; HttpOnly;
+                          Path=/
+                        Strict-Transport-Security: max-age=31536000; includeSubDomains;
+                          preload
+                        X-Content-Type-Options: nosniff
+                        X-Frame-Options: ALLOW-FROM https://pagure.io/
+                        X-Xss-Protection: 1; mode=block
+                      raw: !!binary ""
+                      reason: OK
+                      status_code: 200
+    ogr.services.pagure.service:
+      ogr.services.pagure.user:
+        ogr.services.pagure.service:
+          requests.sessions:
+            requre.objects:
+              requests.sessions:
+                send:
+                - metadata:
+                    latency: 0.8701913356781006
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_pagure
+                    - ogr.services.pagure.service
+                    - ogr.services.pagure.user
+                    - ogr.services.pagure.service
+                    - requests.sessions
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      username: mfocko
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      Connection: Keep-Alive
+                      Content-Length: '26'
+                      Content-Security-Policy: default-src 'self';script-src 'self'
+                        'nonce-YqLDC0BS8d7iY8mKO7VtBbIne' https://apps.fedoraproject.org;
+                        style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'; object-src
+                        'none';base-uri 'self';img-src 'self' https:;
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Keep-Alive: timeout=5, max=100
+                      Referrer-Policy: same-origin
+                      Server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+                        mod_wsgi/3.4 Python/2.7.5
+                      Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiWW1FNU1XWTJZakV6WkdJNU5UWmhOV0V3TkRabVl6UTNPRGRpWldFM05HSmlPRE0wWm1KaFpRPT0ifX0.EYoY4g.FWgiCjLJErzmK5ujbC57wShONyM;
+                        Expires=Fri, 29-May-2020 19:43:30 GMT; Secure; HttpOnly; Path=/
+                      Strict-Transport-Security: max-age=31536000; includeSubDomains;
+                        preload
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: ALLOW-FROM https://pagure.io/
+                      X-Xss-Protection: 1; mode=block
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -700,6 +700,48 @@ class PullRequests(GithubTests):
             == "7cf6d0cbeca285ecbeb19a0067cb243783b3c768"
         )
 
+    def test_source_project_upstream_branch(self):
+        pr = self.hello_world_project.get_pr(72)
+        source_project = pr.source_project
+        assert source_project.namespace == "packit-service"
+        assert source_project.repo == "hello-world"
+
+    def test_source_project_upstream_fork(self):
+        pr = self.hello_world_project.get_pr(111)
+        source_project = pr.source_project
+        assert source_project.namespace == "lbarcziova"
+        assert source_project.repo == "hello-world"
+
+    def test_source_project_fork_fork(self):
+        project = self.service.get_project(repo="hello-world", namespace="mfocko")
+        pr = project.get_pr(1)
+        source_project = pr.source_project
+        assert source_project.namespace == "mfocko"
+        assert source_project.repo == "hello-world"
+
+    def test_source_project_other_fork_fork(self):
+        project = self.service.get_project(
+            repo="hello-world", namespace="lachmanfrantisek"
+        )
+        pr = project.get_pr(1)
+        source_project = pr.source_project
+        assert source_project.namespace == "mfocko"
+        assert source_project.repo == "hello-world"
+
+    def test_source_project_renamed_fork(self):
+        pr = self.hello_world_project.get_pr(113)
+        source_project = pr.source_project
+        assert source_project.namespace == "mfocko"
+        assert source_project.repo == "bye-world"
+
+    def test_source_project_renamed_upstream(self):
+        pr = self.service.get_project(
+            repo="not-potential-spoon", namespace="packit-service"
+        ).get_pr(1)
+        source_project = pr.source_project
+        assert source_project.namespace == "mfocko"
+        assert source_project.repo == "potential-spoon"
+
 
 class Releases(GithubTests):
     def test_get_release(self):

--- a/tests/integration/test_gitlab.py
+++ b/tests/integration/test_gitlab.py
@@ -503,6 +503,48 @@ class PullRequests(GitlabTests):
             == "59b1a9bab5b5198c619270646410867788685c16"
         )
 
+    def test_source_project_upstream_branch(self):
+        pr = self.project.get_pr(23)
+        source_project = pr.source_project
+        assert source_project.namespace == "packit-service"
+        assert source_project.repo == "ogr-tests"
+
+    def test_source_project_upstream_fork(self):
+        pr = self.project.get_pr(22)
+        source_project = pr.source_project
+        assert source_project.namespace == "mfocko"
+        assert source_project.repo == "ogr-tests"
+
+    def test_source_project_fork_fork(self):
+        project = self.service.get_project(repo="ogr-tests", namespace="mfocko")
+        pr = project.get_pr(1)
+        source_project = pr.source_project
+        assert source_project.namespace == "mfocko"
+        assert source_project.repo == "ogr-tests"
+
+    def test_source_project_other_fork_fork(self):
+        project = self.service.get_project(
+            repo="ogr-tests", namespace="lachmanfrantisek"
+        )
+        pr = project.get_pr(1)
+        source_project = pr.source_project
+        assert source_project.namespace == "mfocko"
+        assert source_project.repo == "ogr-tests"
+
+    def test_source_project_renamed_fork(self):
+        pr = self.project.get_pr(24)
+        source_project = pr.source_project
+        assert source_project.namespace == "mfocko"
+        assert source_project.repo == "definitely-not-ogr-tests"
+
+    def test_source_project_renamed_upstream(self):
+        pr = self.service.get_project(
+            repo="old-ogr-testing-repo-in-the-group", namespace="packit-service"
+        ).get_pr(1)
+        source_project = pr.source_project
+        assert source_project.namespace == "mfocko"
+        assert source_project.repo == "new-ogr-testing-repo-in-the-group"
+
 
 class Tags(GitlabTests):
     def test_get_tags(self):

--- a/tests/integration/test_pagure.py
+++ b/tests/integration/test_pagure.py
@@ -339,6 +339,19 @@ class PullRequests(PagureTests):
             == "517121273b142293807606dbd7a2e0f514b21cc8"
         )
 
+    def test_source_project_upstream_branch(self):
+        pr = self.ogr_project.get_pr(4)
+        source_project = pr.source_project
+        assert source_project.namespace is None
+        assert source_project.repo == "ogr-tests"
+
+    def test_source_project_upstream_fork(self):
+        pr = self.ogr_project.get_pr(6)
+        source_project = pr.source_project
+        assert source_project.namespace is None
+        assert source_project.repo == "ogr-tests"
+        assert source_project.full_repo_name == "fork/mfocko/ogr-tests"
+
 
 class Forks(PagureTests):
     def test_fork(self):


### PR DESCRIPTION
Closes #400

# TODO

(copied from issue)

- [x] add `source_project` property (abstract and implementations) returning the project with the source branch
- [x] create tests:
  - [x] basic PR from `fork` to `upstream`
  - [x] renamed `fork`
  - [x] renamed `upstream`
  - [x] PR from `fork` to `fork`
  - [x] PR from `upstream` to `upstream`
- [x] ? `target_project` property that will replace the current `project` one to make it clear
  - [x] don't forget to support both and deprecate the old one
-  [x] squash commits
-  [x] check getting projects by internal representation (github: creating from github.Repository, gitlab: from project_id)
   -  [x] Github: project uses almost the same way of initializing `GithubProject` in `L129, L172, L385, L564`

# Discussion

-  [x] deprecating `.project`
   -  [x] provide `.project` as a property?
   -  [ ] if so, do we need setters for them outside class?
-  [ ] consider having `GithubProject.from_github_repository`, which would take just the github repo from PyGithub and return new project
-  [ ] consider creating GitLab projects just from _project id_ (python-gitlab doesn't offer any way to get to source project than ID)