### PR TITLE
Add PullRequest.patch property

### DIFF
--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -362,6 +362,10 @@ class PullRequest:
         raise NotImplementedError()
 
     @property
+    def patch(self) -> bytes:
+        raise NotImplementedError()
+
+    @property
     def head_commit(self) -> str:
         raise NotImplementedError
 

--- a/ogr/services/pagure/pull_request.py
+++ b/ogr/services/pagure/pull_request.py
@@ -106,6 +106,17 @@ class PagurePullRequest(BasePullRequest):
         return f"{self.url}#request_diff"
 
     @property
+    def patch(self) -> bytes:
+        request_response = self._target_project._call_project_api_raw(
+            "pull-request", f"{self.id}.patch", add_api_endpoint_part=False
+        )
+        if request_response.status_code != 200:
+            raise PagureAPIException(
+                f"Cannot get patch from {self.url}.patch because {request_response.reason}."
+            )
+        return request_response.content
+
+    @property
     def head_commit(self) -> str:
         return self._raw_pr["commit_stop"]
 

--- a/tests/integration/test_data/test_pagure/tests.integration.test_pagure.PullRequests.test_pr_patch.yaml
+++ b/tests/integration/test_data/test_pagure/tests.integration.test_pagure.PullRequests.test_pr_patch.yaml
@@ -1,0 +1,290 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectFull
+  version_storage_file: 2
+unittest.case:
+  tests.integration.test_pagure:
+    ogr.services.pagure.project:
+      ogr.services.pagure.pull_request:
+        ogr.services.pagure.project:
+          ogr.services.pagure.service:
+            requests.sessions:
+              requre.objects:
+                requests.sessions:
+                  send:
+                  - metadata:
+                      latency: 0.2848660945892334
+                      module_call_list:
+                      - unittest.case
+                      - tests.integration.test_pagure
+                      - ogr.services.pagure.project
+                      - ogr.services.pagure.pull_request
+                      - ogr.services.pagure.project
+                      - ogr.services.pagure.service
+                      - requests.sessions
+                      - requre.objects
+                      - requests.sessions
+                      - send
+                    output:
+                      __store_indicator: 2
+                      _content:
+                        assignee: null
+                        branch: master
+                        branch_from: test_pr
+                        cached_merge_status: unknown
+                        closed_at: '1574794962'
+                        closed_by:
+                          fullname: Matej Focko
+                          name: mfocko
+                        comments:
+                        - comment: Pull-Request has been merged by mfocko
+                          commit: null
+                          date_created: '1574794962'
+                          edited_on: null
+                          editor: null
+                          filename: null
+                          id: 103456
+                          line: null
+                          notification: true
+                          parent: null
+                          reactions: {}
+                          tree: null
+                          user:
+                            fullname: Matej Focko
+                            name: mfocko
+                        commit_start: 517121273b142293807606dbd7a2e0f514b21cc8
+                        commit_stop: 517121273b142293807606dbd7a2e0f514b21cc8
+                        date_created: '1574794929'
+                        id: 5
+                        initial_comment: ''
+                        last_updated: '1577395578'
+                        project:
+                          access_groups:
+                            admin: []
+                            commit: []
+                            ticket: []
+                          access_users:
+                            admin:
+                            - jscotka
+                            - lbarczio
+                            - mfocko
+                            commit: []
+                            owner:
+                            - lachmanfrantisek
+                            ticket: []
+                          close_status: []
+                          custom_keys: []
+                          date_created: '1570568389'
+                          date_modified: '1570568529'
+                          description: Testing repository for python-ogr package.
+                          fullname: ogr-tests
+                          id: 6826
+                          milestones: {}
+                          name: ogr-tests
+                          namespace: null
+                          parent: null
+                          priorities: {}
+                          tags: []
+                          url_path: ogr-tests
+                          user:
+                            fullname: "Franti\u0161ek Lachman"
+                            name: lachmanfrantisek
+                        remote_git: null
+                        repo_from:
+                          access_groups:
+                            admin: []
+                            commit: []
+                            ticket: []
+                          access_users:
+                            admin: []
+                            commit: []
+                            owner:
+                            - mfocko
+                            ticket: []
+                          close_status: []
+                          custom_keys: []
+                          date_created: '1570604926'
+                          date_modified: '1570604926'
+                          description: Testing repository for python-ogr package.
+                          fullname: forks/mfocko/ogr-tests
+                          id: 6828
+                          milestones: {}
+                          name: ogr-tests
+                          namespace: null
+                          parent:
+                            access_groups:
+                              admin: []
+                              commit: []
+                              ticket: []
+                            access_users:
+                              admin:
+                              - jscotka
+                              - lbarczio
+                              - mfocko
+                              commit: []
+                              owner:
+                              - lachmanfrantisek
+                              ticket: []
+                            close_status: []
+                            custom_keys: []
+                            date_created: '1570568389'
+                            date_modified: '1570568529'
+                            description: Testing repository for python-ogr package.
+                            fullname: ogr-tests
+                            id: 6826
+                            milestones: {}
+                            name: ogr-tests
+                            namespace: null
+                            parent: null
+                            priorities: {}
+                            tags: []
+                            url_path: ogr-tests
+                            user:
+                              fullname: "Franti\u0161ek Lachman"
+                              name: lachmanfrantisek
+                          priorities: {}
+                          tags: []
+                          url_path: fork/mfocko/ogr-tests
+                          user:
+                            fullname: Matej Focko
+                            name: mfocko
+                        status: Merged
+                        tags: []
+                        threshold_reached: null
+                        title: Test PR
+                        uid: 7aa9105db74241e18a268d0fccb6bd86
+                        updated_on: '1574794962'
+                        user:
+                          fullname: Matej Focko
+                          name: mfocko
+                      _next: null
+                      elapsed: 0.2
+                      encoding: null
+                      headers:
+                        Connection: Keep-Alive
+                        Content-Length: '3484'
+                        Content-Security-Policy: default-src 'self';script-src 'self'
+                          'nonce-YqLDC0BS8d7iY8mKO7VtBbIne' https://apps.fedoraproject.org;
+                          style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'; object-src
+                          'none';base-uri 'self';img-src 'self' https:;
+                        Content-Type: application/json
+                        Date: Fri, 01 Nov 2019 13-36-03 GMT
+                        Keep-Alive: timeout=5, max=99
+                        Referrer-Policy: same-origin
+                        Server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+                          mod_wsgi/3.4 Python/2.7.5
+                        Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiTTJWaU5qaGxPREUyT0RJek1UUTFNelk0T0RRMk5URTJZMkpsTWpObU9XRTBNemd5WVdZMFlRPT0ifX0.EamDBQ.tOuy3jaJwo9PXxqGjf29l9wn5ps;
+                          Expires=Mon, 22-Jun-2020 15:36:37 GMT; Secure; HttpOnly;
+                          Path=/
+                        Strict-Transport-Security: max-age=31536000; includeSubDomains;
+                          preload
+                        X-Content-Type-Options: nosniff
+                        X-Frame-Options: ALLOW-FROM https://pagure.io/
+                        X-Xss-Protection: 1; mode=block
+                      raw: !!binary ""
+                      reason: OK
+                      status_code: 200
+    ogr.services.pagure.pull_request:
+      ogr.services.pagure.project:
+        ogr.services.pagure.service:
+          requests.sessions:
+            requre.objects:
+              requests.sessions:
+                send:
+                - metadata:
+                    latency: 0.3704500198364258
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_pagure
+                    - ogr.services.pagure.pull_request
+                    - ogr.services.pagure.project
+                    - ogr.services.pagure.service
+                    - requests.sessions
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 1
+                    _content: "From 517121273b142293807606dbd7a2e0f514b21cc8 Mon Sep\
+                      \ 17 00:00:00 2001\nFrom: Matej Focko <matej.focko@outlook.com>\n\
+                      Date: Nov 26 2019 19:01:46 +0000\nSubject: Got to merge something\n\
+                      \n\n---\n\ndiff --git a/README.md b/README.md\nindex a40a52a..eb2dadd\
+                      \ 100644\n--- a/README.md\n+++ b/README.md\n@@ -1,3 +1,4 @@\n\
+                      \ # ogr-tests\n \n-Testing repository for python-ogr package.\n\
+                      \\ No newline at end of file\n+Testing repository for python-ogr\
+                      \ package.\n+Last time merged PR.\n\n"
+                    _next: null
+                    elapsed: 0.2
+                    encoding: UTF-8
+                    headers:
+                      Connection: Keep-Alive
+                      Content-Length: '454'
+                      Content-Security-Policy: default-src 'self';script-src 'self'
+                        'nonce-YqLDC0BS8d7iY8mKO7VtBbIne' https://apps.fedoraproject.org;
+                        style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'; object-src
+                        'none';base-uri 'self';img-src 'self' https:;
+                      Content-Type: text/plain;charset=UTF-8
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Keep-Alive: timeout=5, max=98
+                      Referrer-Policy: same-origin
+                      Server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+                        mod_wsgi/3.4 Python/2.7.5
+                      Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiTTJWaU5qaGxPREUyT0RJek1UUTFNelk0T0RRMk5URTJZMkpsTWpObU9XRTBNemd5WVdZMFlRPT0ifX0.EamDBQ.tOuy3jaJwo9PXxqGjf29l9wn5ps;
+                        Expires=Mon, 22-Jun-2020 15:36:37 GMT; Secure; HttpOnly; Path=/
+                      Strict-Transport-Security: max-age=31536000; includeSubDomains;
+                        preload
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: ALLOW-FROM https://pagure.io/
+                      X-Xss-Protection: 1; mode=block
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200
+    ogr.services.pagure.service:
+      ogr.services.pagure.user:
+        ogr.services.pagure.service:
+          requests.sessions:
+            requre.objects:
+              requests.sessions:
+                send:
+                - metadata:
+                    latency: 1.1727259159088135
+                    module_call_list:
+                    - unittest.case
+                    - tests.integration.test_pagure
+                    - ogr.services.pagure.service
+                    - ogr.services.pagure.user
+                    - ogr.services.pagure.service
+                    - requests.sessions
+                    - requre.objects
+                    - requests.sessions
+                    - send
+                  output:
+                    __store_indicator: 2
+                    _content:
+                      username: jpopelka
+                    _next: null
+                    elapsed: 0.2
+                    encoding: null
+                    headers:
+                      Connection: Keep-Alive
+                      Content-Length: '28'
+                      Content-Security-Policy: default-src 'self';script-src 'self'
+                        'nonce-YqLDC0BS8d7iY8mKO7VtBbIne' https://apps.fedoraproject.org;
+                        style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'; object-src
+                        'none';base-uri 'self';img-src 'self' https:;
+                      Content-Type: application/json
+                      Date: Fri, 01 Nov 2019 13-36-03 GMT
+                      Keep-Alive: timeout=5, max=100
+                      Referrer-Policy: same-origin
+                      Server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+                        mod_wsgi/3.4 Python/2.7.5
+                      Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiTTJWaU5qaGxPREUyT0RJek1UUTFNelk0T0RRMk5URTJZMkpsTWpObU9XRTBNemd5WVdZMFlRPT0ifX0.EamDBQ.tOuy3jaJwo9PXxqGjf29l9wn5ps;
+                        Expires=Mon, 22-Jun-2020 15:36:37 GMT; Secure; HttpOnly; Path=/
+                      Strict-Transport-Security: max-age=31536000; includeSubDomains;
+                        preload
+                      X-Content-Type-Options: nosniff
+                      X-Frame-Options: ALLOW-FROM https://pagure.io/
+                      X-Xss-Protection: 1; mode=block
+                    raw: !!binary ""
+                    reason: OK
+                    status_code: 200

--- a/tests/integration/test_pagure.py
+++ b/tests/integration/test_pagure.py
@@ -356,6 +356,12 @@ class PullRequests(PagureTests):
         assert source_project.repo == "ogr-tests"
         assert source_project.full_repo_name == "fork/mfocko/ogr-tests"
 
+    def test_pr_patch(self):
+        pr = self.ogr_project.get_pr(5)
+        patch = pr.patch
+        assert isinstance(patch, bytes)
+        assert "\nDate: Nov 26 2019 19:01:46 +0000\n" in patch.decode()
+
 
 class Forks(PagureTests):
     def test_fork(self):


### PR DESCRIPTION
Currently implemented only for PagurePullRequest.

It returns bytes in case there's some binary blob in the patch.

I'd like to use this in https://github.com/packit-service/packit-service/pull/627