### PR TITLE
Replace Python version glob with macro

### DIFF
--- a/fedora/python-ogr.spec
+++ b/fedora/python-ogr.spec
@@ -48,7 +48,7 @@ rm -rf %{srcname}.egg-info
 %license LICENSE
 %doc README.md
 %{python3_sitelib}/%{srcname}
-%{python3_sitelib}/%{srcname}-%{version}-py?.?.egg-info
+%{python3_sitelib}/%{srcname}-%{version}-py%{python3_version}.egg-info
 
 
 %changelog


### PR DESCRIPTION
This is needed for Python 3.10+.

See devel-list message for details:

https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/PQIGCQCRNBYNXBX2ICWEM3PLDLNOG2ZT/

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>