### PR TITLE
Revert "Drop python 3.6"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     rev: stable
     hooks:
       - id: black
-        language_version: python3.7
+        language_version: python3.6
   - repo: https://github.com/prettier/prettier
     rev: 2.0.5
     hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Topic :: Software Development
@@ -39,7 +40,7 @@ install_requires =
     PyYAML
     cryptography
     python-gitlab
-python_requires = >=3.7
+python_requires = >=3.6
 include_package_data = True
 setup_requires =
     setuptools_scm


### PR DESCRIPTION
This reverts commit 74d84893f16f5020e60d2a1ba35e13d768b514f0.

In Centos 8 Python 3.6 is the default python3. Having Python 3.6 support
will make life easier there.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>