### PR TITLE
GitHub: query only one user when telling if a user can merge PRs

### DIFF
--- a/ogr/services/github/project.py
+++ b/ogr/services/github/project.py
@@ -59,6 +59,8 @@ logger = logging.getLogger(__name__)
 
 class GithubProject(BaseGitProject):
     service: "ogr_github.GithubService"
+    # Permission levels that can merge PRs
+    CAN_MERGE_PERMS = ["admin", "write"]
 
     def __init__(
         self,
@@ -245,7 +247,7 @@ class GithubProject(BaseGitProject):
 
         usernames = []
         for login, permission in collaborators.items():
-            if permission in ["admin", "write"]:
+            if permission in self.CAN_MERGE_PERMS:
                 usernames.append(login)
 
         return set(usernames)
@@ -257,7 +259,10 @@ class GithubProject(BaseGitProject):
         return self.__get_collaborators()
 
     def can_merge_pr(self, username) -> bool:
-        return username in self.who_can_merge_pr()
+        return (
+            self.github_repo.get_collaborator_permission(username)
+            in self.CAN_MERGE_PERMS
+        )
 
     def _get_collaborators_with_permission(self) -> dict:
         """

--- a/tests/integration/test_data/test_github/tests.integration.test_github.GenericCommands.test_pr_permissions.yaml
+++ b/tests/integration/test_data/test_github/tests.integration.test_github.GenericCommands.test_pr_permissions.yaml
@@ -1,3 +1,7 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectFull
+  version_storage_file: 2
 unittest.case:
   tests.integration.test_github:
     ogr.services.github.project:
@@ -7,3172 +11,1782 @@ unittest.case:
             requre.objects:
               requests.sessions:
                 send:
-                - __store_indicator: 2
-                  _content:
-                    allow_merge_commit: true
-                    allow_rebase_merge: true
-                    allow_squash_merge: true
-                    archive_url: https://api.github.com/repos/packit-service/ogr/{archive_format}{/ref}
-                    archived: false
-                    assignees_url: https://api.github.com/repos/packit-service/ogr/assignees{/user}
-                    blobs_url: https://api.github.com/repos/packit-service/ogr/git/blobs{/sha}
-                    branches_url: https://api.github.com/repos/packit-service/ogr/branches{/branch}
-                    clone_url: https://github.com/packit-service/ogr.git
-                    collaborators_url: https://api.github.com/repos/packit-service/ogr/collaborators{/collaborator}
-                    comments_url: https://api.github.com/repos/packit-service/ogr/comments{/number}
-                    commits_url: https://api.github.com/repos/packit-service/ogr/commits{/sha}
-                    compare_url: https://api.github.com/repos/packit-service/ogr/compare/{base}...{head}
-                    contents_url: https://api.github.com/repos/packit-service/ogr/contents/{+path}
-                    contributors_url: https://api.github.com/repos/packit-service/ogr/contributors
-                    created_at: '2018-12-13T12:33:52Z'
-                    default_branch: master
-                    deployments_url: https://api.github.com/repos/packit-service/ogr/deployments
-                    description: One Git library to Rule -- one API for many git forges
-                    disabled: false
-                    downloads_url: https://api.github.com/repos/packit-service/ogr/downloads
-                    events_url: https://api.github.com/repos/packit-service/ogr/events
-                    fork: false
-                    forks: 15
-                    forks_count: 15
-                    forks_url: https://api.github.com/repos/packit-service/ogr/forks
-                    full_name: packit-service/ogr
-                    git_commits_url: https://api.github.com/repos/packit-service/ogr/git/commits{/sha}
-                    git_refs_url: https://api.github.com/repos/packit-service/ogr/git/refs{/sha}
-                    git_tags_url: https://api.github.com/repos/packit-service/ogr/git/tags{/sha}
-                    git_url: git://github.com/packit-service/ogr.git
-                    has_downloads: true
-                    has_issues: true
-                    has_pages: false
-                    has_projects: true
-                    has_wiki: true
-                    homepage: ''
-                    hooks_url: https://api.github.com/repos/packit-service/ogr/hooks
-                    html_url: https://github.com/packit-service/ogr
-                    id: 161636700
-                    issue_comment_url: https://api.github.com/repos/packit-service/ogr/issues/comments{/number}
-                    issue_events_url: https://api.github.com/repos/packit-service/ogr/issues/events{/number}
-                    issues_url: https://api.github.com/repos/packit-service/ogr/issues{/number}
-                    keys_url: https://api.github.com/repos/packit-service/ogr/keys{/key_id}
-                    labels_url: https://api.github.com/repos/packit-service/ogr/labels{/name}
-                    language: Python
-                    languages_url: https://api.github.com/repos/packit-service/ogr/languages
-                    license:
-                      key: mit
-                      name: MIT License
-                      node_id: MDc6TGljZW5zZTEz
-                      spdx_id: MIT
-                      url: https://api.github.com/licenses/mit
-                    merges_url: https://api.github.com/repos/packit-service/ogr/merges
-                    milestones_url: https://api.github.com/repos/packit-service/ogr/milestones{/number}
-                    mirror_url: null
-                    name: ogr
-                    network_count: 15
-                    node_id: MDEwOlJlcG9zaXRvcnkxNjE2MzY3MDA=
-                    notifications_url: https://api.github.com/repos/packit-service/ogr/notifications{?since,all,participating}
-                    open_issues: 32
-                    open_issues_count: 32
-                    organization:
-                      avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
-                      events_url: https://api.github.com/users/packit-service/events{/privacy}
-                      followers_url: https://api.github.com/users/packit-service/followers
-                      following_url: https://api.github.com/users/packit-service/following{/other_user}
-                      gists_url: https://api.github.com/users/packit-service/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/packit-service
-                      id: 46870917
-                      login: packit-service
-                      node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
-                      organizations_url: https://api.github.com/users/packit-service/orgs
-                      received_events_url: https://api.github.com/users/packit-service/received_events
-                      repos_url: https://api.github.com/users/packit-service/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/packit-service/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/packit-service/subscriptions
-                      type: Organization
-                      url: https://api.github.com/users/packit-service
-                    owner:
-                      avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
-                      events_url: https://api.github.com/users/packit-service/events{/privacy}
-                      followers_url: https://api.github.com/users/packit-service/followers
-                      following_url: https://api.github.com/users/packit-service/following{/other_user}
-                      gists_url: https://api.github.com/users/packit-service/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/packit-service
-                      id: 46870917
-                      login: packit-service
-                      node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
-                      organizations_url: https://api.github.com/users/packit-service/orgs
-                      received_events_url: https://api.github.com/users/packit-service/received_events
-                      repos_url: https://api.github.com/users/packit-service/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/packit-service/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/packit-service/subscriptions
-                      type: Organization
-                      url: https://api.github.com/users/packit-service
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    private: false
-                    pulls_url: https://api.github.com/repos/packit-service/ogr/pulls{/number}
-                    pushed_at: '2019-09-27T06:38:19Z'
-                    releases_url: https://api.github.com/repos/packit-service/ogr/releases{/id}
-                    size: 2395
-                    ssh_url: git@github.com:packit-service/ogr.git
-                    stargazers_count: 17
-                    stargazers_url: https://api.github.com/repos/packit-service/ogr/stargazers
-                    statuses_url: https://api.github.com/repos/packit-service/ogr/statuses/{sha}
-                    subscribers_count: 8
-                    subscribers_url: https://api.github.com/repos/packit-service/ogr/subscribers
-                    subscription_url: https://api.github.com/repos/packit-service/ogr/subscription
-                    svn_url: https://github.com/packit-service/ogr
-                    tags_url: https://api.github.com/repos/packit-service/ogr/tags
-                    teams_url: https://api.github.com/repos/packit-service/ogr/teams
-                    trees_url: https://api.github.com/repos/packit-service/ogr/git/trees{/sha}
-                    updated_at: '2019-09-26T10:43:44Z'
-                    url: https://api.github.com/repos/packit-service/ogr
-                    watchers: 17
-                    watchers_count: 17
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Last-Modified: Thu, 26 Sep 2019 10:43:44 GMT
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: repo
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
+                - metadata:
+                    latency: 0.7084658145904541
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_github
+                    - ogr.services.github.project
+                    - github.MainClass
+                    - github.Requester
+                    - requests.sessions
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      allow_merge_commit: true
+                      allow_rebase_merge: true
+                      allow_squash_merge: true
+                      archive_url: https://api.github.com/repos/packit-service/ogr/{archive_format}{/ref}
+                      archived: false
+                      assignees_url: https://api.github.com/repos/packit-service/ogr/assignees{/user}
+                      blobs_url: https://api.github.com/repos/packit-service/ogr/git/blobs{/sha}
+                      branches_url: https://api.github.com/repos/packit-service/ogr/branches{/branch}
+                      clone_url: https://github.com/packit-service/ogr.git
+                      collaborators_url: https://api.github.com/repos/packit-service/ogr/collaborators{/collaborator}
+                      comments_url: https://api.github.com/repos/packit-service/ogr/comments{/number}
+                      commits_url: https://api.github.com/repos/packit-service/ogr/commits{/sha}
+                      compare_url: https://api.github.com/repos/packit-service/ogr/compare/{base}...{head}
+                      contents_url: https://api.github.com/repos/packit-service/ogr/contents/{+path}
+                      contributors_url: https://api.github.com/repos/packit-service/ogr/contributors
+                      created_at: '2018-12-13T12:33:52Z'
+                      default_branch: master
+                      delete_branch_on_merge: false
+                      deployments_url: https://api.github.com/repos/packit-service/ogr/deployments
+                      description: One Git library to Rule -- one API for many git
+                        forges
+                      disabled: false
+                      downloads_url: https://api.github.com/repos/packit-service/ogr/downloads
+                      events_url: https://api.github.com/repos/packit-service/ogr/events
+                      fork: false
+                      forks: 41
+                      forks_count: 41
+                      forks_url: https://api.github.com/repos/packit-service/ogr/forks
+                      full_name: packit-service/ogr
+                      git_commits_url: https://api.github.com/repos/packit-service/ogr/git/commits{/sha}
+                      git_refs_url: https://api.github.com/repos/packit-service/ogr/git/refs{/sha}
+                      git_tags_url: https://api.github.com/repos/packit-service/ogr/git/tags{/sha}
+                      git_url: git://github.com/packit-service/ogr.git
+                      has_downloads: true
+                      has_issues: true
+                      has_pages: false
+                      has_projects: true
+                      has_wiki: true
+                      homepage: ''
+                      hooks_url: https://api.github.com/repos/packit-service/ogr/hooks
+                      html_url: https://github.com/packit-service/ogr
+                      id: 161636700
+                      issue_comment_url: https://api.github.com/repos/packit-service/ogr/issues/comments{/number}
+                      issue_events_url: https://api.github.com/repos/packit-service/ogr/issues/events{/number}
+                      issues_url: https://api.github.com/repos/packit-service/ogr/issues{/number}
+                      keys_url: https://api.github.com/repos/packit-service/ogr/keys{/key_id}
+                      labels_url: https://api.github.com/repos/packit-service/ogr/labels{/name}
+                      language: Python
+                      languages_url: https://api.github.com/repos/packit-service/ogr/languages
+                      license:
+                        key: mit
+                        name: MIT License
+                        node_id: MDc6TGljZW5zZTEz
+                        spdx_id: MIT
+                        url: https://api.github.com/licenses/mit
+                      merges_url: https://api.github.com/repos/packit-service/ogr/merges
+                      milestones_url: https://api.github.com/repos/packit-service/ogr/milestones{/number}
+                      mirror_url: null
+                      name: ogr
+                      network_count: 41
+                      node_id: MDEwOlJlcG9zaXRvcnkxNjE2MzY3MDA=
+                      notifications_url: https://api.github.com/repos/packit-service/ogr/notifications{?since,all,participating}
+                      open_issues: 41
+                      open_issues_count: 41
+                      organization:
+                        avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
+                        events_url: https://api.github.com/users/packit-service/events{/privacy}
+                        followers_url: https://api.github.com/users/packit-service/followers
+                        following_url: https://api.github.com/users/packit-service/following{/other_user}
+                        gists_url: https://api.github.com/users/packit-service/gists{/gist_id}
+                        gravatar_id: ''
+                        html_url: https://github.com/packit-service
+                        id: 46870917
+                        login: packit-service
+                        node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                        organizations_url: https://api.github.com/users/packit-service/orgs
+                        received_events_url: https://api.github.com/users/packit-service/received_events
+                        repos_url: https://api.github.com/users/packit-service/repos
+                        site_admin: false
+                        starred_url: https://api.github.com/users/packit-service/starred{/owner}{/repo}
+                        subscriptions_url: https://api.github.com/users/packit-service/subscriptions
+                        type: Organization
+                        url: https://api.github.com/users/packit-service
+                      owner:
+                        avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
+                        events_url: https://api.github.com/users/packit-service/events{/privacy}
+                        followers_url: https://api.github.com/users/packit-service/followers
+                        following_url: https://api.github.com/users/packit-service/following{/other_user}
+                        gists_url: https://api.github.com/users/packit-service/gists{/gist_id}
+                        gravatar_id: ''
+                        html_url: https://github.com/packit-service
+                        id: 46870917
+                        login: packit-service
+                        node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                        organizations_url: https://api.github.com/users/packit-service/orgs
+                        received_events_url: https://api.github.com/users/packit-service/received_events
+                        repos_url: https://api.github.com/users/packit-service/repos
+                        site_admin: false
+                        starred_url: https://api.github.com/users/packit-service/starred{/owner}{/repo}
+                        subscriptions_url: https://api.github.com/users/packit-service/subscriptions
+                        type: Organization
+                        url: https://api.github.com/users/packit-service
+                      permissions:
+                        admin: true
+                        pull: true
+                        push: true
+                      private: false
+                      pulls_url: https://api.github.com/repos/packit-service/ogr/pulls{/number}
+                      pushed_at: '2020-05-11T01:31:14Z'
+                      releases_url: https://api.github.com/repos/packit-service/ogr/releases{/id}
+                      size: 6020
+                      ssh_url: git@github.com:packit-service/ogr.git
+                      stargazers_count: 29
+                      stargazers_url: https://api.github.com/repos/packit-service/ogr/stargazers
+                      statuses_url: https://api.github.com/repos/packit-service/ogr/statuses/{sha}
+                      subscribers_count: 12
+                      subscribers_url: https://api.github.com/repos/packit-service/ogr/subscribers
+                      subscription_url: https://api.github.com/repos/packit-service/ogr/subscription
+                      svn_url: https://github.com/packit-service/ogr
+                      tags_url: https://api.github.com/repos/packit-service/ogr/tags
+                      teams_url: https://api.github.com/repos/packit-service/ogr/teams
+                      temp_clone_token: ''
+                      trees_url: https://api.github.com/repos/packit-service/ogr/git/trees{/sha}
+                      updated_at: '2020-05-06T15:53:28Z'
+                      url: https://api.github.com/repos/packit-service/ogr
+                      watchers: 29
+                      watchers_count: 29
+                    _next: null
+                    elapsed: 0.2
+                    encoding: utf-8
+                    headers:
+                      Access-Control-Allow-Origin: '*'
+                      Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                        X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+                        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+                        X-GitHub-Media-Type, Deprecation, Sunset
+                      Cache-Control: private, max-age=60, s-maxage=60
+                      Content-Encoding: gzip
+                      Content-Security-Policy: default-src 'none'
+                      Content-Type: application/json; charset=utf-8
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                      Last-Modified: Wed, 06 May 2020 15:53:28 GMT
+                      Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                      Server: GitHub.com
+                      Status: 200 OK
+                      Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                        preload
+                      Transfer-Encoding: chunked
+                      Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                        Accept, X-Requested-With
+                      X-Accepted-OAuth-Scopes: repo
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: deny
+                      X-GitHub-Media-Type: github.v3; format=json
+                      X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                      X-OAuth-Scopes: admin:org, repo
+                      X-RateLimit-Limit: '5000'
+                      X-RateLimit-Remaining: '4972'
+                      X-RateLimit-Reset: '1572953901'
+                      X-XSS-Protection: 1; mode=block
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
       github.PaginatedList:
         github.Requester:
           requests.sessions:
             requre.objects:
               requests.sessions:
                 send:
-                - __store_indicator: 2
-                  _content:
-                  - avatar_url: https://avatars0.githubusercontent.com/u/288686?v=4
-                    events_url: https://api.github.com/users/jpopelka/events{/privacy}
-                    followers_url: https://api.github.com/users/jpopelka/followers
-                    following_url: https://api.github.com/users/jpopelka/following{/other_user}
-                    gists_url: https://api.github.com/users/jpopelka/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/jpopelka
-                    id: 288686
-                    login: jpopelka
-                    node_id: MDQ6VXNlcjI4ODY4Ng==
-                    organizations_url: https://api.github.com/users/jpopelka/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/jpopelka/received_events
-                    repos_url: https://api.github.com/users/jpopelka/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/jpopelka/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/jpopelka/subscriptions
-                    type: User
-                    url: https://api.github.com/users/jpopelka
-                  - avatar_url: https://avatars0.githubusercontent.com/u/1662493?v=4
-                    events_url: https://api.github.com/users/TomasTomecek/events{/privacy}
-                    followers_url: https://api.github.com/users/TomasTomecek/followers
-                    following_url: https://api.github.com/users/TomasTomecek/following{/other_user}
-                    gists_url: https://api.github.com/users/TomasTomecek/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/TomasTomecek
-                    id: 1662493
-                    login: TomasTomecek
-                    node_id: MDQ6VXNlcjE2NjI0OTM=
-                    organizations_url: https://api.github.com/users/TomasTomecek/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/TomasTomecek/received_events
-                    repos_url: https://api.github.com/users/TomasTomecek/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/TomasTomecek/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/TomasTomecek/subscriptions
-                    type: User
-                    url: https://api.github.com/users/TomasTomecek
-                  - avatar_url: https://avatars3.githubusercontent.com/u/1866652?v=4
-                    events_url: https://api.github.com/users/eliskasl/events{/privacy}
-                    followers_url: https://api.github.com/users/eliskasl/followers
-                    following_url: https://api.github.com/users/eliskasl/following{/other_user}
-                    gists_url: https://api.github.com/users/eliskasl/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/eliskasl
-                    id: 1866652
-                    login: eliskasl
-                    node_id: MDQ6VXNlcjE4NjY2NTI=
-                    organizations_url: https://api.github.com/users/eliskasl/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/eliskasl/received_events
-                    repos_url: https://api.github.com/users/eliskasl/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/eliskasl/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/eliskasl/subscriptions
-                    type: User
-                    url: https://api.github.com/users/eliskasl
-                  - avatar_url: https://avatars2.githubusercontent.com/u/3416672?v=4
-                    events_url: https://api.github.com/users/phracek/events{/privacy}
-                    followers_url: https://api.github.com/users/phracek/followers
-                    following_url: https://api.github.com/users/phracek/following{/other_user}
-                    gists_url: https://api.github.com/users/phracek/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/phracek
-                    id: 3416672
-                    login: phracek
-                    node_id: MDQ6VXNlcjM0MTY2NzI=
-                    organizations_url: https://api.github.com/users/phracek/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/phracek/received_events
-                    repos_url: https://api.github.com/users/phracek/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/phracek/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/phracek/subscriptions
-                    type: User
-                    url: https://api.github.com/users/phracek
-                  - avatar_url: https://avatars0.githubusercontent.com/u/8735467?v=4
-                    events_url: https://api.github.com/users/jscotka/events{/privacy}
-                    followers_url: https://api.github.com/users/jscotka/followers
-                    following_url: https://api.github.com/users/jscotka/following{/other_user}
-                    gists_url: https://api.github.com/users/jscotka/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/jscotka
-                    id: 8735467
-                    login: jscotka
-                    node_id: MDQ6VXNlcjg3MzU0Njc=
-                    organizations_url: https://api.github.com/users/jscotka/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/jscotka/received_events
-                    repos_url: https://api.github.com/users/jscotka/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/jscotka/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/jscotka/subscriptions
-                    type: User
-                    url: https://api.github.com/users/jscotka
-                  - avatar_url: https://avatars3.githubusercontent.com/u/17581559?v=4
-                    events_url: https://api.github.com/users/centos-ci/events{/privacy}
-                    followers_url: https://api.github.com/users/centos-ci/followers
-                    following_url: https://api.github.com/users/centos-ci/following{/other_user}
-                    gists_url: https://api.github.com/users/centos-ci/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/centos-ci
-                    id: 17581559
-                    login: centos-ci
-                    node_id: MDQ6VXNlcjE3NTgxNTU5
-                    organizations_url: https://api.github.com/users/centos-ci/orgs
-                    permissions:
-                      admin: false
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/centos-ci/received_events
-                    repos_url: https://api.github.com/users/centos-ci/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/centos-ci/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/centos-ci/subscriptions
-                    type: User
-                    url: https://api.github.com/users/centos-ci
-                  - avatar_url: https://avatars1.githubusercontent.com/u/20214043?v=4
-                    events_url: https://api.github.com/users/lachmanfrantisek/events{/privacy}
-                    followers_url: https://api.github.com/users/lachmanfrantisek/followers
-                    following_url: https://api.github.com/users/lachmanfrantisek/following{/other_user}
-                    gists_url: https://api.github.com/users/lachmanfrantisek/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/lachmanfrantisek
-                    id: 20214043
-                    login: lachmanfrantisek
-                    node_id: MDQ6VXNlcjIwMjE0MDQz
-                    organizations_url: https://api.github.com/users/lachmanfrantisek/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/lachmanfrantisek/received_events
-                    repos_url: https://api.github.com/users/lachmanfrantisek/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/lachmanfrantisek/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/lachmanfrantisek/subscriptions
-                    type: User
-                    url: https://api.github.com/users/lachmanfrantisek
-                  - avatar_url: https://avatars1.githubusercontent.com/u/25414049?v=4
-                    events_url: https://api.github.com/users/marusinm/events{/privacy}
-                    followers_url: https://api.github.com/users/marusinm/followers
-                    following_url: https://api.github.com/users/marusinm/following{/other_user}
-                    gists_url: https://api.github.com/users/marusinm/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/marusinm
-                    id: 25414049
-                    login: marusinm
-                    node_id: MDQ6VXNlcjI1NDE0MDQ5
-                    organizations_url: https://api.github.com/users/marusinm/orgs
-                    permissions:
-                      admin: false
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/marusinm/received_events
-                    repos_url: https://api.github.com/users/marusinm/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/marusinm/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/marusinm/subscriptions
-                    type: User
-                    url: https://api.github.com/users/marusinm
-                  - avatar_url: https://avatars3.githubusercontent.com/u/26160778?v=4
-                    events_url: https://api.github.com/users/rpitonak/events{/privacy}
-                    followers_url: https://api.github.com/users/rpitonak/followers
-                    following_url: https://api.github.com/users/rpitonak/following{/other_user}
-                    gists_url: https://api.github.com/users/rpitonak/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/rpitonak
-                    id: 26160778
-                    login: rpitonak
-                    node_id: MDQ6VXNlcjI2MTYwNzc4
-                    organizations_url: https://api.github.com/users/rpitonak/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/rpitonak/received_events
-                    repos_url: https://api.github.com/users/rpitonak/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/rpitonak/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/rpitonak/subscriptions
-                    type: User
-                    url: https://api.github.com/users/rpitonak
-                  - avatar_url: https://avatars2.githubusercontent.com/u/31201372?v=4
-                    events_url: https://api.github.com/users/dhodovsk/events{/privacy}
-                    followers_url: https://api.github.com/users/dhodovsk/followers
-                    following_url: https://api.github.com/users/dhodovsk/following{/other_user}
-                    gists_url: https://api.github.com/users/dhodovsk/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/dhodovsk
-                    id: 31201372
-                    login: dhodovsk
-                    node_id: MDQ6VXNlcjMxMjAxMzcy
-                    organizations_url: https://api.github.com/users/dhodovsk/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/dhodovsk/received_events
-                    repos_url: https://api.github.com/users/dhodovsk/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/dhodovsk/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/dhodovsk/subscriptions
-                    type: User
-                    url: https://api.github.com/users/dhodovsk
-                  - avatar_url: https://avatars1.githubusercontent.com/u/36231209?v=4
-                    events_url: https://api.github.com/users/usercont-release-bot/events{/privacy}
-                    followers_url: https://api.github.com/users/usercont-release-bot/followers
-                    following_url: https://api.github.com/users/usercont-release-bot/following{/other_user}
-                    gists_url: https://api.github.com/users/usercont-release-bot/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/usercont-release-bot
-                    id: 36231209
-                    login: usercont-release-bot
-                    node_id: MDQ6VXNlcjM2MjMxMjA5
-                    organizations_url: https://api.github.com/users/usercont-release-bot/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/usercont-release-bot/received_events
-                    repos_url: https://api.github.com/users/usercont-release-bot/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/usercont-release-bot/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/usercont-release-bot/subscriptions
-                    type: User
-                    url: https://api.github.com/users/usercont-release-bot
-                  - avatar_url: https://avatars3.githubusercontent.com/u/49026743?v=4
-                    events_url: https://api.github.com/users/lbarcziova/events{/privacy}
-                    followers_url: https://api.github.com/users/lbarcziova/followers
-                    following_url: https://api.github.com/users/lbarcziova/following{/other_user}
-                    gists_url: https://api.github.com/users/lbarcziova/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/lbarcziova
-                    id: 49026743
-                    login: lbarcziova
-                    node_id: MDQ6VXNlcjQ5MDI2NzQz
-                    organizations_url: https://api.github.com/users/lbarcziova/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/lbarcziova/received_events
-                    repos_url: https://api.github.com/users/lbarcziova/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/lbarcziova/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/lbarcziova/subscriptions
-                    type: User
-                    url: https://api.github.com/users/lbarcziova
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                  - avatar_url: https://avatars0.githubusercontent.com/u/288686?v=4
-                    events_url: https://api.github.com/users/jpopelka/events{/privacy}
-                    followers_url: https://api.github.com/users/jpopelka/followers
-                    following_url: https://api.github.com/users/jpopelka/following{/other_user}
-                    gists_url: https://api.github.com/users/jpopelka/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/jpopelka
-                    id: 288686
-                    login: jpopelka
-                    node_id: MDQ6VXNlcjI4ODY4Ng==
-                    organizations_url: https://api.github.com/users/jpopelka/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/jpopelka/received_events
-                    repos_url: https://api.github.com/users/jpopelka/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/jpopelka/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/jpopelka/subscriptions
-                    type: User
-                    url: https://api.github.com/users/jpopelka
-                  - avatar_url: https://avatars0.githubusercontent.com/u/1662493?v=4
-                    events_url: https://api.github.com/users/TomasTomecek/events{/privacy}
-                    followers_url: https://api.github.com/users/TomasTomecek/followers
-                    following_url: https://api.github.com/users/TomasTomecek/following{/other_user}
-                    gists_url: https://api.github.com/users/TomasTomecek/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/TomasTomecek
-                    id: 1662493
-                    login: TomasTomecek
-                    node_id: MDQ6VXNlcjE2NjI0OTM=
-                    organizations_url: https://api.github.com/users/TomasTomecek/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/TomasTomecek/received_events
-                    repos_url: https://api.github.com/users/TomasTomecek/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/TomasTomecek/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/TomasTomecek/subscriptions
-                    type: User
-                    url: https://api.github.com/users/TomasTomecek
-                  - avatar_url: https://avatars3.githubusercontent.com/u/1866652?v=4
-                    events_url: https://api.github.com/users/eliskasl/events{/privacy}
-                    followers_url: https://api.github.com/users/eliskasl/followers
-                    following_url: https://api.github.com/users/eliskasl/following{/other_user}
-                    gists_url: https://api.github.com/users/eliskasl/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/eliskasl
-                    id: 1866652
-                    login: eliskasl
-                    node_id: MDQ6VXNlcjE4NjY2NTI=
-                    organizations_url: https://api.github.com/users/eliskasl/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/eliskasl/received_events
-                    repos_url: https://api.github.com/users/eliskasl/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/eliskasl/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/eliskasl/subscriptions
-                    type: User
-                    url: https://api.github.com/users/eliskasl
-                  - avatar_url: https://avatars2.githubusercontent.com/u/3416672?v=4
-                    events_url: https://api.github.com/users/phracek/events{/privacy}
-                    followers_url: https://api.github.com/users/phracek/followers
-                    following_url: https://api.github.com/users/phracek/following{/other_user}
-                    gists_url: https://api.github.com/users/phracek/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/phracek
-                    id: 3416672
-                    login: phracek
-                    node_id: MDQ6VXNlcjM0MTY2NzI=
-                    organizations_url: https://api.github.com/users/phracek/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/phracek/received_events
-                    repos_url: https://api.github.com/users/phracek/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/phracek/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/phracek/subscriptions
-                    type: User
-                    url: https://api.github.com/users/phracek
-                  - avatar_url: https://avatars0.githubusercontent.com/u/8735467?v=4
-                    events_url: https://api.github.com/users/jscotka/events{/privacy}
-                    followers_url: https://api.github.com/users/jscotka/followers
-                    following_url: https://api.github.com/users/jscotka/following{/other_user}
-                    gists_url: https://api.github.com/users/jscotka/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/jscotka
-                    id: 8735467
-                    login: jscotka
-                    node_id: MDQ6VXNlcjg3MzU0Njc=
-                    organizations_url: https://api.github.com/users/jscotka/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/jscotka/received_events
-                    repos_url: https://api.github.com/users/jscotka/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/jscotka/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/jscotka/subscriptions
-                    type: User
-                    url: https://api.github.com/users/jscotka
-                  - avatar_url: https://avatars3.githubusercontent.com/u/17581559?v=4
-                    events_url: https://api.github.com/users/centos-ci/events{/privacy}
-                    followers_url: https://api.github.com/users/centos-ci/followers
-                    following_url: https://api.github.com/users/centos-ci/following{/other_user}
-                    gists_url: https://api.github.com/users/centos-ci/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/centos-ci
-                    id: 17581559
-                    login: centos-ci
-                    node_id: MDQ6VXNlcjE3NTgxNTU5
-                    organizations_url: https://api.github.com/users/centos-ci/orgs
-                    permissions:
-                      admin: false
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/centos-ci/received_events
-                    repos_url: https://api.github.com/users/centos-ci/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/centos-ci/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/centos-ci/subscriptions
-                    type: User
-                    url: https://api.github.com/users/centos-ci
-                  - avatar_url: https://avatars1.githubusercontent.com/u/20214043?v=4
-                    events_url: https://api.github.com/users/lachmanfrantisek/events{/privacy}
-                    followers_url: https://api.github.com/users/lachmanfrantisek/followers
-                    following_url: https://api.github.com/users/lachmanfrantisek/following{/other_user}
-                    gists_url: https://api.github.com/users/lachmanfrantisek/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/lachmanfrantisek
-                    id: 20214043
-                    login: lachmanfrantisek
-                    node_id: MDQ6VXNlcjIwMjE0MDQz
-                    organizations_url: https://api.github.com/users/lachmanfrantisek/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/lachmanfrantisek/received_events
-                    repos_url: https://api.github.com/users/lachmanfrantisek/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/lachmanfrantisek/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/lachmanfrantisek/subscriptions
-                    type: User
-                    url: https://api.github.com/users/lachmanfrantisek
-                  - avatar_url: https://avatars1.githubusercontent.com/u/25414049?v=4
-                    events_url: https://api.github.com/users/marusinm/events{/privacy}
-                    followers_url: https://api.github.com/users/marusinm/followers
-                    following_url: https://api.github.com/users/marusinm/following{/other_user}
-                    gists_url: https://api.github.com/users/marusinm/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/marusinm
-                    id: 25414049
-                    login: marusinm
-                    node_id: MDQ6VXNlcjI1NDE0MDQ5
-                    organizations_url: https://api.github.com/users/marusinm/orgs
-                    permissions:
-                      admin: false
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/marusinm/received_events
-                    repos_url: https://api.github.com/users/marusinm/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/marusinm/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/marusinm/subscriptions
-                    type: User
-                    url: https://api.github.com/users/marusinm
-                  - avatar_url: https://avatars3.githubusercontent.com/u/26160778?v=4
-                    events_url: https://api.github.com/users/rpitonak/events{/privacy}
-                    followers_url: https://api.github.com/users/rpitonak/followers
-                    following_url: https://api.github.com/users/rpitonak/following{/other_user}
-                    gists_url: https://api.github.com/users/rpitonak/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/rpitonak
-                    id: 26160778
-                    login: rpitonak
-                    node_id: MDQ6VXNlcjI2MTYwNzc4
-                    organizations_url: https://api.github.com/users/rpitonak/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/rpitonak/received_events
-                    repos_url: https://api.github.com/users/rpitonak/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/rpitonak/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/rpitonak/subscriptions
-                    type: User
-                    url: https://api.github.com/users/rpitonak
-                  - avatar_url: https://avatars2.githubusercontent.com/u/31201372?v=4
-                    events_url: https://api.github.com/users/dhodovsk/events{/privacy}
-                    followers_url: https://api.github.com/users/dhodovsk/followers
-                    following_url: https://api.github.com/users/dhodovsk/following{/other_user}
-                    gists_url: https://api.github.com/users/dhodovsk/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/dhodovsk
-                    id: 31201372
-                    login: dhodovsk
-                    node_id: MDQ6VXNlcjMxMjAxMzcy
-                    organizations_url: https://api.github.com/users/dhodovsk/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/dhodovsk/received_events
-                    repos_url: https://api.github.com/users/dhodovsk/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/dhodovsk/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/dhodovsk/subscriptions
-                    type: User
-                    url: https://api.github.com/users/dhodovsk
-                  - avatar_url: https://avatars1.githubusercontent.com/u/36231209?v=4
-                    events_url: https://api.github.com/users/usercont-release-bot/events{/privacy}
-                    followers_url: https://api.github.com/users/usercont-release-bot/followers
-                    following_url: https://api.github.com/users/usercont-release-bot/following{/other_user}
-                    gists_url: https://api.github.com/users/usercont-release-bot/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/usercont-release-bot
-                    id: 36231209
-                    login: usercont-release-bot
-                    node_id: MDQ6VXNlcjM2MjMxMjA5
-                    organizations_url: https://api.github.com/users/usercont-release-bot/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/usercont-release-bot/received_events
-                    repos_url: https://api.github.com/users/usercont-release-bot/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/usercont-release-bot/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/usercont-release-bot/subscriptions
-                    type: User
-                    url: https://api.github.com/users/usercont-release-bot
-                  - avatar_url: https://avatars3.githubusercontent.com/u/49026743?v=4
-                    events_url: https://api.github.com/users/lbarcziova/events{/privacy}
-                    followers_url: https://api.github.com/users/lbarcziova/followers
-                    following_url: https://api.github.com/users/lbarcziova/following{/other_user}
-                    gists_url: https://api.github.com/users/lbarcziova/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/lbarcziova
-                    id: 49026743
-                    login: lbarcziova
-                    node_id: MDQ6VXNlcjQ5MDI2NzQz
-                    organizations_url: https://api.github.com/users/lbarcziova/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/lbarcziova/received_events
-                    repos_url: https://api.github.com/users/lbarcziova/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/lbarcziova/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/lbarcziova/subscriptions
-                    type: User
-                    url: https://api.github.com/users/lbarcziova
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                  - avatar_url: https://avatars0.githubusercontent.com/u/288686?v=4
-                    events_url: https://api.github.com/users/jpopelka/events{/privacy}
-                    followers_url: https://api.github.com/users/jpopelka/followers
-                    following_url: https://api.github.com/users/jpopelka/following{/other_user}
-                    gists_url: https://api.github.com/users/jpopelka/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/jpopelka
-                    id: 288686
-                    login: jpopelka
-                    node_id: MDQ6VXNlcjI4ODY4Ng==
-                    organizations_url: https://api.github.com/users/jpopelka/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/jpopelka/received_events
-                    repos_url: https://api.github.com/users/jpopelka/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/jpopelka/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/jpopelka/subscriptions
-                    type: User
-                    url: https://api.github.com/users/jpopelka
-                  - avatar_url: https://avatars0.githubusercontent.com/u/1662493?v=4
-                    events_url: https://api.github.com/users/TomasTomecek/events{/privacy}
-                    followers_url: https://api.github.com/users/TomasTomecek/followers
-                    following_url: https://api.github.com/users/TomasTomecek/following{/other_user}
-                    gists_url: https://api.github.com/users/TomasTomecek/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/TomasTomecek
-                    id: 1662493
-                    login: TomasTomecek
-                    node_id: MDQ6VXNlcjE2NjI0OTM=
-                    organizations_url: https://api.github.com/users/TomasTomecek/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/TomasTomecek/received_events
-                    repos_url: https://api.github.com/users/TomasTomecek/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/TomasTomecek/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/TomasTomecek/subscriptions
-                    type: User
-                    url: https://api.github.com/users/TomasTomecek
-                  - avatar_url: https://avatars3.githubusercontent.com/u/1866652?v=4
-                    events_url: https://api.github.com/users/eliskasl/events{/privacy}
-                    followers_url: https://api.github.com/users/eliskasl/followers
-                    following_url: https://api.github.com/users/eliskasl/following{/other_user}
-                    gists_url: https://api.github.com/users/eliskasl/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/eliskasl
-                    id: 1866652
-                    login: eliskasl
-                    node_id: MDQ6VXNlcjE4NjY2NTI=
-                    organizations_url: https://api.github.com/users/eliskasl/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/eliskasl/received_events
-                    repos_url: https://api.github.com/users/eliskasl/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/eliskasl/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/eliskasl/subscriptions
-                    type: User
-                    url: https://api.github.com/users/eliskasl
-                  - avatar_url: https://avatars2.githubusercontent.com/u/3416672?v=4
-                    events_url: https://api.github.com/users/phracek/events{/privacy}
-                    followers_url: https://api.github.com/users/phracek/followers
-                    following_url: https://api.github.com/users/phracek/following{/other_user}
-                    gists_url: https://api.github.com/users/phracek/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/phracek
-                    id: 3416672
-                    login: phracek
-                    node_id: MDQ6VXNlcjM0MTY2NzI=
-                    organizations_url: https://api.github.com/users/phracek/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/phracek/received_events
-                    repos_url: https://api.github.com/users/phracek/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/phracek/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/phracek/subscriptions
-                    type: User
-                    url: https://api.github.com/users/phracek
-                  - avatar_url: https://avatars0.githubusercontent.com/u/8735467?v=4
-                    events_url: https://api.github.com/users/jscotka/events{/privacy}
-                    followers_url: https://api.github.com/users/jscotka/followers
-                    following_url: https://api.github.com/users/jscotka/following{/other_user}
-                    gists_url: https://api.github.com/users/jscotka/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/jscotka
-                    id: 8735467
-                    login: jscotka
-                    node_id: MDQ6VXNlcjg3MzU0Njc=
-                    organizations_url: https://api.github.com/users/jscotka/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/jscotka/received_events
-                    repos_url: https://api.github.com/users/jscotka/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/jscotka/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/jscotka/subscriptions
-                    type: User
-                    url: https://api.github.com/users/jscotka
-                  - avatar_url: https://avatars3.githubusercontent.com/u/17581559?v=4
-                    events_url: https://api.github.com/users/centos-ci/events{/privacy}
-                    followers_url: https://api.github.com/users/centos-ci/followers
-                    following_url: https://api.github.com/users/centos-ci/following{/other_user}
-                    gists_url: https://api.github.com/users/centos-ci/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/centos-ci
-                    id: 17581559
-                    login: centos-ci
-                    node_id: MDQ6VXNlcjE3NTgxNTU5
-                    organizations_url: https://api.github.com/users/centos-ci/orgs
-                    permissions:
-                      admin: false
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/centos-ci/received_events
-                    repos_url: https://api.github.com/users/centos-ci/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/centos-ci/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/centos-ci/subscriptions
-                    type: User
-                    url: https://api.github.com/users/centos-ci
-                  - avatar_url: https://avatars1.githubusercontent.com/u/20214043?v=4
-                    events_url: https://api.github.com/users/lachmanfrantisek/events{/privacy}
-                    followers_url: https://api.github.com/users/lachmanfrantisek/followers
-                    following_url: https://api.github.com/users/lachmanfrantisek/following{/other_user}
-                    gists_url: https://api.github.com/users/lachmanfrantisek/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/lachmanfrantisek
-                    id: 20214043
-                    login: lachmanfrantisek
-                    node_id: MDQ6VXNlcjIwMjE0MDQz
-                    organizations_url: https://api.github.com/users/lachmanfrantisek/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/lachmanfrantisek/received_events
-                    repos_url: https://api.github.com/users/lachmanfrantisek/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/lachmanfrantisek/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/lachmanfrantisek/subscriptions
-                    type: User
-                    url: https://api.github.com/users/lachmanfrantisek
-                  - avatar_url: https://avatars1.githubusercontent.com/u/25414049?v=4
-                    events_url: https://api.github.com/users/marusinm/events{/privacy}
-                    followers_url: https://api.github.com/users/marusinm/followers
-                    following_url: https://api.github.com/users/marusinm/following{/other_user}
-                    gists_url: https://api.github.com/users/marusinm/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/marusinm
-                    id: 25414049
-                    login: marusinm
-                    node_id: MDQ6VXNlcjI1NDE0MDQ5
-                    organizations_url: https://api.github.com/users/marusinm/orgs
-                    permissions:
-                      admin: false
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/marusinm/received_events
-                    repos_url: https://api.github.com/users/marusinm/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/marusinm/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/marusinm/subscriptions
-                    type: User
-                    url: https://api.github.com/users/marusinm
-                  - avatar_url: https://avatars3.githubusercontent.com/u/26160778?v=4
-                    events_url: https://api.github.com/users/rpitonak/events{/privacy}
-                    followers_url: https://api.github.com/users/rpitonak/followers
-                    following_url: https://api.github.com/users/rpitonak/following{/other_user}
-                    gists_url: https://api.github.com/users/rpitonak/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/rpitonak
-                    id: 26160778
-                    login: rpitonak
-                    node_id: MDQ6VXNlcjI2MTYwNzc4
-                    organizations_url: https://api.github.com/users/rpitonak/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/rpitonak/received_events
-                    repos_url: https://api.github.com/users/rpitonak/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/rpitonak/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/rpitonak/subscriptions
-                    type: User
-                    url: https://api.github.com/users/rpitonak
-                  - avatar_url: https://avatars2.githubusercontent.com/u/31201372?v=4
-                    events_url: https://api.github.com/users/dhodovsk/events{/privacy}
-                    followers_url: https://api.github.com/users/dhodovsk/followers
-                    following_url: https://api.github.com/users/dhodovsk/following{/other_user}
-                    gists_url: https://api.github.com/users/dhodovsk/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/dhodovsk
-                    id: 31201372
-                    login: dhodovsk
-                    node_id: MDQ6VXNlcjMxMjAxMzcy
-                    organizations_url: https://api.github.com/users/dhodovsk/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/dhodovsk/received_events
-                    repos_url: https://api.github.com/users/dhodovsk/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/dhodovsk/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/dhodovsk/subscriptions
-                    type: User
-                    url: https://api.github.com/users/dhodovsk
-                  - avatar_url: https://avatars1.githubusercontent.com/u/36231209?v=4
-                    events_url: https://api.github.com/users/usercont-release-bot/events{/privacy}
-                    followers_url: https://api.github.com/users/usercont-release-bot/followers
-                    following_url: https://api.github.com/users/usercont-release-bot/following{/other_user}
-                    gists_url: https://api.github.com/users/usercont-release-bot/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/usercont-release-bot
-                    id: 36231209
-                    login: usercont-release-bot
-                    node_id: MDQ6VXNlcjM2MjMxMjA5
-                    organizations_url: https://api.github.com/users/usercont-release-bot/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/usercont-release-bot/received_events
-                    repos_url: https://api.github.com/users/usercont-release-bot/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/usercont-release-bot/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/usercont-release-bot/subscriptions
-                    type: User
-                    url: https://api.github.com/users/usercont-release-bot
-                  - avatar_url: https://avatars3.githubusercontent.com/u/49026743?v=4
-                    events_url: https://api.github.com/users/lbarcziova/events{/privacy}
-                    followers_url: https://api.github.com/users/lbarcziova/followers
-                    following_url: https://api.github.com/users/lbarcziova/following{/other_user}
-                    gists_url: https://api.github.com/users/lbarcziova/gists{/gist_id}
-                    gravatar_id: ''
-                    html_url: https://github.com/lbarcziova
-                    id: 49026743
-                    login: lbarcziova
-                    node_id: MDQ6VXNlcjQ5MDI2NzQz
-                    organizations_url: https://api.github.com/users/lbarcziova/orgs
-                    permissions:
-                      admin: true
-                      pull: true
-                      push: true
-                    received_events_url: https://api.github.com/users/lbarcziova/received_events
-                    repos_url: https://api.github.com/users/lbarcziova/repos
-                    site_admin: false
-                    starred_url: https://api.github.com/users/lbarcziova/starred{/owner}{/repo}
-                    subscriptions_url: https://api.github.com/users/lbarcziova/subscriptions
-                    type: User
-                    url: https://api.github.com/users/lbarcziova
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
+                - metadata:
+                    latency: 0.6889429092407227
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_github
+                    - ogr.services.github.project
+                    - github.PaginatedList
+                    - github.Requester
+                    - requests.sessions
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                    - avatar_url: https://avatars0.githubusercontent.com/u/288686?v=4
+                      events_url: https://api.github.com/users/jpopelka/events{/privacy}
+                      followers_url: https://api.github.com/users/jpopelka/followers
+                      following_url: https://api.github.com/users/jpopelka/following{/other_user}
+                      gists_url: https://api.github.com/users/jpopelka/gists{/gist_id}
+                      gravatar_id: ''
+                      html_url: https://github.com/jpopelka
+                      id: 288686
+                      login: jpopelka
+                      node_id: MDQ6VXNlcjI4ODY4Ng==
+                      organizations_url: https://api.github.com/users/jpopelka/orgs
+                      permissions:
+                        admin: true
+                        pull: true
+                        push: true
+                      received_events_url: https://api.github.com/users/jpopelka/received_events
+                      repos_url: https://api.github.com/users/jpopelka/repos
+                      site_admin: false
+                      starred_url: https://api.github.com/users/jpopelka/starred{/owner}{/repo}
+                      subscriptions_url: https://api.github.com/users/jpopelka/subscriptions
+                      type: User
+                      url: https://api.github.com/users/jpopelka
+                    - avatar_url: https://avatars1.githubusercontent.com/u/633969?v=4
+                      events_url: https://api.github.com/users/thrix/events{/privacy}
+                      followers_url: https://api.github.com/users/thrix/followers
+                      following_url: https://api.github.com/users/thrix/following{/other_user}
+                      gists_url: https://api.github.com/users/thrix/gists{/gist_id}
+                      gravatar_id: ''
+                      html_url: https://github.com/thrix
+                      id: 633969
+                      login: thrix
+                      node_id: MDQ6VXNlcjYzMzk2OQ==
+                      organizations_url: https://api.github.com/users/thrix/orgs
+                      permissions:
+                        admin: true
+                        pull: true
+                        push: true
+                      received_events_url: https://api.github.com/users/thrix/received_events
+                      repos_url: https://api.github.com/users/thrix/repos
+                      site_admin: false
+                      starred_url: https://api.github.com/users/thrix/starred{/owner}{/repo}
+                      subscriptions_url: https://api.github.com/users/thrix/subscriptions
+                      type: User
+                      url: https://api.github.com/users/thrix
+                    - avatar_url: https://avatars0.githubusercontent.com/u/1662493?v=4
+                      events_url: https://api.github.com/users/TomasTomecek/events{/privacy}
+                      followers_url: https://api.github.com/users/TomasTomecek/followers
+                      following_url: https://api.github.com/users/TomasTomecek/following{/other_user}
+                      gists_url: https://api.github.com/users/TomasTomecek/gists{/gist_id}
+                      gravatar_id: ''
+                      html_url: https://github.com/TomasTomecek
+                      id: 1662493
+                      login: TomasTomecek
+                      node_id: MDQ6VXNlcjE2NjI0OTM=
+                      organizations_url: https://api.github.com/users/TomasTomecek/orgs
+                      permissions:
+                        admin: true
+                        pull: true
+                        push: true
+                      received_events_url: https://api.github.com/users/TomasTomecek/received_events
+                      repos_url: https://api.github.com/users/TomasTomecek/repos
+                      site_admin: false
+                      starred_url: https://api.github.com/users/TomasTomecek/starred{/owner}{/repo}
+                      subscriptions_url: https://api.github.com/users/TomasTomecek/subscriptions
+                      type: User
+                      url: https://api.github.com/users/TomasTomecek
+                    - avatar_url: https://avatars3.githubusercontent.com/u/1866652?v=4
+                      events_url: https://api.github.com/users/eliskasl/events{/privacy}
+                      followers_url: https://api.github.com/users/eliskasl/followers
+                      following_url: https://api.github.com/users/eliskasl/following{/other_user}
+                      gists_url: https://api.github.com/users/eliskasl/gists{/gist_id}
+                      gravatar_id: ''
+                      html_url: https://github.com/eliskasl
+                      id: 1866652
+                      login: eliskasl
+                      node_id: MDQ6VXNlcjE4NjY2NTI=
+                      organizations_url: https://api.github.com/users/eliskasl/orgs
+                      permissions:
+                        admin: true
+                        pull: true
+                        push: true
+                      received_events_url: https://api.github.com/users/eliskasl/received_events
+                      repos_url: https://api.github.com/users/eliskasl/repos
+                      site_admin: false
+                      starred_url: https://api.github.com/users/eliskasl/starred{/owner}{/repo}
+                      subscriptions_url: https://api.github.com/users/eliskasl/subscriptions
+                      type: User
+                      url: https://api.github.com/users/eliskasl
+                    - avatar_url: https://avatars2.githubusercontent.com/u/2803150?v=4
+                      events_url: https://api.github.com/users/psss/events{/privacy}
+                      followers_url: https://api.github.com/users/psss/followers
+                      following_url: https://api.github.com/users/psss/following{/other_user}
+                      gists_url: https://api.github.com/users/psss/gists{/gist_id}
+                      gravatar_id: ''
+                      html_url: https://github.com/psss
+                      id: 2803150
+                      login: psss
+                      node_id: MDQ6VXNlcjI4MDMxNTA=
+                      organizations_url: https://api.github.com/users/psss/orgs
+                      permissions:
+                        admin: true
+                        pull: true
+                        push: true
+                      received_events_url: https://api.github.com/users/psss/received_events
+                      repos_url: https://api.github.com/users/psss/repos
+                      site_admin: false
+                      starred_url: https://api.github.com/users/psss/starred{/owner}{/repo}
+                      subscriptions_url: https://api.github.com/users/psss/subscriptions
+                      type: User
+                      url: https://api.github.com/users/psss
+                    - avatar_url: https://avatars2.githubusercontent.com/u/7654857?v=4
+                      events_url: https://api.github.com/users/sakalosj/events{/privacy}
+                      followers_url: https://api.github.com/users/sakalosj/followers
+                      following_url: https://api.github.com/users/sakalosj/following{/other_user}
+                      gists_url: https://api.github.com/users/sakalosj/gists{/gist_id}
+                      gravatar_id: ''
+                      html_url: https://github.com/sakalosj
+                      id: 7654857
+                      login: sakalosj
+                      node_id: MDQ6VXNlcjc2NTQ4NTc=
+                      organizations_url: https://api.github.com/users/sakalosj/orgs
+                      permissions:
+                        admin: true
+                        pull: true
+                        push: true
+                      received_events_url: https://api.github.com/users/sakalosj/received_events
+                      repos_url: https://api.github.com/users/sakalosj/repos
+                      site_admin: false
+                      starred_url: https://api.github.com/users/sakalosj/starred{/owner}{/repo}
+                      subscriptions_url: https://api.github.com/users/sakalosj/subscriptions
+                      type: User
+                      url: https://api.github.com/users/sakalosj
+                    - avatar_url: https://avatars0.githubusercontent.com/u/8149784?v=4
+                      events_url: https://api.github.com/users/mfocko/events{/privacy}
+                      followers_url: https://api.github.com/users/mfocko/followers
+                      following_url: https://api.github.com/users/mfocko/following{/other_user}
+                      gists_url: https://api.github.com/users/mfocko/gists{/gist_id}
+                      gravatar_id: ''
+                      html_url: https://github.com/mfocko
+                      id: 8149784
+                      login: mfocko
+                      node_id: MDQ6VXNlcjgxNDk3ODQ=
+                      organizations_url: https://api.github.com/users/mfocko/orgs
+                      permissions:
+                        admin: true
+                        pull: true
+                        push: true
+                      received_events_url: https://api.github.com/users/mfocko/received_events
+                      repos_url: https://api.github.com/users/mfocko/repos
+                      site_admin: false
+                      starred_url: https://api.github.com/users/mfocko/starred{/owner}{/repo}
+                      subscriptions_url: https://api.github.com/users/mfocko/subscriptions
+                      type: User
+                      url: https://api.github.com/users/mfocko
+                    - avatar_url: https://avatars0.githubusercontent.com/u/8735467?v=4
+                      events_url: https://api.github.com/users/jscotka/events{/privacy}
+                      followers_url: https://api.github.com/users/jscotka/followers
+                      following_url: https://api.github.com/users/jscotka/following{/other_user}
+                      gists_url: https://api.github.com/users/jscotka/gists{/gist_id}
+                      gravatar_id: ''
+                      html_url: https://github.com/jscotka
+                      id: 8735467
+                      login: jscotka
+                      node_id: MDQ6VXNlcjg3MzU0Njc=
+                      organizations_url: https://api.github.com/users/jscotka/orgs
+                      permissions:
+                        admin: true
+                        pull: true
+                        push: true
+                      received_events_url: https://api.github.com/users/jscotka/received_events
+                      repos_url: https://api.github.com/users/jscotka/repos
+                      site_admin: false
+                      starred_url: https://api.github.com/users/jscotka/starred{/owner}{/repo}
+                      subscriptions_url: https://api.github.com/users/jscotka/subscriptions
+                      type: User
+                      url: https://api.github.com/users/jscotka
+                    - avatar_url: https://avatars0.githubusercontent.com/u/11816497?v=4
+                      events_url: https://api.github.com/users/csomh/events{/privacy}
+                      followers_url: https://api.github.com/users/csomh/followers
+                      following_url: https://api.github.com/users/csomh/following{/other_user}
+                      gists_url: https://api.github.com/users/csomh/gists{/gist_id}
+                      gravatar_id: ''
+                      html_url: https://github.com/csomh
+                      id: 11816497
+                      login: csomh
+                      node_id: MDQ6VXNlcjExODE2NDk3
+                      organizations_url: https://api.github.com/users/csomh/orgs
+                      permissions:
+                        admin: true
+                        pull: true
+                        push: true
+                      received_events_url: https://api.github.com/users/csomh/received_events
+                      repos_url: https://api.github.com/users/csomh/repos
+                      site_admin: false
+                      starred_url: https://api.github.com/users/csomh/starred{/owner}{/repo}
+                      subscriptions_url: https://api.github.com/users/csomh/subscriptions
+                      type: User
+                      url: https://api.github.com/users/csomh
+                    - avatar_url: https://avatars3.githubusercontent.com/u/17581559?v=4
+                      events_url: https://api.github.com/users/centos-ci/events{/privacy}
+                      followers_url: https://api.github.com/users/centos-ci/followers
+                      following_url: https://api.github.com/users/centos-ci/following{/other_user}
+                      gists_url: https://api.github.com/users/centos-ci/gists{/gist_id}
+                      gravatar_id: ''
+                      html_url: https://github.com/centos-ci
+                      id: 17581559
+                      login: centos-ci
+                      node_id: MDQ6VXNlcjE3NTgxNTU5
+                      organizations_url: https://api.github.com/users/centos-ci/orgs
+                      permissions:
+                        admin: false
+                        pull: true
+                        push: true
+                      received_events_url: https://api.github.com/users/centos-ci/received_events
+                      repos_url: https://api.github.com/users/centos-ci/repos
+                      site_admin: false
+                      starred_url: https://api.github.com/users/centos-ci/starred{/owner}{/repo}
+                      subscriptions_url: https://api.github.com/users/centos-ci/subscriptions
+                      type: User
+                      url: https://api.github.com/users/centos-ci
+                    - avatar_url: https://avatars1.githubusercontent.com/u/20214043?v=4
+                      events_url: https://api.github.com/users/lachmanfrantisek/events{/privacy}
+                      followers_url: https://api.github.com/users/lachmanfrantisek/followers
+                      following_url: https://api.github.com/users/lachmanfrantisek/following{/other_user}
+                      gists_url: https://api.github.com/users/lachmanfrantisek/gists{/gist_id}
+                      gravatar_id: ''
+                      html_url: https://github.com/lachmanfrantisek
+                      id: 20214043
+                      login: lachmanfrantisek
+                      node_id: MDQ6VXNlcjIwMjE0MDQz
+                      organizations_url: https://api.github.com/users/lachmanfrantisek/orgs
+                      permissions:
+                        admin: true
+                        pull: true
+                        push: true
+                      received_events_url: https://api.github.com/users/lachmanfrantisek/received_events
+                      repos_url: https://api.github.com/users/lachmanfrantisek/repos
+                      site_admin: false
+                      starred_url: https://api.github.com/users/lachmanfrantisek/starred{/owner}{/repo}
+                      subscriptions_url: https://api.github.com/users/lachmanfrantisek/subscriptions
+                      type: User
+                      url: https://api.github.com/users/lachmanfrantisek
+                    - avatar_url: https://avatars1.githubusercontent.com/u/25414049?v=4
+                      events_url: https://api.github.com/users/marusinm/events{/privacy}
+                      followers_url: https://api.github.com/users/marusinm/followers
+                      following_url: https://api.github.com/users/marusinm/following{/other_user}
+                      gists_url: https://api.github.com/users/marusinm/gists{/gist_id}
+                      gravatar_id: ''
+                      html_url: https://github.com/marusinm
+                      id: 25414049
+                      login: marusinm
+                      node_id: MDQ6VXNlcjI1NDE0MDQ5
+                      organizations_url: https://api.github.com/users/marusinm/orgs
+                      permissions:
+                        admin: false
+                        pull: true
+                        push: true
+                      received_events_url: https://api.github.com/users/marusinm/received_events
+                      repos_url: https://api.github.com/users/marusinm/repos
+                      site_admin: false
+                      starred_url: https://api.github.com/users/marusinm/starred{/owner}{/repo}
+                      subscriptions_url: https://api.github.com/users/marusinm/subscriptions
+                      type: User
+                      url: https://api.github.com/users/marusinm
+                    - avatar_url: https://avatars2.githubusercontent.com/u/31201372?v=4
+                      events_url: https://api.github.com/users/dhodovsk/events{/privacy}
+                      followers_url: https://api.github.com/users/dhodovsk/followers
+                      following_url: https://api.github.com/users/dhodovsk/following{/other_user}
+                      gists_url: https://api.github.com/users/dhodovsk/gists{/gist_id}
+                      gravatar_id: ''
+                      html_url: https://github.com/dhodovsk
+                      id: 31201372
+                      login: dhodovsk
+                      node_id: MDQ6VXNlcjMxMjAxMzcy
+                      organizations_url: https://api.github.com/users/dhodovsk/orgs
+                      permissions:
+                        admin: true
+                        pull: true
+                        push: true
+                      received_events_url: https://api.github.com/users/dhodovsk/received_events
+                      repos_url: https://api.github.com/users/dhodovsk/repos
+                      site_admin: false
+                      starred_url: https://api.github.com/users/dhodovsk/starred{/owner}{/repo}
+                      subscriptions_url: https://api.github.com/users/dhodovsk/subscriptions
+                      type: User
+                      url: https://api.github.com/users/dhodovsk
+                    - avatar_url: https://avatars1.githubusercontent.com/u/36231209?v=4
+                      events_url: https://api.github.com/users/usercont-release-bot/events{/privacy}
+                      followers_url: https://api.github.com/users/usercont-release-bot/followers
+                      following_url: https://api.github.com/users/usercont-release-bot/following{/other_user}
+                      gists_url: https://api.github.com/users/usercont-release-bot/gists{/gist_id}
+                      gravatar_id: ''
+                      html_url: https://github.com/usercont-release-bot
+                      id: 36231209
+                      login: usercont-release-bot
+                      node_id: MDQ6VXNlcjM2MjMxMjA5
+                      organizations_url: https://api.github.com/users/usercont-release-bot/orgs
+                      permissions:
+                        admin: true
+                        pull: true
+                        push: true
+                      received_events_url: https://api.github.com/users/usercont-release-bot/received_events
+                      repos_url: https://api.github.com/users/usercont-release-bot/repos
+                      site_admin: false
+                      starred_url: https://api.github.com/users/usercont-release-bot/starred{/owner}{/repo}
+                      subscriptions_url: https://api.github.com/users/usercont-release-bot/subscriptions
+                      type: User
+                      url: https://api.github.com/users/usercont-release-bot
+                    - avatar_url: https://avatars3.githubusercontent.com/u/49026743?v=4
+                      events_url: https://api.github.com/users/lbarcziova/events{/privacy}
+                      followers_url: https://api.github.com/users/lbarcziova/followers
+                      following_url: https://api.github.com/users/lbarcziova/following{/other_user}
+                      gists_url: https://api.github.com/users/lbarcziova/gists{/gist_id}
+                      gravatar_id: ''
+                      html_url: https://github.com/lbarcziova
+                      id: 49026743
+                      login: lbarcziova
+                      node_id: MDQ6VXNlcjQ5MDI2NzQz
+                      organizations_url: https://api.github.com/users/lbarcziova/orgs
+                      permissions:
+                        admin: true
+                        pull: true
+                        push: true
+                      received_events_url: https://api.github.com/users/lbarcziova/received_events
+                      repos_url: https://api.github.com/users/lbarcziova/repos
+                      site_admin: false
+                      starred_url: https://api.github.com/users/lbarcziova/starred{/owner}{/repo}
+                      subscriptions_url: https://api.github.com/users/lbarcziova/subscriptions
+                      type: User
+                      url: https://api.github.com/users/lbarcziova
+                    _next: null
+                    elapsed: 0.2
+                    encoding: utf-8
+                    headers:
+                      Access-Control-Allow-Origin: '*'
+                      Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                        X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+                        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+                        X-GitHub-Media-Type, Deprecation, Sunset
+                      Cache-Control: private, max-age=60, s-maxage=60
+                      Content-Encoding: gzip
+                      Content-Security-Policy: default-src 'none'
+                      Content-Type: application/json; charset=utf-8
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                      Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                      Server: GitHub.com
+                      Status: 200 OK
+                      Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                        preload
+                      Transfer-Encoding: chunked
+                      Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                        Accept, X-Requested-With
+                      X-Accepted-OAuth-Scopes: ''
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: deny
+                      X-GitHub-Media-Type: github.v3; format=json
+                      X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                      X-OAuth-Scopes: admin:org, repo
+                      X-RateLimit-Limit: '5000'
+                      X-RateLimit-Remaining: '4972'
+                      X-RateLimit-Reset: '1572953901'
+                      X-XSS-Protection: 1; mode=block
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
       github.Repository:
         github.Requester:
           requests.sessions:
             requre.objects:
               requests.sessions:
                 send:
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars0.githubusercontent.com/u/288686?v=4
-                      events_url: https://api.github.com/users/jpopelka/events{/privacy}
-                      followers_url: https://api.github.com/users/jpopelka/followers
-                      following_url: https://api.github.com/users/jpopelka/following{/other_user}
-                      gists_url: https://api.github.com/users/jpopelka/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/jpopelka
-                      id: 288686
-                      login: jpopelka
-                      node_id: MDQ6VXNlcjI4ODY4Ng==
-                      organizations_url: https://api.github.com/users/jpopelka/orgs
-                      received_events_url: https://api.github.com/users/jpopelka/received_events
-                      repos_url: https://api.github.com/users/jpopelka/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/jpopelka/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/jpopelka/subscriptions
-                      type: User
-                      url: https://api.github.com/users/jpopelka
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars0.githubusercontent.com/u/1662493?v=4
-                      events_url: https://api.github.com/users/TomasTomecek/events{/privacy}
-                      followers_url: https://api.github.com/users/TomasTomecek/followers
-                      following_url: https://api.github.com/users/TomasTomecek/following{/other_user}
-                      gists_url: https://api.github.com/users/TomasTomecek/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/TomasTomecek
-                      id: 1662493
-                      login: TomasTomecek
-                      node_id: MDQ6VXNlcjE2NjI0OTM=
-                      organizations_url: https://api.github.com/users/TomasTomecek/orgs
-                      received_events_url: https://api.github.com/users/TomasTomecek/received_events
-                      repos_url: https://api.github.com/users/TomasTomecek/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/TomasTomecek/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/TomasTomecek/subscriptions
-                      type: User
-                      url: https://api.github.com/users/TomasTomecek
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars3.githubusercontent.com/u/1866652?v=4
-                      events_url: https://api.github.com/users/eliskasl/events{/privacy}
-                      followers_url: https://api.github.com/users/eliskasl/followers
-                      following_url: https://api.github.com/users/eliskasl/following{/other_user}
-                      gists_url: https://api.github.com/users/eliskasl/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/eliskasl
-                      id: 1866652
-                      login: eliskasl
-                      node_id: MDQ6VXNlcjE4NjY2NTI=
-                      organizations_url: https://api.github.com/users/eliskasl/orgs
-                      received_events_url: https://api.github.com/users/eliskasl/received_events
-                      repos_url: https://api.github.com/users/eliskasl/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/eliskasl/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/eliskasl/subscriptions
-                      type: User
-                      url: https://api.github.com/users/eliskasl
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars2.githubusercontent.com/u/3416672?v=4
-                      events_url: https://api.github.com/users/phracek/events{/privacy}
-                      followers_url: https://api.github.com/users/phracek/followers
-                      following_url: https://api.github.com/users/phracek/following{/other_user}
-                      gists_url: https://api.github.com/users/phracek/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/phracek
-                      id: 3416672
-                      login: phracek
-                      node_id: MDQ6VXNlcjM0MTY2NzI=
-                      organizations_url: https://api.github.com/users/phracek/orgs
-                      received_events_url: https://api.github.com/users/phracek/received_events
-                      repos_url: https://api.github.com/users/phracek/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/phracek/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/phracek/subscriptions
-                      type: User
-                      url: https://api.github.com/users/phracek
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars0.githubusercontent.com/u/8735467?v=4
-                      events_url: https://api.github.com/users/jscotka/events{/privacy}
-                      followers_url: https://api.github.com/users/jscotka/followers
-                      following_url: https://api.github.com/users/jscotka/following{/other_user}
-                      gists_url: https://api.github.com/users/jscotka/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/jscotka
-                      id: 8735467
-                      login: jscotka
-                      node_id: MDQ6VXNlcjg3MzU0Njc=
-                      organizations_url: https://api.github.com/users/jscotka/orgs
-                      received_events_url: https://api.github.com/users/jscotka/received_events
-                      repos_url: https://api.github.com/users/jscotka/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/jscotka/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/jscotka/subscriptions
-                      type: User
-                      url: https://api.github.com/users/jscotka
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: write
-                    user:
-                      avatar_url: https://avatars3.githubusercontent.com/u/17581559?v=4
-                      events_url: https://api.github.com/users/centos-ci/events{/privacy}
-                      followers_url: https://api.github.com/users/centos-ci/followers
-                      following_url: https://api.github.com/users/centos-ci/following{/other_user}
-                      gists_url: https://api.github.com/users/centos-ci/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/centos-ci
-                      id: 17581559
-                      login: centos-ci
-                      node_id: MDQ6VXNlcjE3NTgxNTU5
-                      organizations_url: https://api.github.com/users/centos-ci/orgs
-                      received_events_url: https://api.github.com/users/centos-ci/received_events
-                      repos_url: https://api.github.com/users/centos-ci/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/centos-ci/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/centos-ci/subscriptions
-                      type: User
-                      url: https://api.github.com/users/centos-ci
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars1.githubusercontent.com/u/20214043?v=4
-                      events_url: https://api.github.com/users/lachmanfrantisek/events{/privacy}
-                      followers_url: https://api.github.com/users/lachmanfrantisek/followers
-                      following_url: https://api.github.com/users/lachmanfrantisek/following{/other_user}
-                      gists_url: https://api.github.com/users/lachmanfrantisek/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/lachmanfrantisek
-                      id: 20214043
-                      login: lachmanfrantisek
-                      node_id: MDQ6VXNlcjIwMjE0MDQz
-                      organizations_url: https://api.github.com/users/lachmanfrantisek/orgs
-                      received_events_url: https://api.github.com/users/lachmanfrantisek/received_events
-                      repos_url: https://api.github.com/users/lachmanfrantisek/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/lachmanfrantisek/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/lachmanfrantisek/subscriptions
-                      type: User
-                      url: https://api.github.com/users/lachmanfrantisek
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: write
-                    user:
-                      avatar_url: https://avatars1.githubusercontent.com/u/25414049?v=4
-                      events_url: https://api.github.com/users/marusinm/events{/privacy}
-                      followers_url: https://api.github.com/users/marusinm/followers
-                      following_url: https://api.github.com/users/marusinm/following{/other_user}
-                      gists_url: https://api.github.com/users/marusinm/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/marusinm
-                      id: 25414049
-                      login: marusinm
-                      node_id: MDQ6VXNlcjI1NDE0MDQ5
-                      organizations_url: https://api.github.com/users/marusinm/orgs
-                      received_events_url: https://api.github.com/users/marusinm/received_events
-                      repos_url: https://api.github.com/users/marusinm/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/marusinm/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/marusinm/subscriptions
-                      type: User
-                      url: https://api.github.com/users/marusinm
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars3.githubusercontent.com/u/26160778?v=4
-                      events_url: https://api.github.com/users/rpitonak/events{/privacy}
-                      followers_url: https://api.github.com/users/rpitonak/followers
-                      following_url: https://api.github.com/users/rpitonak/following{/other_user}
-                      gists_url: https://api.github.com/users/rpitonak/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/rpitonak
-                      id: 26160778
-                      login: rpitonak
-                      node_id: MDQ6VXNlcjI2MTYwNzc4
-                      organizations_url: https://api.github.com/users/rpitonak/orgs
-                      received_events_url: https://api.github.com/users/rpitonak/received_events
-                      repos_url: https://api.github.com/users/rpitonak/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/rpitonak/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/rpitonak/subscriptions
-                      type: User
-                      url: https://api.github.com/users/rpitonak
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars2.githubusercontent.com/u/31201372?v=4
-                      events_url: https://api.github.com/users/dhodovsk/events{/privacy}
-                      followers_url: https://api.github.com/users/dhodovsk/followers
-                      following_url: https://api.github.com/users/dhodovsk/following{/other_user}
-                      gists_url: https://api.github.com/users/dhodovsk/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/dhodovsk
-                      id: 31201372
-                      login: dhodovsk
-                      node_id: MDQ6VXNlcjMxMjAxMzcy
-                      organizations_url: https://api.github.com/users/dhodovsk/orgs
-                      received_events_url: https://api.github.com/users/dhodovsk/received_events
-                      repos_url: https://api.github.com/users/dhodovsk/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/dhodovsk/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/dhodovsk/subscriptions
-                      type: User
-                      url: https://api.github.com/users/dhodovsk
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars1.githubusercontent.com/u/36231209?v=4
-                      events_url: https://api.github.com/users/usercont-release-bot/events{/privacy}
-                      followers_url: https://api.github.com/users/usercont-release-bot/followers
-                      following_url: https://api.github.com/users/usercont-release-bot/following{/other_user}
-                      gists_url: https://api.github.com/users/usercont-release-bot/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/usercont-release-bot
-                      id: 36231209
-                      login: usercont-release-bot
-                      node_id: MDQ6VXNlcjM2MjMxMjA5
-                      organizations_url: https://api.github.com/users/usercont-release-bot/orgs
-                      received_events_url: https://api.github.com/users/usercont-release-bot/received_events
-                      repos_url: https://api.github.com/users/usercont-release-bot/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/usercont-release-bot/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/usercont-release-bot/subscriptions
-                      type: User
-                      url: https://api.github.com/users/usercont-release-bot
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars3.githubusercontent.com/u/49026743?v=4
-                      events_url: https://api.github.com/users/lbarcziova/events{/privacy}
-                      followers_url: https://api.github.com/users/lbarcziova/followers
-                      following_url: https://api.github.com/users/lbarcziova/following{/other_user}
-                      gists_url: https://api.github.com/users/lbarcziova/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/lbarcziova
-                      id: 49026743
-                      login: lbarcziova
-                      node_id: MDQ6VXNlcjQ5MDI2NzQz
-                      organizations_url: https://api.github.com/users/lbarcziova/orgs
-                      received_events_url: https://api.github.com/users/lbarcziova/received_events
-                      repos_url: https://api.github.com/users/lbarcziova/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/lbarcziova/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/lbarcziova/subscriptions
-                      type: User
-                      url: https://api.github.com/users/lbarcziova
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars0.githubusercontent.com/u/288686?v=4
-                      events_url: https://api.github.com/users/jpopelka/events{/privacy}
-                      followers_url: https://api.github.com/users/jpopelka/followers
-                      following_url: https://api.github.com/users/jpopelka/following{/other_user}
-                      gists_url: https://api.github.com/users/jpopelka/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/jpopelka
-                      id: 288686
-                      login: jpopelka
-                      node_id: MDQ6VXNlcjI4ODY4Ng==
-                      organizations_url: https://api.github.com/users/jpopelka/orgs
-                      received_events_url: https://api.github.com/users/jpopelka/received_events
-                      repos_url: https://api.github.com/users/jpopelka/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/jpopelka/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/jpopelka/subscriptions
-                      type: User
-                      url: https://api.github.com/users/jpopelka
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars0.githubusercontent.com/u/1662493?v=4
-                      events_url: https://api.github.com/users/TomasTomecek/events{/privacy}
-                      followers_url: https://api.github.com/users/TomasTomecek/followers
-                      following_url: https://api.github.com/users/TomasTomecek/following{/other_user}
-                      gists_url: https://api.github.com/users/TomasTomecek/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/TomasTomecek
-                      id: 1662493
-                      login: TomasTomecek
-                      node_id: MDQ6VXNlcjE2NjI0OTM=
-                      organizations_url: https://api.github.com/users/TomasTomecek/orgs
-                      received_events_url: https://api.github.com/users/TomasTomecek/received_events
-                      repos_url: https://api.github.com/users/TomasTomecek/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/TomasTomecek/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/TomasTomecek/subscriptions
-                      type: User
-                      url: https://api.github.com/users/TomasTomecek
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars3.githubusercontent.com/u/1866652?v=4
-                      events_url: https://api.github.com/users/eliskasl/events{/privacy}
-                      followers_url: https://api.github.com/users/eliskasl/followers
-                      following_url: https://api.github.com/users/eliskasl/following{/other_user}
-                      gists_url: https://api.github.com/users/eliskasl/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/eliskasl
-                      id: 1866652
-                      login: eliskasl
-                      node_id: MDQ6VXNlcjE4NjY2NTI=
-                      organizations_url: https://api.github.com/users/eliskasl/orgs
-                      received_events_url: https://api.github.com/users/eliskasl/received_events
-                      repos_url: https://api.github.com/users/eliskasl/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/eliskasl/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/eliskasl/subscriptions
-                      type: User
-                      url: https://api.github.com/users/eliskasl
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars2.githubusercontent.com/u/3416672?v=4
-                      events_url: https://api.github.com/users/phracek/events{/privacy}
-                      followers_url: https://api.github.com/users/phracek/followers
-                      following_url: https://api.github.com/users/phracek/following{/other_user}
-                      gists_url: https://api.github.com/users/phracek/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/phracek
-                      id: 3416672
-                      login: phracek
-                      node_id: MDQ6VXNlcjM0MTY2NzI=
-                      organizations_url: https://api.github.com/users/phracek/orgs
-                      received_events_url: https://api.github.com/users/phracek/received_events
-                      repos_url: https://api.github.com/users/phracek/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/phracek/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/phracek/subscriptions
-                      type: User
-                      url: https://api.github.com/users/phracek
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars0.githubusercontent.com/u/8735467?v=4
-                      events_url: https://api.github.com/users/jscotka/events{/privacy}
-                      followers_url: https://api.github.com/users/jscotka/followers
-                      following_url: https://api.github.com/users/jscotka/following{/other_user}
-                      gists_url: https://api.github.com/users/jscotka/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/jscotka
-                      id: 8735467
-                      login: jscotka
-                      node_id: MDQ6VXNlcjg3MzU0Njc=
-                      organizations_url: https://api.github.com/users/jscotka/orgs
-                      received_events_url: https://api.github.com/users/jscotka/received_events
-                      repos_url: https://api.github.com/users/jscotka/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/jscotka/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/jscotka/subscriptions
-                      type: User
-                      url: https://api.github.com/users/jscotka
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: write
-                    user:
-                      avatar_url: https://avatars3.githubusercontent.com/u/17581559?v=4
-                      events_url: https://api.github.com/users/centos-ci/events{/privacy}
-                      followers_url: https://api.github.com/users/centos-ci/followers
-                      following_url: https://api.github.com/users/centos-ci/following{/other_user}
-                      gists_url: https://api.github.com/users/centos-ci/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/centos-ci
-                      id: 17581559
-                      login: centos-ci
-                      node_id: MDQ6VXNlcjE3NTgxNTU5
-                      organizations_url: https://api.github.com/users/centos-ci/orgs
-                      received_events_url: https://api.github.com/users/centos-ci/received_events
-                      repos_url: https://api.github.com/users/centos-ci/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/centos-ci/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/centos-ci/subscriptions
-                      type: User
-                      url: https://api.github.com/users/centos-ci
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars1.githubusercontent.com/u/20214043?v=4
-                      events_url: https://api.github.com/users/lachmanfrantisek/events{/privacy}
-                      followers_url: https://api.github.com/users/lachmanfrantisek/followers
-                      following_url: https://api.github.com/users/lachmanfrantisek/following{/other_user}
-                      gists_url: https://api.github.com/users/lachmanfrantisek/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/lachmanfrantisek
-                      id: 20214043
-                      login: lachmanfrantisek
-                      node_id: MDQ6VXNlcjIwMjE0MDQz
-                      organizations_url: https://api.github.com/users/lachmanfrantisek/orgs
-                      received_events_url: https://api.github.com/users/lachmanfrantisek/received_events
-                      repos_url: https://api.github.com/users/lachmanfrantisek/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/lachmanfrantisek/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/lachmanfrantisek/subscriptions
-                      type: User
-                      url: https://api.github.com/users/lachmanfrantisek
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: write
-                    user:
-                      avatar_url: https://avatars1.githubusercontent.com/u/25414049?v=4
-                      events_url: https://api.github.com/users/marusinm/events{/privacy}
-                      followers_url: https://api.github.com/users/marusinm/followers
-                      following_url: https://api.github.com/users/marusinm/following{/other_user}
-                      gists_url: https://api.github.com/users/marusinm/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/marusinm
-                      id: 25414049
-                      login: marusinm
-                      node_id: MDQ6VXNlcjI1NDE0MDQ5
-                      organizations_url: https://api.github.com/users/marusinm/orgs
-                      received_events_url: https://api.github.com/users/marusinm/received_events
-                      repos_url: https://api.github.com/users/marusinm/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/marusinm/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/marusinm/subscriptions
-                      type: User
-                      url: https://api.github.com/users/marusinm
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars3.githubusercontent.com/u/26160778?v=4
-                      events_url: https://api.github.com/users/rpitonak/events{/privacy}
-                      followers_url: https://api.github.com/users/rpitonak/followers
-                      following_url: https://api.github.com/users/rpitonak/following{/other_user}
-                      gists_url: https://api.github.com/users/rpitonak/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/rpitonak
-                      id: 26160778
-                      login: rpitonak
-                      node_id: MDQ6VXNlcjI2MTYwNzc4
-                      organizations_url: https://api.github.com/users/rpitonak/orgs
-                      received_events_url: https://api.github.com/users/rpitonak/received_events
-                      repos_url: https://api.github.com/users/rpitonak/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/rpitonak/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/rpitonak/subscriptions
-                      type: User
-                      url: https://api.github.com/users/rpitonak
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars2.githubusercontent.com/u/31201372?v=4
-                      events_url: https://api.github.com/users/dhodovsk/events{/privacy}
-                      followers_url: https://api.github.com/users/dhodovsk/followers
-                      following_url: https://api.github.com/users/dhodovsk/following{/other_user}
-                      gists_url: https://api.github.com/users/dhodovsk/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/dhodovsk
-                      id: 31201372
-                      login: dhodovsk
-                      node_id: MDQ6VXNlcjMxMjAxMzcy
-                      organizations_url: https://api.github.com/users/dhodovsk/orgs
-                      received_events_url: https://api.github.com/users/dhodovsk/received_events
-                      repos_url: https://api.github.com/users/dhodovsk/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/dhodovsk/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/dhodovsk/subscriptions
-                      type: User
-                      url: https://api.github.com/users/dhodovsk
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars1.githubusercontent.com/u/36231209?v=4
-                      events_url: https://api.github.com/users/usercont-release-bot/events{/privacy}
-                      followers_url: https://api.github.com/users/usercont-release-bot/followers
-                      following_url: https://api.github.com/users/usercont-release-bot/following{/other_user}
-                      gists_url: https://api.github.com/users/usercont-release-bot/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/usercont-release-bot
-                      id: 36231209
-                      login: usercont-release-bot
-                      node_id: MDQ6VXNlcjM2MjMxMjA5
-                      organizations_url: https://api.github.com/users/usercont-release-bot/orgs
-                      received_events_url: https://api.github.com/users/usercont-release-bot/received_events
-                      repos_url: https://api.github.com/users/usercont-release-bot/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/usercont-release-bot/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/usercont-release-bot/subscriptions
-                      type: User
-                      url: https://api.github.com/users/usercont-release-bot
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars3.githubusercontent.com/u/49026743?v=4
-                      events_url: https://api.github.com/users/lbarcziova/events{/privacy}
-                      followers_url: https://api.github.com/users/lbarcziova/followers
-                      following_url: https://api.github.com/users/lbarcziova/following{/other_user}
-                      gists_url: https://api.github.com/users/lbarcziova/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/lbarcziova
-                      id: 49026743
-                      login: lbarcziova
-                      node_id: MDQ6VXNlcjQ5MDI2NzQz
-                      organizations_url: https://api.github.com/users/lbarcziova/orgs
-                      received_events_url: https://api.github.com/users/lbarcziova/received_events
-                      repos_url: https://api.github.com/users/lbarcziova/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/lbarcziova/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/lbarcziova/subscriptions
-                      type: User
-                      url: https://api.github.com/users/lbarcziova
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars0.githubusercontent.com/u/288686?v=4
-                      events_url: https://api.github.com/users/jpopelka/events{/privacy}
-                      followers_url: https://api.github.com/users/jpopelka/followers
-                      following_url: https://api.github.com/users/jpopelka/following{/other_user}
-                      gists_url: https://api.github.com/users/jpopelka/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/jpopelka
-                      id: 288686
-                      login: jpopelka
-                      node_id: MDQ6VXNlcjI4ODY4Ng==
-                      organizations_url: https://api.github.com/users/jpopelka/orgs
-                      received_events_url: https://api.github.com/users/jpopelka/received_events
-                      repos_url: https://api.github.com/users/jpopelka/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/jpopelka/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/jpopelka/subscriptions
-                      type: User
-                      url: https://api.github.com/users/jpopelka
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars0.githubusercontent.com/u/1662493?v=4
-                      events_url: https://api.github.com/users/TomasTomecek/events{/privacy}
-                      followers_url: https://api.github.com/users/TomasTomecek/followers
-                      following_url: https://api.github.com/users/TomasTomecek/following{/other_user}
-                      gists_url: https://api.github.com/users/TomasTomecek/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/TomasTomecek
-                      id: 1662493
-                      login: TomasTomecek
-                      node_id: MDQ6VXNlcjE2NjI0OTM=
-                      organizations_url: https://api.github.com/users/TomasTomecek/orgs
-                      received_events_url: https://api.github.com/users/TomasTomecek/received_events
-                      repos_url: https://api.github.com/users/TomasTomecek/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/TomasTomecek/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/TomasTomecek/subscriptions
-                      type: User
-                      url: https://api.github.com/users/TomasTomecek
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars3.githubusercontent.com/u/1866652?v=4
-                      events_url: https://api.github.com/users/eliskasl/events{/privacy}
-                      followers_url: https://api.github.com/users/eliskasl/followers
-                      following_url: https://api.github.com/users/eliskasl/following{/other_user}
-                      gists_url: https://api.github.com/users/eliskasl/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/eliskasl
-                      id: 1866652
-                      login: eliskasl
-                      node_id: MDQ6VXNlcjE4NjY2NTI=
-                      organizations_url: https://api.github.com/users/eliskasl/orgs
-                      received_events_url: https://api.github.com/users/eliskasl/received_events
-                      repos_url: https://api.github.com/users/eliskasl/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/eliskasl/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/eliskasl/subscriptions
-                      type: User
-                      url: https://api.github.com/users/eliskasl
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars2.githubusercontent.com/u/3416672?v=4
-                      events_url: https://api.github.com/users/phracek/events{/privacy}
-                      followers_url: https://api.github.com/users/phracek/followers
-                      following_url: https://api.github.com/users/phracek/following{/other_user}
-                      gists_url: https://api.github.com/users/phracek/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/phracek
-                      id: 3416672
-                      login: phracek
-                      node_id: MDQ6VXNlcjM0MTY2NzI=
-                      organizations_url: https://api.github.com/users/phracek/orgs
-                      received_events_url: https://api.github.com/users/phracek/received_events
-                      repos_url: https://api.github.com/users/phracek/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/phracek/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/phracek/subscriptions
-                      type: User
-                      url: https://api.github.com/users/phracek
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars0.githubusercontent.com/u/8735467?v=4
-                      events_url: https://api.github.com/users/jscotka/events{/privacy}
-                      followers_url: https://api.github.com/users/jscotka/followers
-                      following_url: https://api.github.com/users/jscotka/following{/other_user}
-                      gists_url: https://api.github.com/users/jscotka/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/jscotka
-                      id: 8735467
-                      login: jscotka
-                      node_id: MDQ6VXNlcjg3MzU0Njc=
-                      organizations_url: https://api.github.com/users/jscotka/orgs
-                      received_events_url: https://api.github.com/users/jscotka/received_events
-                      repos_url: https://api.github.com/users/jscotka/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/jscotka/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/jscotka/subscriptions
-                      type: User
-                      url: https://api.github.com/users/jscotka
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: write
-                    user:
-                      avatar_url: https://avatars3.githubusercontent.com/u/17581559?v=4
-                      events_url: https://api.github.com/users/centos-ci/events{/privacy}
-                      followers_url: https://api.github.com/users/centos-ci/followers
-                      following_url: https://api.github.com/users/centos-ci/following{/other_user}
-                      gists_url: https://api.github.com/users/centos-ci/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/centos-ci
-                      id: 17581559
-                      login: centos-ci
-                      node_id: MDQ6VXNlcjE3NTgxNTU5
-                      organizations_url: https://api.github.com/users/centos-ci/orgs
-                      received_events_url: https://api.github.com/users/centos-ci/received_events
-                      repos_url: https://api.github.com/users/centos-ci/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/centos-ci/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/centos-ci/subscriptions
-                      type: User
-                      url: https://api.github.com/users/centos-ci
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars1.githubusercontent.com/u/20214043?v=4
-                      events_url: https://api.github.com/users/lachmanfrantisek/events{/privacy}
-                      followers_url: https://api.github.com/users/lachmanfrantisek/followers
-                      following_url: https://api.github.com/users/lachmanfrantisek/following{/other_user}
-                      gists_url: https://api.github.com/users/lachmanfrantisek/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/lachmanfrantisek
-                      id: 20214043
-                      login: lachmanfrantisek
-                      node_id: MDQ6VXNlcjIwMjE0MDQz
-                      organizations_url: https://api.github.com/users/lachmanfrantisek/orgs
-                      received_events_url: https://api.github.com/users/lachmanfrantisek/received_events
-                      repos_url: https://api.github.com/users/lachmanfrantisek/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/lachmanfrantisek/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/lachmanfrantisek/subscriptions
-                      type: User
-                      url: https://api.github.com/users/lachmanfrantisek
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: write
-                    user:
-                      avatar_url: https://avatars1.githubusercontent.com/u/25414049?v=4
-                      events_url: https://api.github.com/users/marusinm/events{/privacy}
-                      followers_url: https://api.github.com/users/marusinm/followers
-                      following_url: https://api.github.com/users/marusinm/following{/other_user}
-                      gists_url: https://api.github.com/users/marusinm/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/marusinm
-                      id: 25414049
-                      login: marusinm
-                      node_id: MDQ6VXNlcjI1NDE0MDQ5
-                      organizations_url: https://api.github.com/users/marusinm/orgs
-                      received_events_url: https://api.github.com/users/marusinm/received_events
-                      repos_url: https://api.github.com/users/marusinm/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/marusinm/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/marusinm/subscriptions
-                      type: User
-                      url: https://api.github.com/users/marusinm
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars3.githubusercontent.com/u/26160778?v=4
-                      events_url: https://api.github.com/users/rpitonak/events{/privacy}
-                      followers_url: https://api.github.com/users/rpitonak/followers
-                      following_url: https://api.github.com/users/rpitonak/following{/other_user}
-                      gists_url: https://api.github.com/users/rpitonak/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/rpitonak
-                      id: 26160778
-                      login: rpitonak
-                      node_id: MDQ6VXNlcjI2MTYwNzc4
-                      organizations_url: https://api.github.com/users/rpitonak/orgs
-                      received_events_url: https://api.github.com/users/rpitonak/received_events
-                      repos_url: https://api.github.com/users/rpitonak/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/rpitonak/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/rpitonak/subscriptions
-                      type: User
-                      url: https://api.github.com/users/rpitonak
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars2.githubusercontent.com/u/31201372?v=4
-                      events_url: https://api.github.com/users/dhodovsk/events{/privacy}
-                      followers_url: https://api.github.com/users/dhodovsk/followers
-                      following_url: https://api.github.com/users/dhodovsk/following{/other_user}
-                      gists_url: https://api.github.com/users/dhodovsk/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/dhodovsk
-                      id: 31201372
-                      login: dhodovsk
-                      node_id: MDQ6VXNlcjMxMjAxMzcy
-                      organizations_url: https://api.github.com/users/dhodovsk/orgs
-                      received_events_url: https://api.github.com/users/dhodovsk/received_events
-                      repos_url: https://api.github.com/users/dhodovsk/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/dhodovsk/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/dhodovsk/subscriptions
-                      type: User
-                      url: https://api.github.com/users/dhodovsk
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars1.githubusercontent.com/u/36231209?v=4
-                      events_url: https://api.github.com/users/usercont-release-bot/events{/privacy}
-                      followers_url: https://api.github.com/users/usercont-release-bot/followers
-                      following_url: https://api.github.com/users/usercont-release-bot/following{/other_user}
-                      gists_url: https://api.github.com/users/usercont-release-bot/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/usercont-release-bot
-                      id: 36231209
-                      login: usercont-release-bot
-                      node_id: MDQ6VXNlcjM2MjMxMjA5
-                      organizations_url: https://api.github.com/users/usercont-release-bot/orgs
-                      received_events_url: https://api.github.com/users/usercont-release-bot/received_events
-                      repos_url: https://api.github.com/users/usercont-release-bot/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/usercont-release-bot/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/usercont-release-bot/subscriptions
-                      type: User
-                      url: https://api.github.com/users/usercont-release-bot
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
-                - __store_indicator: 2
-                  _content:
-                    permission: admin
-                    user:
-                      avatar_url: https://avatars3.githubusercontent.com/u/49026743?v=4
-                      events_url: https://api.github.com/users/lbarcziova/events{/privacy}
-                      followers_url: https://api.github.com/users/lbarcziova/followers
-                      following_url: https://api.github.com/users/lbarcziova/following{/other_user}
-                      gists_url: https://api.github.com/users/lbarcziova/gists{/gist_id}
-                      gravatar_id: ''
-                      html_url: https://github.com/lbarcziova
-                      id: 49026743
-                      login: lbarcziova
-                      node_id: MDQ6VXNlcjQ5MDI2NzQz
-                      organizations_url: https://api.github.com/users/lbarcziova/orgs
-                      received_events_url: https://api.github.com/users/lbarcziova/received_events
-                      repos_url: https://api.github.com/users/lbarcziova/repos
-                      site_admin: false
-                      starred_url: https://api.github.com/users/lbarcziova/starred{/owner}{/repo}
-                      subscriptions_url: https://api.github.com/users/lbarcziova/subscriptions
-                      type: User
-                      url: https://api.github.com/users/lbarcziova
-                  _next: null
-                  elapsed: 0.2
-                  encoding: utf-8
-                  headers:
-                    Access-Control-Allow-Origin: '*'
-                    Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
-                      X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-                      X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
-                    Cache-Control: private, max-age=60, s-maxage=60
-                    Content-Encoding: gzip
-                    Content-Security-Policy: default-src 'none'
-                    Content-Type: application/json; charset=utf-8
-                    Date: Fri, 01 Nov 2019 13-36-03 GMT
-                    ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
-                    Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
-                    Server: GitHub.com
-                    Status: 200 OK
-                    Strict-Transport-Security: max-age=31536000; includeSubdomains;
-                      preload
-                    Transfer-Encoding: chunked
-                    Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
-                    X-Accepted-OAuth-Scopes: ''
-                    X-Content-Type-Options: nosniff
-                    X-Frame-Options: deny
-                    X-GitHub-Media-Type: github.v3; format=json
-                    X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
-                    X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
-                      admin:repo_hook, delete_repo, gist, notifications, repo, user,
-                      write:discussion
-                    X-RateLimit-Limit: '5000'
-                    X-RateLimit-Remaining: '4972'
-                    X-RateLimit-Reset: '1572953901'
-                    X-XSS-Protection: 1; mode=block
-                  raw: !!binary ""
-                  reason: OK
-                  status_code: 200
+                - metadata:
+                    latency: 0.2444748878479004
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_github
+                    - ogr.services.github.project
+                    - github.Repository
+                    - github.Requester
+                    - requests.sessions
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      permission: admin
+                      user:
+                        avatar_url: https://avatars0.githubusercontent.com/u/288686?v=4
+                        events_url: https://api.github.com/users/jpopelka/events{/privacy}
+                        followers_url: https://api.github.com/users/jpopelka/followers
+                        following_url: https://api.github.com/users/jpopelka/following{/other_user}
+                        gists_url: https://api.github.com/users/jpopelka/gists{/gist_id}
+                        gravatar_id: ''
+                        html_url: https://github.com/jpopelka
+                        id: 288686
+                        login: jpopelka
+                        node_id: MDQ6VXNlcjI4ODY4Ng==
+                        organizations_url: https://api.github.com/users/jpopelka/orgs
+                        received_events_url: https://api.github.com/users/jpopelka/received_events
+                        repos_url: https://api.github.com/users/jpopelka/repos
+                        site_admin: false
+                        starred_url: https://api.github.com/users/jpopelka/starred{/owner}{/repo}
+                        subscriptions_url: https://api.github.com/users/jpopelka/subscriptions
+                        type: User
+                        url: https://api.github.com/users/jpopelka
+                    _next: null
+                    elapsed: 0.2
+                    encoding: utf-8
+                    headers:
+                      Access-Control-Allow-Origin: '*'
+                      Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                        X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+                        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+                        X-GitHub-Media-Type, Deprecation, Sunset
+                      Cache-Control: private, max-age=60, s-maxage=60
+                      Content-Encoding: gzip
+                      Content-Security-Policy: default-src 'none'
+                      Content-Type: application/json; charset=utf-8
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                      Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                      Server: GitHub.com
+                      Status: 200 OK
+                      Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                        preload
+                      Transfer-Encoding: chunked
+                      Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                        Accept, X-Requested-With
+                      X-Accepted-OAuth-Scopes: ''
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: deny
+                      X-GitHub-Media-Type: github.v3; format=json
+                      X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                      X-OAuth-Scopes: admin:org, repo
+                      X-RateLimit-Limit: '5000'
+                      X-RateLimit-Remaining: '4972'
+                      X-RateLimit-Reset: '1572953901'
+                      X-XSS-Protection: 1; mode=block
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.7379956245422363
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_github
+                    - ogr.services.github.project
+                    - github.Repository
+                    - github.Requester
+                    - requests.sessions
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      permission: admin
+                      user:
+                        avatar_url: https://avatars1.githubusercontent.com/u/633969?v=4
+                        events_url: https://api.github.com/users/thrix/events{/privacy}
+                        followers_url: https://api.github.com/users/thrix/followers
+                        following_url: https://api.github.com/users/thrix/following{/other_user}
+                        gists_url: https://api.github.com/users/thrix/gists{/gist_id}
+                        gravatar_id: ''
+                        html_url: https://github.com/thrix
+                        id: 633969
+                        login: thrix
+                        node_id: MDQ6VXNlcjYzMzk2OQ==
+                        organizations_url: https://api.github.com/users/thrix/orgs
+                        received_events_url: https://api.github.com/users/thrix/received_events
+                        repos_url: https://api.github.com/users/thrix/repos
+                        site_admin: false
+                        starred_url: https://api.github.com/users/thrix/starred{/owner}{/repo}
+                        subscriptions_url: https://api.github.com/users/thrix/subscriptions
+                        type: User
+                        url: https://api.github.com/users/thrix
+                    _next: null
+                    elapsed: 0.2
+                    encoding: utf-8
+                    headers:
+                      Access-Control-Allow-Origin: '*'
+                      Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                        X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+                        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+                        X-GitHub-Media-Type, Deprecation, Sunset
+                      Cache-Control: private, max-age=60, s-maxage=60
+                      Content-Encoding: gzip
+                      Content-Security-Policy: default-src 'none'
+                      Content-Type: application/json; charset=utf-8
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                      Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                      Server: GitHub.com
+                      Status: 200 OK
+                      Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                        preload
+                      Transfer-Encoding: chunked
+                      Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                        Accept, X-Requested-With
+                      X-Accepted-OAuth-Scopes: ''
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: deny
+                      X-GitHub-Media-Type: github.v3; format=json
+                      X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                      X-OAuth-Scopes: admin:org, repo
+                      X-RateLimit-Limit: '5000'
+                      X-RateLimit-Remaining: '4972'
+                      X-RateLimit-Reset: '1572953901'
+                      X-XSS-Protection: 1; mode=block
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.19634389877319336
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_github
+                    - ogr.services.github.project
+                    - github.Repository
+                    - github.Requester
+                    - requests.sessions
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      permission: admin
+                      user:
+                        avatar_url: https://avatars0.githubusercontent.com/u/1662493?v=4
+                        events_url: https://api.github.com/users/TomasTomecek/events{/privacy}
+                        followers_url: https://api.github.com/users/TomasTomecek/followers
+                        following_url: https://api.github.com/users/TomasTomecek/following{/other_user}
+                        gists_url: https://api.github.com/users/TomasTomecek/gists{/gist_id}
+                        gravatar_id: ''
+                        html_url: https://github.com/TomasTomecek
+                        id: 1662493
+                        login: TomasTomecek
+                        node_id: MDQ6VXNlcjE2NjI0OTM=
+                        organizations_url: https://api.github.com/users/TomasTomecek/orgs
+                        received_events_url: https://api.github.com/users/TomasTomecek/received_events
+                        repos_url: https://api.github.com/users/TomasTomecek/repos
+                        site_admin: false
+                        starred_url: https://api.github.com/users/TomasTomecek/starred{/owner}{/repo}
+                        subscriptions_url: https://api.github.com/users/TomasTomecek/subscriptions
+                        type: User
+                        url: https://api.github.com/users/TomasTomecek
+                    _next: null
+                    elapsed: 0.2
+                    encoding: utf-8
+                    headers:
+                      Access-Control-Allow-Origin: '*'
+                      Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                        X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+                        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+                        X-GitHub-Media-Type, Deprecation, Sunset
+                      Cache-Control: private, max-age=60, s-maxage=60
+                      Content-Encoding: gzip
+                      Content-Security-Policy: default-src 'none'
+                      Content-Type: application/json; charset=utf-8
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                      Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                      Server: GitHub.com
+                      Status: 200 OK
+                      Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                        preload
+                      Transfer-Encoding: chunked
+                      Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                        Accept, X-Requested-With
+                      X-Accepted-OAuth-Scopes: ''
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: deny
+                      X-GitHub-Media-Type: github.v3; format=json
+                      X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                      X-OAuth-Scopes: admin:org, repo
+                      X-RateLimit-Limit: '5000'
+                      X-RateLimit-Remaining: '4972'
+                      X-RateLimit-Reset: '1572953901'
+                      X-XSS-Protection: 1; mode=block
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.37120676040649414
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_github
+                    - ogr.services.github.project
+                    - github.Repository
+                    - github.Requester
+                    - requests.sessions
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      permission: admin
+                      user:
+                        avatar_url: https://avatars3.githubusercontent.com/u/1866652?v=4
+                        events_url: https://api.github.com/users/eliskasl/events{/privacy}
+                        followers_url: https://api.github.com/users/eliskasl/followers
+                        following_url: https://api.github.com/users/eliskasl/following{/other_user}
+                        gists_url: https://api.github.com/users/eliskasl/gists{/gist_id}
+                        gravatar_id: ''
+                        html_url: https://github.com/eliskasl
+                        id: 1866652
+                        login: eliskasl
+                        node_id: MDQ6VXNlcjE4NjY2NTI=
+                        organizations_url: https://api.github.com/users/eliskasl/orgs
+                        received_events_url: https://api.github.com/users/eliskasl/received_events
+                        repos_url: https://api.github.com/users/eliskasl/repos
+                        site_admin: false
+                        starred_url: https://api.github.com/users/eliskasl/starred{/owner}{/repo}
+                        subscriptions_url: https://api.github.com/users/eliskasl/subscriptions
+                        type: User
+                        url: https://api.github.com/users/eliskasl
+                    _next: null
+                    elapsed: 0.2
+                    encoding: utf-8
+                    headers:
+                      Access-Control-Allow-Origin: '*'
+                      Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                        X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+                        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+                        X-GitHub-Media-Type, Deprecation, Sunset
+                      Cache-Control: private, max-age=60, s-maxage=60
+                      Content-Encoding: gzip
+                      Content-Security-Policy: default-src 'none'
+                      Content-Type: application/json; charset=utf-8
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                      Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                      Server: GitHub.com
+                      Status: 200 OK
+                      Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                        preload
+                      Transfer-Encoding: chunked
+                      Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                        Accept, X-Requested-With
+                      X-Accepted-OAuth-Scopes: ''
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: deny
+                      X-GitHub-Media-Type: github.v3; format=json
+                      X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                      X-OAuth-Scopes: admin:org, repo
+                      X-RateLimit-Limit: '5000'
+                      X-RateLimit-Remaining: '4972'
+                      X-RateLimit-Reset: '1572953901'
+                      X-XSS-Protection: 1; mode=block
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.2154850959777832
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_github
+                    - ogr.services.github.project
+                    - github.Repository
+                    - github.Requester
+                    - requests.sessions
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      permission: admin
+                      user:
+                        avatar_url: https://avatars2.githubusercontent.com/u/2803150?v=4
+                        events_url: https://api.github.com/users/psss/events{/privacy}
+                        followers_url: https://api.github.com/users/psss/followers
+                        following_url: https://api.github.com/users/psss/following{/other_user}
+                        gists_url: https://api.github.com/users/psss/gists{/gist_id}
+                        gravatar_id: ''
+                        html_url: https://github.com/psss
+                        id: 2803150
+                        login: psss
+                        node_id: MDQ6VXNlcjI4MDMxNTA=
+                        organizations_url: https://api.github.com/users/psss/orgs
+                        received_events_url: https://api.github.com/users/psss/received_events
+                        repos_url: https://api.github.com/users/psss/repos
+                        site_admin: false
+                        starred_url: https://api.github.com/users/psss/starred{/owner}{/repo}
+                        subscriptions_url: https://api.github.com/users/psss/subscriptions
+                        type: User
+                        url: https://api.github.com/users/psss
+                    _next: null
+                    elapsed: 0.2
+                    encoding: utf-8
+                    headers:
+                      Access-Control-Allow-Origin: '*'
+                      Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                        X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+                        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+                        X-GitHub-Media-Type, Deprecation, Sunset
+                      Cache-Control: private, max-age=60, s-maxage=60
+                      Content-Encoding: gzip
+                      Content-Security-Policy: default-src 'none'
+                      Content-Type: application/json; charset=utf-8
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                      Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                      Server: GitHub.com
+                      Status: 200 OK
+                      Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                        preload
+                      Transfer-Encoding: chunked
+                      Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                        Accept, X-Requested-With
+                      X-Accepted-OAuth-Scopes: ''
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: deny
+                      X-GitHub-Media-Type: github.v3; format=json
+                      X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                      X-OAuth-Scopes: admin:org, repo
+                      X-RateLimit-Limit: '5000'
+                      X-RateLimit-Remaining: '4972'
+                      X-RateLimit-Reset: '1572953901'
+                      X-XSS-Protection: 1; mode=block
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.2399146556854248
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_github
+                    - ogr.services.github.project
+                    - github.Repository
+                    - github.Requester
+                    - requests.sessions
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      permission: admin
+                      user:
+                        avatar_url: https://avatars2.githubusercontent.com/u/7654857?v=4
+                        events_url: https://api.github.com/users/sakalosj/events{/privacy}
+                        followers_url: https://api.github.com/users/sakalosj/followers
+                        following_url: https://api.github.com/users/sakalosj/following{/other_user}
+                        gists_url: https://api.github.com/users/sakalosj/gists{/gist_id}
+                        gravatar_id: ''
+                        html_url: https://github.com/sakalosj
+                        id: 7654857
+                        login: sakalosj
+                        node_id: MDQ6VXNlcjc2NTQ4NTc=
+                        organizations_url: https://api.github.com/users/sakalosj/orgs
+                        received_events_url: https://api.github.com/users/sakalosj/received_events
+                        repos_url: https://api.github.com/users/sakalosj/repos
+                        site_admin: false
+                        starred_url: https://api.github.com/users/sakalosj/starred{/owner}{/repo}
+                        subscriptions_url: https://api.github.com/users/sakalosj/subscriptions
+                        type: User
+                        url: https://api.github.com/users/sakalosj
+                    _next: null
+                    elapsed: 0.2
+                    encoding: utf-8
+                    headers:
+                      Access-Control-Allow-Origin: '*'
+                      Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                        X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+                        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+                        X-GitHub-Media-Type, Deprecation, Sunset
+                      Cache-Control: private, max-age=60, s-maxage=60
+                      Content-Encoding: gzip
+                      Content-Security-Policy: default-src 'none'
+                      Content-Type: application/json; charset=utf-8
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                      Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                      Server: GitHub.com
+                      Status: 200 OK
+                      Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                        preload
+                      Transfer-Encoding: chunked
+                      Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                        Accept, X-Requested-With
+                      X-Accepted-OAuth-Scopes: ''
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: deny
+                      X-GitHub-Media-Type: github.v3; format=json
+                      X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                      X-OAuth-Scopes: admin:org, repo
+                      X-RateLimit-Limit: '5000'
+                      X-RateLimit-Remaining: '4972'
+                      X-RateLimit-Reset: '1572953901'
+                      X-XSS-Protection: 1; mode=block
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.27405858039855957
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_github
+                    - ogr.services.github.project
+                    - github.Repository
+                    - github.Requester
+                    - requests.sessions
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      permission: admin
+                      user:
+                        avatar_url: https://avatars0.githubusercontent.com/u/8149784?v=4
+                        events_url: https://api.github.com/users/mfocko/events{/privacy}
+                        followers_url: https://api.github.com/users/mfocko/followers
+                        following_url: https://api.github.com/users/mfocko/following{/other_user}
+                        gists_url: https://api.github.com/users/mfocko/gists{/gist_id}
+                        gravatar_id: ''
+                        html_url: https://github.com/mfocko
+                        id: 8149784
+                        login: mfocko
+                        node_id: MDQ6VXNlcjgxNDk3ODQ=
+                        organizations_url: https://api.github.com/users/mfocko/orgs
+                        received_events_url: https://api.github.com/users/mfocko/received_events
+                        repos_url: https://api.github.com/users/mfocko/repos
+                        site_admin: false
+                        starred_url: https://api.github.com/users/mfocko/starred{/owner}{/repo}
+                        subscriptions_url: https://api.github.com/users/mfocko/subscriptions
+                        type: User
+                        url: https://api.github.com/users/mfocko
+                    _next: null
+                    elapsed: 0.2
+                    encoding: utf-8
+                    headers:
+                      Access-Control-Allow-Origin: '*'
+                      Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                        X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+                        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+                        X-GitHub-Media-Type, Deprecation, Sunset
+                      Cache-Control: private, max-age=60, s-maxage=60
+                      Content-Encoding: gzip
+                      Content-Security-Policy: default-src 'none'
+                      Content-Type: application/json; charset=utf-8
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                      Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                      Server: GitHub.com
+                      Status: 200 OK
+                      Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                        preload
+                      Transfer-Encoding: chunked
+                      Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                        Accept, X-Requested-With
+                      X-Accepted-OAuth-Scopes: ''
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: deny
+                      X-GitHub-Media-Type: github.v3; format=json
+                      X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                      X-OAuth-Scopes: admin:org, repo
+                      X-RateLimit-Limit: '5000'
+                      X-RateLimit-Remaining: '4972'
+                      X-RateLimit-Reset: '1572953901'
+                      X-XSS-Protection: 1; mode=block
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.283236026763916
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_github
+                    - ogr.services.github.project
+                    - github.Repository
+                    - github.Requester
+                    - requests.sessions
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      permission: admin
+                      user:
+                        avatar_url: https://avatars0.githubusercontent.com/u/8735467?v=4
+                        events_url: https://api.github.com/users/jscotka/events{/privacy}
+                        followers_url: https://api.github.com/users/jscotka/followers
+                        following_url: https://api.github.com/users/jscotka/following{/other_user}
+                        gists_url: https://api.github.com/users/jscotka/gists{/gist_id}
+                        gravatar_id: ''
+                        html_url: https://github.com/jscotka
+                        id: 8735467
+                        login: jscotka
+                        node_id: MDQ6VXNlcjg3MzU0Njc=
+                        organizations_url: https://api.github.com/users/jscotka/orgs
+                        received_events_url: https://api.github.com/users/jscotka/received_events
+                        repos_url: https://api.github.com/users/jscotka/repos
+                        site_admin: false
+                        starred_url: https://api.github.com/users/jscotka/starred{/owner}{/repo}
+                        subscriptions_url: https://api.github.com/users/jscotka/subscriptions
+                        type: User
+                        url: https://api.github.com/users/jscotka
+                    _next: null
+                    elapsed: 0.2
+                    encoding: utf-8
+                    headers:
+                      Access-Control-Allow-Origin: '*'
+                      Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                        X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+                        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+                        X-GitHub-Media-Type, Deprecation, Sunset
+                      Cache-Control: private, max-age=60, s-maxage=60
+                      Content-Encoding: gzip
+                      Content-Security-Policy: default-src 'none'
+                      Content-Type: application/json; charset=utf-8
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                      Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                      Server: GitHub.com
+                      Status: 200 OK
+                      Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                        preload
+                      Transfer-Encoding: chunked
+                      Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                        Accept, X-Requested-With
+                      X-Accepted-OAuth-Scopes: ''
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: deny
+                      X-GitHub-Media-Type: github.v3; format=json
+                      X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                      X-OAuth-Scopes: admin:org, repo
+                      X-RateLimit-Limit: '5000'
+                      X-RateLimit-Remaining: '4972'
+                      X-RateLimit-Reset: '1572953901'
+                      X-XSS-Protection: 1; mode=block
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.29772281646728516
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_github
+                    - ogr.services.github.project
+                    - github.Repository
+                    - github.Requester
+                    - requests.sessions
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      permission: admin
+                      user:
+                        avatar_url: https://avatars0.githubusercontent.com/u/11816497?v=4
+                        events_url: https://api.github.com/users/csomh/events{/privacy}
+                        followers_url: https://api.github.com/users/csomh/followers
+                        following_url: https://api.github.com/users/csomh/following{/other_user}
+                        gists_url: https://api.github.com/users/csomh/gists{/gist_id}
+                        gravatar_id: ''
+                        html_url: https://github.com/csomh
+                        id: 11816497
+                        login: csomh
+                        node_id: MDQ6VXNlcjExODE2NDk3
+                        organizations_url: https://api.github.com/users/csomh/orgs
+                        received_events_url: https://api.github.com/users/csomh/received_events
+                        repos_url: https://api.github.com/users/csomh/repos
+                        site_admin: false
+                        starred_url: https://api.github.com/users/csomh/starred{/owner}{/repo}
+                        subscriptions_url: https://api.github.com/users/csomh/subscriptions
+                        type: User
+                        url: https://api.github.com/users/csomh
+                    _next: null
+                    elapsed: 0.2
+                    encoding: utf-8
+                    headers:
+                      Access-Control-Allow-Origin: '*'
+                      Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                        X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+                        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+                        X-GitHub-Media-Type, Deprecation, Sunset
+                      Cache-Control: private, max-age=60, s-maxage=60
+                      Content-Encoding: gzip
+                      Content-Security-Policy: default-src 'none'
+                      Content-Type: application/json; charset=utf-8
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                      Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                      Server: GitHub.com
+                      Status: 200 OK
+                      Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                        preload
+                      Transfer-Encoding: chunked
+                      Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                        Accept, X-Requested-With
+                      X-Accepted-OAuth-Scopes: ''
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: deny
+                      X-GitHub-Media-Type: github.v3; format=json
+                      X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                      X-OAuth-Scopes: admin:org, repo
+                      X-RateLimit-Limit: '5000'
+                      X-RateLimit-Remaining: '4972'
+                      X-RateLimit-Reset: '1572953901'
+                      X-XSS-Protection: 1; mode=block
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.5814836025238037
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_github
+                    - ogr.services.github.project
+                    - github.Repository
+                    - github.Requester
+                    - requests.sessions
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      permission: write
+                      user:
+                        avatar_url: https://avatars3.githubusercontent.com/u/17581559?v=4
+                        events_url: https://api.github.com/users/centos-ci/events{/privacy}
+                        followers_url: https://api.github.com/users/centos-ci/followers
+                        following_url: https://api.github.com/users/centos-ci/following{/other_user}
+                        gists_url: https://api.github.com/users/centos-ci/gists{/gist_id}
+                        gravatar_id: ''
+                        html_url: https://github.com/centos-ci
+                        id: 17581559
+                        login: centos-ci
+                        node_id: MDQ6VXNlcjE3NTgxNTU5
+                        organizations_url: https://api.github.com/users/centos-ci/orgs
+                        received_events_url: https://api.github.com/users/centos-ci/received_events
+                        repos_url: https://api.github.com/users/centos-ci/repos
+                        site_admin: false
+                        starred_url: https://api.github.com/users/centos-ci/starred{/owner}{/repo}
+                        subscriptions_url: https://api.github.com/users/centos-ci/subscriptions
+                        type: User
+                        url: https://api.github.com/users/centos-ci
+                    _next: null
+                    elapsed: 0.2
+                    encoding: utf-8
+                    headers:
+                      Access-Control-Allow-Origin: '*'
+                      Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                        X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+                        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+                        X-GitHub-Media-Type, Deprecation, Sunset
+                      Cache-Control: private, max-age=60, s-maxage=60
+                      Content-Encoding: gzip
+                      Content-Security-Policy: default-src 'none'
+                      Content-Type: application/json; charset=utf-8
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                      Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                      Server: GitHub.com
+                      Status: 200 OK
+                      Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                        preload
+                      Transfer-Encoding: chunked
+                      Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                        Accept, X-Requested-With
+                      X-Accepted-OAuth-Scopes: ''
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: deny
+                      X-GitHub-Media-Type: github.v3; format=json
+                      X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                      X-OAuth-Scopes: admin:org, repo
+                      X-RateLimit-Limit: '5000'
+                      X-RateLimit-Remaining: '4972'
+                      X-RateLimit-Reset: '1572953901'
+                      X-XSS-Protection: 1; mode=block
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.3059072494506836
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_github
+                    - ogr.services.github.project
+                    - github.Repository
+                    - github.Requester
+                    - requests.sessions
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      permission: admin
+                      user:
+                        avatar_url: https://avatars1.githubusercontent.com/u/20214043?v=4
+                        events_url: https://api.github.com/users/lachmanfrantisek/events{/privacy}
+                        followers_url: https://api.github.com/users/lachmanfrantisek/followers
+                        following_url: https://api.github.com/users/lachmanfrantisek/following{/other_user}
+                        gists_url: https://api.github.com/users/lachmanfrantisek/gists{/gist_id}
+                        gravatar_id: ''
+                        html_url: https://github.com/lachmanfrantisek
+                        id: 20214043
+                        login: lachmanfrantisek
+                        node_id: MDQ6VXNlcjIwMjE0MDQz
+                        organizations_url: https://api.github.com/users/lachmanfrantisek/orgs
+                        received_events_url: https://api.github.com/users/lachmanfrantisek/received_events
+                        repos_url: https://api.github.com/users/lachmanfrantisek/repos
+                        site_admin: false
+                        starred_url: https://api.github.com/users/lachmanfrantisek/starred{/owner}{/repo}
+                        subscriptions_url: https://api.github.com/users/lachmanfrantisek/subscriptions
+                        type: User
+                        url: https://api.github.com/users/lachmanfrantisek
+                    _next: null
+                    elapsed: 0.2
+                    encoding: utf-8
+                    headers:
+                      Access-Control-Allow-Origin: '*'
+                      Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                        X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+                        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+                        X-GitHub-Media-Type, Deprecation, Sunset
+                      Cache-Control: private, max-age=60, s-maxage=60
+                      Content-Encoding: gzip
+                      Content-Security-Policy: default-src 'none'
+                      Content-Type: application/json; charset=utf-8
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                      Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                      Server: GitHub.com
+                      Status: 200 OK
+                      Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                        preload
+                      Transfer-Encoding: chunked
+                      Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                        Accept, X-Requested-With
+                      X-Accepted-OAuth-Scopes: ''
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: deny
+                      X-GitHub-Media-Type: github.v3; format=json
+                      X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                      X-OAuth-Scopes: admin:org, repo
+                      X-RateLimit-Limit: '5000'
+                      X-RateLimit-Remaining: '4972'
+                      X-RateLimit-Reset: '1572953901'
+                      X-XSS-Protection: 1; mode=block
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.378525972366333
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_github
+                    - ogr.services.github.project
+                    - github.Repository
+                    - github.Requester
+                    - requests.sessions
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      permission: write
+                      user:
+                        avatar_url: https://avatars1.githubusercontent.com/u/25414049?v=4
+                        events_url: https://api.github.com/users/marusinm/events{/privacy}
+                        followers_url: https://api.github.com/users/marusinm/followers
+                        following_url: https://api.github.com/users/marusinm/following{/other_user}
+                        gists_url: https://api.github.com/users/marusinm/gists{/gist_id}
+                        gravatar_id: ''
+                        html_url: https://github.com/marusinm
+                        id: 25414049
+                        login: marusinm
+                        node_id: MDQ6VXNlcjI1NDE0MDQ5
+                        organizations_url: https://api.github.com/users/marusinm/orgs
+                        received_events_url: https://api.github.com/users/marusinm/received_events
+                        repos_url: https://api.github.com/users/marusinm/repos
+                        site_admin: false
+                        starred_url: https://api.github.com/users/marusinm/starred{/owner}{/repo}
+                        subscriptions_url: https://api.github.com/users/marusinm/subscriptions
+                        type: User
+                        url: https://api.github.com/users/marusinm
+                    _next: null
+                    elapsed: 0.2
+                    encoding: utf-8
+                    headers:
+                      Access-Control-Allow-Origin: '*'
+                      Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                        X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+                        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+                        X-GitHub-Media-Type, Deprecation, Sunset
+                      Cache-Control: private, max-age=60, s-maxage=60
+                      Content-Encoding: gzip
+                      Content-Security-Policy: default-src 'none'
+                      Content-Type: application/json; charset=utf-8
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                      Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                      Server: GitHub.com
+                      Status: 200 OK
+                      Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                        preload
+                      Transfer-Encoding: chunked
+                      Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                        Accept, X-Requested-With
+                      X-Accepted-OAuth-Scopes: ''
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: deny
+                      X-GitHub-Media-Type: github.v3; format=json
+                      X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                      X-OAuth-Scopes: admin:org, repo
+                      X-RateLimit-Limit: '5000'
+                      X-RateLimit-Remaining: '4972'
+                      X-RateLimit-Reset: '1572953901'
+                      X-XSS-Protection: 1; mode=block
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.39438772201538086
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_github
+                    - ogr.services.github.project
+                    - github.Repository
+                    - github.Requester
+                    - requests.sessions
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      permission: admin
+                      user:
+                        avatar_url: https://avatars2.githubusercontent.com/u/31201372?v=4
+                        events_url: https://api.github.com/users/dhodovsk/events{/privacy}
+                        followers_url: https://api.github.com/users/dhodovsk/followers
+                        following_url: https://api.github.com/users/dhodovsk/following{/other_user}
+                        gists_url: https://api.github.com/users/dhodovsk/gists{/gist_id}
+                        gravatar_id: ''
+                        html_url: https://github.com/dhodovsk
+                        id: 31201372
+                        login: dhodovsk
+                        node_id: MDQ6VXNlcjMxMjAxMzcy
+                        organizations_url: https://api.github.com/users/dhodovsk/orgs
+                        received_events_url: https://api.github.com/users/dhodovsk/received_events
+                        repos_url: https://api.github.com/users/dhodovsk/repos
+                        site_admin: false
+                        starred_url: https://api.github.com/users/dhodovsk/starred{/owner}{/repo}
+                        subscriptions_url: https://api.github.com/users/dhodovsk/subscriptions
+                        type: User
+                        url: https://api.github.com/users/dhodovsk
+                    _next: null
+                    elapsed: 0.2
+                    encoding: utf-8
+                    headers:
+                      Access-Control-Allow-Origin: '*'
+                      Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                        X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+                        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+                        X-GitHub-Media-Type, Deprecation, Sunset
+                      Cache-Control: private, max-age=60, s-maxage=60
+                      Content-Encoding: gzip
+                      Content-Security-Policy: default-src 'none'
+                      Content-Type: application/json; charset=utf-8
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                      Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                      Server: GitHub.com
+                      Status: 200 OK
+                      Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                        preload
+                      Transfer-Encoding: chunked
+                      Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                        Accept, X-Requested-With
+                      X-Accepted-OAuth-Scopes: ''
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: deny
+                      X-GitHub-Media-Type: github.v3; format=json
+                      X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                      X-OAuth-Scopes: admin:org, repo
+                      X-RateLimit-Limit: '5000'
+                      X-RateLimit-Remaining: '4972'
+                      X-RateLimit-Reset: '1572953901'
+                      X-XSS-Protection: 1; mode=block
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.8861291408538818
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_github
+                    - ogr.services.github.project
+                    - github.Repository
+                    - github.Requester
+                    - requests.sessions
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      permission: admin
+                      user:
+                        avatar_url: https://avatars1.githubusercontent.com/u/36231209?v=4
+                        events_url: https://api.github.com/users/usercont-release-bot/events{/privacy}
+                        followers_url: https://api.github.com/users/usercont-release-bot/followers
+                        following_url: https://api.github.com/users/usercont-release-bot/following{/other_user}
+                        gists_url: https://api.github.com/users/usercont-release-bot/gists{/gist_id}
+                        gravatar_id: ''
+                        html_url: https://github.com/usercont-release-bot
+                        id: 36231209
+                        login: usercont-release-bot
+                        node_id: MDQ6VXNlcjM2MjMxMjA5
+                        organizations_url: https://api.github.com/users/usercont-release-bot/orgs
+                        received_events_url: https://api.github.com/users/usercont-release-bot/received_events
+                        repos_url: https://api.github.com/users/usercont-release-bot/repos
+                        site_admin: false
+                        starred_url: https://api.github.com/users/usercont-release-bot/starred{/owner}{/repo}
+                        subscriptions_url: https://api.github.com/users/usercont-release-bot/subscriptions
+                        type: User
+                        url: https://api.github.com/users/usercont-release-bot
+                    _next: null
+                    elapsed: 0.2
+                    encoding: utf-8
+                    headers:
+                      Access-Control-Allow-Origin: '*'
+                      Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                        X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+                        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+                        X-GitHub-Media-Type, Deprecation, Sunset
+                      Cache-Control: private, max-age=60, s-maxage=60
+                      Content-Encoding: gzip
+                      Content-Security-Policy: default-src 'none'
+                      Content-Type: application/json; charset=utf-8
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                      Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                      Server: GitHub.com
+                      Status: 200 OK
+                      Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                        preload
+                      Transfer-Encoding: chunked
+                      Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                        Accept, X-Requested-With
+                      X-Accepted-OAuth-Scopes: ''
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: deny
+                      X-GitHub-Media-Type: github.v3; format=json
+                      X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                      X-OAuth-Scopes: admin:org, repo
+                      X-RateLimit-Limit: '5000'
+                      X-RateLimit-Remaining: '4972'
+                      X-RateLimit-Reset: '1572953901'
+                      X-XSS-Protection: 1; mode=block
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 1.2048547267913818
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_github
+                    - ogr.services.github.project
+                    - github.Repository
+                    - github.Requester
+                    - requests.sessions
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      permission: admin
+                      user:
+                        avatar_url: https://avatars3.githubusercontent.com/u/49026743?v=4
+                        events_url: https://api.github.com/users/lbarcziova/events{/privacy}
+                        followers_url: https://api.github.com/users/lbarcziova/followers
+                        following_url: https://api.github.com/users/lbarcziova/following{/other_user}
+                        gists_url: https://api.github.com/users/lbarcziova/gists{/gist_id}
+                        gravatar_id: ''
+                        html_url: https://github.com/lbarcziova
+                        id: 49026743
+                        login: lbarcziova
+                        node_id: MDQ6VXNlcjQ5MDI2NzQz
+                        organizations_url: https://api.github.com/users/lbarcziova/orgs
+                        received_events_url: https://api.github.com/users/lbarcziova/received_events
+                        repos_url: https://api.github.com/users/lbarcziova/repos
+                        site_admin: false
+                        starred_url: https://api.github.com/users/lbarcziova/starred{/owner}{/repo}
+                        subscriptions_url: https://api.github.com/users/lbarcziova/subscriptions
+                        type: User
+                        url: https://api.github.com/users/lbarcziova
+                    _next: null
+                    elapsed: 0.2
+                    encoding: utf-8
+                    headers:
+                      Access-Control-Allow-Origin: '*'
+                      Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                        X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+                        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+                        X-GitHub-Media-Type, Deprecation, Sunset
+                      Cache-Control: private, max-age=60, s-maxage=60
+                      Content-Encoding: gzip
+                      Content-Security-Policy: default-src 'none'
+                      Content-Type: application/json; charset=utf-8
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                      Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                      Server: GitHub.com
+                      Status: 200 OK
+                      Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                        preload
+                      Transfer-Encoding: chunked
+                      Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                        Accept, X-Requested-With
+                      X-Accepted-OAuth-Scopes: ''
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: deny
+                      X-GitHub-Media-Type: github.v3; format=json
+                      X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                      X-OAuth-Scopes: admin:org, repo
+                      X-RateLimit-Limit: '5000'
+                      X-RateLimit-Remaining: '4972'
+                      X-RateLimit-Reset: '1572953901'
+                      X-XSS-Protection: 1; mode=block
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.7905521392822266
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_github
+                    - ogr.services.github.project
+                    - github.Repository
+                    - github.Requester
+                    - requests.sessions
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      permission: admin
+                      user:
+                        avatar_url: https://avatars1.githubusercontent.com/u/20214043?v=4
+                        events_url: https://api.github.com/users/lachmanfrantisek/events{/privacy}
+                        followers_url: https://api.github.com/users/lachmanfrantisek/followers
+                        following_url: https://api.github.com/users/lachmanfrantisek/following{/other_user}
+                        gists_url: https://api.github.com/users/lachmanfrantisek/gists{/gist_id}
+                        gravatar_id: ''
+                        html_url: https://github.com/lachmanfrantisek
+                        id: 20214043
+                        login: lachmanfrantisek
+                        node_id: MDQ6VXNlcjIwMjE0MDQz
+                        organizations_url: https://api.github.com/users/lachmanfrantisek/orgs
+                        received_events_url: https://api.github.com/users/lachmanfrantisek/received_events
+                        repos_url: https://api.github.com/users/lachmanfrantisek/repos
+                        site_admin: false
+                        starred_url: https://api.github.com/users/lachmanfrantisek/starred{/owner}{/repo}
+                        subscriptions_url: https://api.github.com/users/lachmanfrantisek/subscriptions
+                        type: User
+                        url: https://api.github.com/users/lachmanfrantisek
+                    _next: null
+                    elapsed: 0.2
+                    encoding: utf-8
+                    headers:
+                      Access-Control-Allow-Origin: '*'
+                      Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                        X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+                        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+                        X-GitHub-Media-Type, Deprecation, Sunset
+                      Cache-Control: private, max-age=60, s-maxage=60
+                      Content-Encoding: gzip
+                      Content-Security-Policy: default-src 'none'
+                      Content-Type: application/json; charset=utf-8
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                      Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                      Server: GitHub.com
+                      Status: 200 OK
+                      Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                        preload
+                      Transfer-Encoding: chunked
+                      Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                        Accept, X-Requested-With
+                      X-Accepted-OAuth-Scopes: ''
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: deny
+                      X-GitHub-Media-Type: github.v3; format=json
+                      X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                      X-OAuth-Scopes: admin:org, repo
+                      X-RateLimit-Limit: '5000'
+                      X-RateLimit-Remaining: '4972'
+                      X-RateLimit-Reset: '1572953901'
+                      X-XSS-Protection: 1; mode=block
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+                - metadata:
+                    latency: 0.7943410873413086
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_github
+                    - ogr.services.github.project
+                    - github.Repository
+                    - github.Requester
+                    - requests.sessions
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      permission: read
+                      user:
+                        avatar_url: https://avatars0.githubusercontent.com/u/1024025?v=4
+                        events_url: https://api.github.com/users/torvalds/events{/privacy}
+                        followers_url: https://api.github.com/users/torvalds/followers
+                        following_url: https://api.github.com/users/torvalds/following{/other_user}
+                        gists_url: https://api.github.com/users/torvalds/gists{/gist_id}
+                        gravatar_id: ''
+                        html_url: https://github.com/torvalds
+                        id: 1024025
+                        login: torvalds
+                        node_id: MDQ6VXNlcjEwMjQwMjU=
+                        organizations_url: https://api.github.com/users/torvalds/orgs
+                        received_events_url: https://api.github.com/users/torvalds/received_events
+                        repos_url: https://api.github.com/users/torvalds/repos
+                        site_admin: false
+                        starred_url: https://api.github.com/users/torvalds/starred{/owner}{/repo}
+                        subscriptions_url: https://api.github.com/users/torvalds/subscriptions
+                        type: User
+                        url: https://api.github.com/users/torvalds
+                    _next: null
+                    elapsed: 0.2
+                    encoding: utf-8
+                    headers:
+                      Access-Control-Allow-Origin: '*'
+                      Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                        X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+                        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+                        X-GitHub-Media-Type, Deprecation, Sunset
+                      Cache-Control: private, max-age=60, s-maxage=60
+                      Content-Encoding: gzip
+                      Content-Security-Policy: default-src 'none'
+                      Content-Type: application/json; charset=utf-8
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                      Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                      Server: GitHub.com
+                      Status: 200 OK
+                      Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                        preload
+                      Transfer-Encoding: chunked
+                      Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                        Accept, X-Requested-With
+                      X-Accepted-OAuth-Scopes: ''
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: deny
+                      X-GitHub-Media-Type: github.v3; format=json
+                      X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                      X-OAuth-Scopes: admin:org, repo
+                      X-RateLimit-Limit: '5000'
+                      X-RateLimit-Remaining: '4972'
+                      X-RateLimit-Reset: '1572953901'
+                      X-XSS-Protection: 1; mode=block
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -300,7 +300,9 @@ class GenericCommands(GithubTests):
         assert "lachmanfrantisek" in users
 
         assert self.ogr_project.can_merge_pr("lachmanfrantisek")
-        assert not self.ogr_project.can_merge_pr("unknown_user")
+        # can_merge_pr() requires an existing user,
+        # otherwise the GitHub API fails with 'not a user'
+        assert not self.ogr_project.can_merge_pr("torvalds")
 
     def test_set_commit_status(self):
         status = self.ogr_project.set_commit_status(


### PR DESCRIPTION
When telling if a user can merge PRs in a GitHub repo, ask GitHub for
the user's permission on the repo instead of checking if the user is in
the list of collaborators.

This should lead to fewer API calls in cases when the full list of
collaborators is not needed, but it also returns better results: the
list of collaborators does not seem to be always up to date when queries
are done using GitHub App tokens.

Relates to packit-service/packit-service#612.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>