### PR TITLE
Job metadata key 'dist_git_branch' was renamed to 'dist_git_branches'

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -22,7 +22,7 @@ jobs:
   - job: propose_downstream
     trigger: release
     metadata:
-      dist_git_branch: fedora-all
+      dist_git_branches: fedora-all
   - job: copr_build
     trigger: pull_request
     metadata:


### PR DESCRIPTION
in https://github.com/packit-service/packit/pull/797