### PR TITLE
Fix get_file_content() returning bytes

### DIFF
--- a/ogr/services/gitlab/project.py
+++ b/ogr/services/gitlab/project.py
@@ -364,7 +364,7 @@ class GitlabProject(BaseGitProject):
     def get_file_content(self, path, ref="master") -> str:
         try:
             file = self.gitlab_repo.files.get(file_path=path, ref=ref)
-            return str(file.decode())
+            return file.decode().decode()
         except gitlab.exceptions.GitlabGetError as ex:
             raise FileNotFoundError(f"File '{path}' on {ref} not found", ex)
 

--- a/tests/integration/test_data/test_gitlab/tests.integration.test_gitlab.GenericCommands.test_get_file_content.yaml
+++ b/tests/integration/test_data/test_gitlab/tests.integration.test_gitlab.GenericCommands.test_get_file_content.yaml
@@ -1,0 +1,330 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectFull
+  version_storage_file: 2
+unittest.case:
+  tests.integration.test_gitlab:
+    ogr.services.gitlab.project:
+      gitlab.cli:
+        gitlab.v4.objects:
+          gitlab.exceptions:
+            gitlab.mixins:
+              gitlab:
+                requre.objects:
+                  requre.cassette:
+                    requests.sessions:
+                      send:
+                      - metadata:
+                          latency: 1.0445001125335693
+                          module_call_list:
+                          - unittest.case
+                          - tests.integration.test_gitlab
+                          - ogr.services.gitlab.project
+                          - gitlab.cli
+                          - gitlab.v4.objects
+                          - gitlab.exceptions
+                          - gitlab.mixins
+                          - gitlab
+                          - requre.objects
+                          - requre.cassette
+                          - requests.sessions
+                          - send
+                        output:
+                          __store_indicator: 2
+                          _content:
+                            blob_id: e2e4fde810a779db69c2ecb2b90863a7ea7507ac
+                            commit_id: b8e18207cfdad954f1b3a96db34d0706b272e6cf
+                            content: IyBvZ3ItdGVzdHMKClRlc3RpbmcgcmVwb3NpdG9yeSBmb3IgcHl0aG9uLW9nciBwYWNrYWdlLiB8IGh0dHBzOi8vZ2l0aHViLmNvbS9wYWNraXQtc2VydmljZS9vZ3IKCnRlc3QxCnRlc3QyCg==
+                            content_sha256: 89db43e799da0b6a4a4190e3440c6af50a557d1a4a780997bbbce1a201842d6b
+                            encoding: base64
+                            file_name: README.md
+                            file_path: README.md
+                            last_commit_id: 59b1a9bab5b5198c619270646410867788685c16
+                            ref: b8e18207cfdad954f1b3a96db34d0706b272e6cf
+                            size: 109
+                          _next: null
+                          elapsed: 0.2
+                          encoding: null
+                          headers:
+                            CF-Cache-Status: DYNAMIC
+                            CF-RAY: 5aaed0302cf08a8f-BOM
+                            Cache-Control: max-age=0, private, must-revalidate
+                            Connection: keep-alive
+                            Content-Encoding: gzip
+                            Content-Type: application/json
+                            Date: Fri, 01 Nov 2019 13-36-03 GMT
+                            Etag: W/"003d2eca7a0a430e4911005e1086dac3"
+                            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                            GitLab-LB: fe-06-lb-gprd
+                            GitLab-SV: localhost
+                            RateLimit-Limit: '600'
+                            RateLimit-Observed: '3'
+                            RateLimit-Remaining: '597'
+                            RateLimit-Reset: '1593425020'
+                            RateLimit-ResetTime: Mon, 29 Jun 2020 10:03:40 GMT
+                            Referrer-Policy: strict-origin-when-cross-origin
+                            Server: cloudflare
+                            Strict-Transport-Security: max-age=31536000
+                            Transfer-Encoding: chunked
+                            Vary: Origin
+                            X-Content-Type-Options: nosniff
+                            X-Frame-Options: SAMEORIGIN
+                            X-Gitlab-Blob-Id: e2e4fde810a779db69c2ecb2b90863a7ea7507ac
+                            X-Gitlab-Commit-Id: b8e18207cfdad954f1b3a96db34d0706b272e6cf
+                            X-Gitlab-Content-Sha256: 89db43e799da0b6a4a4190e3440c6af50a557d1a4a780997bbbce1a201842d6b
+                            X-Gitlab-Encoding: base64
+                            X-Gitlab-File-Name: README.md
+                            X-Gitlab-File-Path: README.md
+                            X-Gitlab-Last-Commit-Id: 59b1a9bab5b5198c619270646410867788685c16
+                            X-Gitlab-Ref: b8e18207cfdad954f1b3a96db34d0706b272e6cf
+                            X-Gitlab-Size: '109'
+                            X-Request-Id: xVpV8MbjIg4
+                            X-Runtime: '0.098809'
+                            cf-request-id: 03a120721a00008a8fe7a97200000001
+                          raw: !!binary ""
+                          reason: OK
+                          status_code: 200
+      gitlab.exceptions:
+        gitlab.mixins:
+          gitlab:
+            requre.objects:
+              requre.cassette:
+                requests.sessions:
+                  send:
+                  - metadata:
+                      latency: 1.080246925354004
+                      module_call_list:
+                      - unittest.case
+                      - tests.integration.test_gitlab
+                      - ogr.services.gitlab.project
+                      - gitlab.exceptions
+                      - gitlab.mixins
+                      - gitlab
+                      - requre.objects
+                      - requre.cassette
+                      - requests.sessions
+                      - send
+                    output:
+                      __store_indicator: 2
+                      _content:
+                        _links:
+                          events: https://gitlab.com/api/v4/projects/14233409/events
+                          issues: https://gitlab.com/api/v4/projects/14233409/issues
+                          labels: https://gitlab.com/api/v4/projects/14233409/labels
+                          members: https://gitlab.com/api/v4/projects/14233409/members
+                          merge_requests: https://gitlab.com/api/v4/projects/14233409/merge_requests
+                          repo_branches: https://gitlab.com/api/v4/projects/14233409/repository/branches
+                          self: https://gitlab.com/api/v4/projects/14233409
+                        allow_merge_on_skipped_pipeline: null
+                        approvals_before_merge: 0
+                        archived: false
+                        auto_cancel_pending_pipelines: enabled
+                        auto_devops_deploy_strategy: continuous
+                        auto_devops_enabled: false
+                        autoclose_referenced_issues: true
+                        avatar_url: null
+                        build_coverage_regex: null
+                        build_timeout: 3600
+                        builds_access_level: enabled
+                        can_create_merge_request_in: true
+                        ci_config_path: null
+                        ci_default_git_depth: 50
+                        compliance_frameworks: []
+                        container_registry_enabled: true
+                        created_at: '2019-09-10T10:28:09.946Z'
+                        creator_id: 433670
+                        default_branch: master
+                        description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+                        emails_disabled: null
+                        empty_repo: false
+                        external_authorization_classification_label: ''
+                        forking_access_level: enabled
+                        forks_count: 4
+                        http_url_to_repo: https://gitlab.com/packit-service/ogr-tests.git
+                        id: 14233409
+                        import_status: none
+                        issues_access_level: enabled
+                        issues_enabled: true
+                        jobs_enabled: true
+                        last_activity_at: '2020-05-28T15:49:29.184Z'
+                        lfs_enabled: true
+                        marked_for_deletion_at: null
+                        marked_for_deletion_on: null
+                        merge_method: merge
+                        merge_requests_access_level: enabled
+                        merge_requests_enabled: true
+                        mirror: false
+                        name: ogr-tests
+                        name_with_namespace: packit-service / ogr-tests
+                        namespace:
+                          avatar_url: /uploads/-/system/group/avatar/6032704/packit-logo.png
+                          full_path: packit-service
+                          id: 6032704
+                          kind: group
+                          name: packit-service
+                          parent_id: null
+                          path: packit-service
+                          web_url: https://gitlab.com/groups/packit-service
+                        only_allow_merge_if_all_discussions_are_resolved: false
+                        only_allow_merge_if_pipeline_succeeds: false
+                        open_issues_count: 42
+                        packages_enabled: true
+                        pages_access_level: enabled
+                        path: ogr-tests
+                        path_with_namespace: packit-service/ogr-tests
+                        permissions:
+                          group_access: null
+                          project_access: null
+                        printing_merge_request_link_enabled: true
+                        public_jobs: true
+                        readme_url: https://gitlab.com/packit-service/ogr-tests/-/blob/master/README.md
+                        remove_source_branch_after_merge: null
+                        repository_access_level: enabled
+                        request_access_enabled: false
+                        resolve_outdated_diff_discussions: false
+                        service_desk_address: incoming+packit-service-ogr-tests-14233409-issue-@incoming.gitlab.com
+                        service_desk_enabled: true
+                        shared_runners_enabled: true
+                        shared_with_groups: []
+                        snippets_access_level: enabled
+                        snippets_enabled: true
+                        ssh_url_to_repo: git@gitlab.com:packit-service/ogr-tests.git
+                        star_count: 0
+                        suggestion_commit_message: null
+                        tag_list: []
+                        visibility: public
+                        web_url: https://gitlab.com/packit-service/ogr-tests
+                        wiki_access_level: enabled
+                        wiki_enabled: true
+                      _next: null
+                      elapsed: 0.2
+                      encoding: null
+                      headers:
+                        CF-Cache-Status: DYNAMIC
+                        CF-RAY: 5aaed0295aec8a8f-BOM
+                        Cache-Control: max-age=0, private, must-revalidate
+                        Connection: keep-alive
+                        Content-Encoding: gzip
+                        Content-Type: application/json
+                        Date: Fri, 01 Nov 2019 13-36-03 GMT
+                        Etag: W/"5c8b5554f7d95db1458410c7c7dfd55d"
+                        Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                        GitLab-LB: fe-12-lb-gprd
+                        GitLab-SV: localhost
+                        RateLimit-Limit: '600'
+                        RateLimit-Observed: '2'
+                        RateLimit-Remaining: '598'
+                        RateLimit-Reset: '1593425019'
+                        RateLimit-ResetTime: Mon, 29 Jun 2020 10:03:39 GMT
+                        Referrer-Policy: strict-origin-when-cross-origin
+                        Server: cloudflare
+                        Strict-Transport-Security: max-age=31536000
+                        Transfer-Encoding: chunked
+                        Vary: Origin
+                        X-Content-Type-Options: nosniff
+                        X-Frame-Options: SAMEORIGIN
+                        X-Request-Id: qN1a4OLZcza
+                        X-Runtime: '0.186916'
+                        cf-request-id: 03a1206dda00008a8fe7a7d200000001
+                      raw: !!binary ""
+                      reason: OK
+                      status_code: 200
+      ogr.services.gitlab.service:
+        gitlab:
+          gitlab.exceptions:
+            gitlab.mixins:
+              gitlab:
+                requre.objects:
+                  requre.cassette:
+                    requests.sessions:
+                      send:
+                      - metadata:
+                          latency: 1.0915420055389404
+                          module_call_list:
+                          - unittest.case
+                          - tests.integration.test_gitlab
+                          - ogr.services.gitlab.project
+                          - ogr.services.gitlab.service
+                          - gitlab
+                          - gitlab.exceptions
+                          - gitlab.mixins
+                          - gitlab
+                          - requre.objects
+                          - requre.cassette
+                          - requests.sessions
+                          - send
+                        output:
+                          __store_indicator: 2
+                          _content:
+                            avatar_url: https://assets.gitlab-static.net/uploads/-/system/user/avatar/5647360/avatar.png
+                            bio: ''
+                            can_create_group: true
+                            can_create_project: true
+                            color_scheme_id: 1
+                            confirmed_at: '2020-03-19T21:52:09.146Z'
+                            created_at: '2020-03-19T21:52:09.216Z'
+                            current_sign_in_at: '2020-06-28T17:15:47.263Z'
+                            email: spapinwar@gmail.com
+                            external: false
+                            extra_shared_runners_minutes_limit: null
+                            id: 5647360
+                            identities:
+                            - extern_uid: '22324802'
+                              provider: github
+                              saml_provider_id: null
+                            job_title: ''
+                            last_activity_on: '2020-06-29'
+                            last_sign_in_at: '2020-06-27T10:52:21.850Z'
+                            linkedin: ''
+                            location: ''
+                            name: Shreyas Papinwar
+                            organization: ''
+                            private_profile: false
+                            projects_limit: 100000
+                            public_email: ''
+                            shared_runners_minutes_limit: null
+                            skype: shreyas.papinwar
+                            state: active
+                            theme_id: 1
+                            twitter: '@spapinwar'
+                            two_factor_enabled: false
+                            username: shreyaspapi
+                            web_url: https://gitlab.com/shreyaspapi
+                            website_url: https://shreyasp.me
+                            work_information: null
+                          _next: null
+                          elapsed: 0.2
+                          encoding: null
+                          headers:
+                            CF-Cache-Status: DYNAMIC
+                            CF-RAY: 5aaed0231a5a8a8f-BOM
+                            Cache-Control: max-age=0, private, must-revalidate
+                            Connection: keep-alive
+                            Content-Encoding: gzip
+                            Content-Type: application/json
+                            Date: Fri, 01 Nov 2019 13-36-03 GMT
+                            Etag: W/"103c26360d97a8e2c3bcf886e99859bd"
+                            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+                            GitLab-LB: fe-05-lb-gprd
+                            GitLab-SV: localhost
+                            RateLimit-Limit: '600'
+                            RateLimit-Observed: '1'
+                            RateLimit-Remaining: '599'
+                            RateLimit-Reset: '1593425018'
+                            RateLimit-ResetTime: Mon, 29 Jun 2020 10:03:38 GMT
+                            Referrer-Policy: strict-origin-when-cross-origin
+                            Server: cloudflare
+                            Set-Cookie: __cfduid=da4352b0ca6e132c16bc7532c25015d0a1593424957;
+                              expires=Wed, 29-Jul-20 10:02:37 GMT; path=/; domain=.gitlab.com;
+                              HttpOnly; SameSite=Lax; Secure
+                            Strict-Transport-Security: max-age=31536000
+                            Transfer-Encoding: chunked
+                            Vary: Origin
+                            X-Content-Type-Options: nosniff
+                            X-Frame-Options: SAMEORIGIN
+                            X-Request-Id: qbxmlwYzbs4
+                            X-Runtime: '0.032855'
+                            cf-request-id: 03a12069f200008a8fe7a76200000001
+                          raw: !!binary ""
+                          reason: OK
+                          status_code: 200

--- a/tests/integration/test_gitlab.py
+++ b/tests/integration/test_gitlab.py
@@ -34,6 +34,15 @@ class GitlabTests(RequreTestCase):
 
 
 class GenericCommands(GitlabTests):
+    def test_get_file_content(self):
+        file = self.project.get_file_content(
+            path="README.md", ref="b8e18207cfdad954f1b3a96db34d0706b272e6cf"
+        )
+        assert (
+            file == "# ogr-tests\n\nTesting repository for python-ogr package. | "
+            "https://github.com/packit-service/ogr\n\ntest1\ntest2\n"
+        )
+
     def test_add_user(self):
         project = self.service.get_project(
             repo="hello-there", namespace="testing-packit"


### PR DESCRIPTION
The object [gitlab.v4.objects.ProjectFile](https://python-gitlab.readthedocs.io/en/stable/api/gitlab.v4.html#gitlab.v4.objects.ProjectFile) with the function [decode()](https://python-gitlab.readthedocs.io/en/stable/api/gitlab.v4.html#gitlab.v4.objects.ProjectFile.decode) will return bytes -

`b'---\nspecfile_path: hello.spec\nsynced_files:\n  - hello.spec\n# actions:\n#   post-upstream-clone: "python3 setup.py sdist --dist-dir ."\n# current_version_command: ["python3", "setup.py", "--version"]\n# create_tarball_command: ["python3", "setup.py", "sdist", "--dist-dir", "."]\njobs:\n- job: copr_build\n  trigger: pull_request\n  metadata:\n    targets:\n    - fedora-30-x86_64'`

Expected string - 

```
---
specfile_path: hello.spec
synced_files:
  - hello.spec
# actions:
#   post-upstream-clone: "python3 setup.py sdist --dist-dir ."
# current_version_command: ["python3", "setup.py", "--version"]
# create_tarball_command: ["python3", "setup.py", "sdist", "--dist-dir", "."]
jobs:
- job: copr_build
  trigger: pull_request
  metadata:
    targets:
    - fedora-30-x86_64
```
