### PR TITLE
Create PR's to forked Repo fixed for Github

### DIFF
--- a/ogr/services/github/pull_request.py
+++ b/ogr/services/github/pull_request.py
@@ -123,14 +123,16 @@ class GithubPullRequest(BasePullRequest):
         source_branch: str,
         fork_username: str = None,
     ) -> "PullRequest":
+        """
+        The default behavior is the pull request is made to the immediate parent repository
+        if the repository is a forked repository.
+        If you want to create a pull request to the forked repo, please pass
+        the `fork_username` parameter.
+        """
         github_repo = project.github_repo
 
-        if project.is_fork and fork_username:
-            logger.warning(
-                f"{project.full_repo_name} is fork, ignoring fork_username arg"
-            )
-
-        if project.is_fork:
+        if project.is_fork and fork_username is None:
+            logger.warning(f"{project.full_repo_name} is fork, ignoring fork_repo.")
             source_branch = f"{project.namespace}:{source_branch}"
             github_repo = project.parent.github_repo
         elif fork_username:

--- a/tests/unit/test_github.py
+++ b/tests/unit/test_github.py
@@ -63,7 +63,7 @@ class TestGithubProject:
         github_project.parent.github_repo.should_call("create_pull").never()
         github_project.github_repo.should_call("create_pull").once()
 
-        github_project.pr_create(
+        github_project.create_pr(
             title="test_title",
             body="test_content",
             target_branch="master",
@@ -72,11 +72,7 @@ class TestGithubProject:
         )
 
     @pytest.mark.parametrize(
-        "fork_username",
-        [
-            pytest.param("test_fork_username", id="fork_username_set"),
-            pytest.param(None, id="fork_username_None"),
-        ],
+        "fork_username", [pytest.param("test_fork_username", id="fork_username_set")],
     )
     def test_pr_create_is_fork(self, github_project, fork_username):
         github_project.should_receive("is_fork").and_return(True)
@@ -87,11 +83,12 @@ class TestGithubProject:
             body="test_content",
             base="master",
             head=f"{github_project}:master",
+            fork_username=fork_username,
         )
-        github_project.parent.github_repo.should_call("create_pull").once()
-        github_project.github_repo.should_call("create_pull").never()
+        github_project.parent.github_repo.should_call("create_pull").never()
+        github_project.github_repo.should_call("create_pull").once()
 
-        github_project.pr_create(
+        github_project.create_pr(
             title="test_title",
             body="test_content",
             target_branch="master",


### PR DESCRIPTION
Related to #307 
If the fork_name arg is passed, PR is created on the forked repo.
If the fork_name arg is not passed PR is made to parent repo. 

Tested for (fork-fork, fork-upstream, upstream-upstream)