### PR TITLE
Copr build for master and releases

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -33,3 +33,20 @@ jobs:
     metadata:
       targets:
         - fedora-all
+  - job: copr_build
+    trigger: commit
+    metadata:
+      branch: master
+      targets:
+        - fedora-stable
+      project: packit-master
+      list_on_homepage: True
+      preserve_project: True
+  - job: copr_build
+    trigger: release
+    metadata:
+      targets:
+        - fedora-stable
+      project: packit-releases
+      list_on_homepage: True
+      preserve_project: True

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Library for one API for many git forges. (e.g. GitHub, GitLab, Pagure).
 ## Currently supported git forges:
 
 - GitHub
+- GitLab
 - Pagure
 
 ## Usage
@@ -57,6 +58,44 @@ You can use the same API for other forges, you just need to replace `GithubServi
 
 For more info on functionality that _is not_ supported in all services the same way
 see [compatibility tables](COMPATIBILITY.md).
+
+## Installation
+
+On Fedora:
+
+```
+$ dnf install python3-ogr
+```
+
+You can also use our [`packit-releases` Copr repository](https://copr.fedorainfracloud.org/coprs/packit/packit-releases/)
+(contains also released versions of [OGR](https://github.com/packit-service/ogr)):
+
+```
+$ dnf copr enable packit/packit-releases
+$ dnf install python3-ogr
+```
+
+Or from PyPI:
+
+```
+$ pip3 install --user ogr
+```
+
+You can also install OGR from `master` branch, if you are brave enough:
+
+You can use our [`packit-master` Copr repository](https://copr.fedorainfracloud.org/coprs/packit/packit-master/)
+(contains `master` version of [ogr](https://github.com/packit-service/ogr)):
+
+```
+$ dnf copr enable packit/packit-master
+$ dnf install python3-ogr
+```
+
+Or
+
+```
+$ pip3 install --user git+https://github.com/packit-service/ogr.git
+```
 
 ## Requirements
 


### PR DESCRIPTION
- Build in Copr for master commits and releases.
- We are using same copr projects as we do for packit.
- Relates to https://github.com/packit-service/ogr/pull/428.